### PR TITLE
feat: BreadRecord Entity Mapping

### DIFF
--- a/src/main/java/com/bean/breadbook/BreadbookApplication.java
+++ b/src/main/java/com/bean/breadbook/BreadbookApplication.java
@@ -2,7 +2,9 @@ package com.bean.breadbook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BreadbookApplication {
 

--- a/src/main/java/com/bean/breadbook/domain/bread/entity/BreadRecord.java
+++ b/src/main/java/com/bean/breadbook/domain/bread/entity/BreadRecord.java
@@ -1,0 +1,78 @@
+package com.bean.breadbook.domain.bread.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "bread_records")
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BreadRecord {
+
+    @Id
+    @EqualsAndHashCode.Include
+    @Column(name = "id", length = 36, nullable = false, updatable = false)
+    private String id;
+
+    @Column(name = "user_id", length = 36, nullable = false)
+    private String userId;
+
+    @Column(name = "sticker_number", nullable = false)
+    private Integer stickerNumber;
+
+    @Column(name = "photo_url", length = 500, nullable = false)
+    private String photoUrl;
+
+    @Column(name = "name", length = 30, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "bread_type", length = 20, nullable = false)
+    private BreadType breadType;
+
+    @Column(name = "shop_name", length = 50)
+    private String shopName;
+
+    @Builder.Default
+    @Column(name = "eaten_date", nullable = false)
+    private LocalDate eatenDate = LocalDate.now();
+
+    @Column(name = "rating", nullable = false)
+    private Integer rating;
+
+    @Column(name = "review", columnDefinition = "TEXT")
+    private String review;
+
+    @Builder.Default
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic = true;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void prePersist() {
+        if (this.id == null) {
+            this.id = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/src/main/java/com/bean/breadbook/domain/bread/entity/BreadType.java
+++ b/src/main/java/com/bean/breadbook/domain/bread/entity/BreadType.java
@@ -1,0 +1,11 @@
+package com.bean.breadbook.domain.bread.entity;
+
+public enum BreadType {
+    PASTRY,
+    BREAD,
+    DONUT,
+    CAKE,
+    BAGEL,
+    TART,
+    OTHER
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #1 

## 🛠️ 작업 내용
- `BreadRecord` 엔티티 생성 및 `bread_records` 테이블 매핑
- JPA Auditing 적용 (`@CreatedDate`, `@LastModifiedDate`)
- UUID 기반 PK 생성 로직 (`@PrePersist`) 추가
- **`BreadType enum`** 정의 및 매핑 적용

## 📢 참고 및 특이사항
- Auditing 사용을 위해 @EnableJpaAuditing 설정 추가

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인