### PR TITLE
feat: update bread and bread record entities

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/entity/Bread.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/entity/Bread.java
@@ -1,0 +1,58 @@
+package com.bean.breaddiary.domain.bread.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(
+        name = "breads",
+        indexes = {
+                @Index(name = "idx_breads_name", columnList = "name"),
+                @Index(name = "idx_breads_sticker_number", columnList = "sticker_number", unique = true)
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bread {
+
+    @Id
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "sticker_number", nullable = false, unique = true)
+    private Integer stickerNumber;
+
+    @Column(name = "name", length = 30, nullable = false, unique = true)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "bread_type", length = 20, nullable = false)
+    private BreadType breadType;
+
+    @Column(name = "image_url", length = 500, nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/entity/BreadRecord.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/entity/BreadRecord.java
@@ -1,7 +1,16 @@
-package com.bean.breaddiary.domain.bread.entity;
+package com.bean.breaddiary.domain.breadrecord.entity;
 
+import com.bean.breaddiary.domain.bread.entity.Bread;
 import jakarta.persistence.*;
-import lombok.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -13,7 +22,14 @@ import java.util.UUID;
 @Entity
 @Getter
 @Builder
-@Table(name = "bread_records")
+@Table(
+        name = "bread_records",
+        indexes = {
+                @Index(name = "idx_bread_records_user_id", columnList = "user_id"),
+                @Index(name = "idx_bread_records_user_bread", columnList = "user_id,bread_id"),
+                @Index(name = "idx_bread_records_created_at", columnList = "created_at")
+        }
+)
 @EntityListeners(AuditingEntityListener.class)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -22,24 +38,19 @@ public class BreadRecord {
 
     @Id
     @EqualsAndHashCode.Include
-    @Column(name = "id", length = 36, nullable = false, updatable = false)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
 
-    @Column(name = "user_id", length = 36, nullable = false)
-    private String userId;
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
 
-    @Column(name = "sticker_number", nullable = false)
-    private Integer stickerNumber;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bread_id", nullable = false)
+    private Bread bread;
 
     @Column(name = "photo_url", length = 500, nullable = false)
     private String photoUrl;
-
-    @Column(name = "name", length = 30, nullable = false)
-    private String name;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "bread_type", length = 20, nullable = false)
-    private BreadType breadType;
 
     @Column(name = "shop_name", length = 50)
     private String shopName;
@@ -48,9 +59,12 @@ public class BreadRecord {
     @Column(name = "eaten_date", nullable = false)
     private LocalDate eatenDate = LocalDate.now();
 
+    @Min(1)
+    @Max(5)
     @Column(name = "rating", nullable = false)
     private Integer rating;
 
+    @Size(max = 500)
     @Column(name = "review", columnDefinition = "TEXT")
     private String review;
 
@@ -69,10 +83,4 @@ public class BreadRecord {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @PrePersist
-    protected void prePersist() {
-        if (this.id == null) {
-            this.id = UUID.randomUUID().toString();
-        }
-    }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #5 

## 🛠️ 작업 내용

- `Bread` 엔티티를 추가하고 `breads`  테이블 매핑을 반영했습니다.
- 기존 `BreadRecord` 엔티티를 `bread_id` 기반 연관 관계 구조로 수정했습니다.
- `BreadRecord` 엔티티의 `rating`, `review` 필드에 대해 **유효성 검증**을 추가했습니다.

## 📢 참고 및 특이사항

- `eatenDate` 필드는 기본값으로 `LocalDate.now()`를 사용합니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인