### PR TITLE
feat: implement bread record creation flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+	implementation 'org.mapstruct:mapstruct:1.6.3'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 	implementation 'org.mapstruct:mapstruct:1.6.3'
+	implementation platform('software.amazon.awssdk:bom:2.27.21')
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:url-connection-client'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -1,0 +1,21 @@
+package com.bean.breaddiary.domain.bread.dto.mapper;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.UUID;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface BreadMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "stickerNumber", source = "stickerNumber")
+    @Mapping(target = "name", source = "request.name")
+    @Mapping(target = "breadType", source = "request.breadType")
+    @Mapping(target = "imageUrl", source = "imageUrl")
+    @Mapping(target = "createdBy", source = "userId")
+    Bread mapToBread(CreateNewBreadRecordRequest request, Integer stickerNumber, String imageUrl, UUID userId);
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -1,0 +1,18 @@
+package com.bean.breaddiary.domain.bread.repository;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BreadRepository extends JpaRepository<Bread, UUID> {
+
+    Optional<Bread> findByName(String name);
+
+    Optional<Bread> findByStickerNumber(Integer stickerNumber);
+
+    Optional<Bread> findTopByOrderByStickerNumberDesc();
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -1,0 +1,66 @@
+package com.bean.breaddiary.domain.bread.service;
+
+import com.bean.breaddiary.domain.bread.dto.mapper.BreadMapper;
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.repository.BreadRepository;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BreadService {
+
+    private static final String DEFAULT_USER_BREAD_IMAGE_URL =
+            "https://cdn.bread-diary.app/catalog/default_user_bread.webp";
+
+    private final BreadRepository breadRepository;
+    private final BreadMapper breadMapper;
+
+    public Bread getBreadById(UUID breadId) {
+        return breadRepository.findById(breadId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 빵을 카탈로그에서 찾을 수 없습니다."
+                ));
+    }
+
+    public boolean existsByName(String name) {
+        return breadRepository.existsByName(name);
+    }
+
+    @Transactional
+    public Bread createUserBread(CreateNewBreadRecordRequest request, UUID userId) {
+        validateBreadNameNotDuplicated(request.getName());
+
+        Bread bread = breadMapper.mapToBread(
+                request,
+                getNextStickerNumber(),
+                DEFAULT_USER_BREAD_IMAGE_URL,
+                userId
+        );
+
+        return breadRepository.save(bread);
+    }
+
+    private Integer getNextStickerNumber() {
+        return breadRepository.findTopByOrderByStickerNumberDesc()
+                .map(Bread::getStickerNumber)
+                .orElse(0) + 1;
+    }
+
+    private void validateBreadNameNotDuplicated(String name) {
+        if (existsByName(name)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "같은 이름의 빵이 이미 카탈로그에 있습니다."
+            );
+        }
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
@@ -1,0 +1,121 @@
+package com.bean.breaddiary.domain.breadrecord.controller;
+
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
+import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * packageName    : com.bean.breaddiary.domain.breadrecord.controller<br>
+ * fileName       : BreadRecordController.java<br>
+ * description    : BreadRecord entity 요청을 처리하는 controller 클래스입니다.<br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 26.04.16          haelim             최초 생성<br>
+ */
+@Tag(name = "빵 기록 API", description = "빵 기록을 관리하는 API입니다.")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/breads")
+public class BreadRecordController {
+
+    private static final UUID DUMMY_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private final BreadRecordComplexService breadRecordComplexService;
+
+    /**
+     * 카탈로그에 존재하는 빵에 대해 새 기록을 생성합니다.
+     *
+     * @param userId 임시 사용자 ID
+     * @param request 기존 빵 기록 생성 요청
+     * @return 생성된 빵 기록 정보
+     */
+    @Operation(
+            summary = "기존 빵 기록 생성",
+            description = "카탈로그에 이미 존재하는 빵에 대해 새 기록을 생성합니다. multipart/form-data 필드명은 camelCase를 사용합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "빵 기록 생성 성공",
+                    content = @Content(schema = @Schema(implementation = BreadRecordCreateResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "빵 카탈로그를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BreadRecordCreateResponse> createBreadRecord(
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
+            @Valid @ModelAttribute CreateBreadRecordRequest request
+    ) {
+        BreadRecordCreateResponse response = breadRecordComplexService.createBreadRecord(
+                resolveUserId(userId),
+                request
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다.
+     *
+     * @param userId 임시 사용자 ID
+     * @param request 신규 빵 기록 생성 요청
+     * @return 생성된 빵 기록 정보
+     */
+    @Operation(
+            summary = "신규 빵 추가 및 기록 생성",
+            description = "카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다. multipart/form-data 필드명은 camelCase를 사용합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "신규 빵 및 기록 생성 성공",
+                    content = @Content(schema = @Schema(implementation = BreadRecordCreateResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "409", description = "중복된 빵 이름"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping(path = "/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BreadRecordCreateResponse> createNewBreadRecord(
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
+            @Valid @ModelAttribute CreateNewBreadRecordRequest request
+    ) {
+        BreadRecordCreateResponse response = breadRecordComplexService.createNewBreadRecord(
+                resolveUserId(userId),
+                request
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    private UUID resolveUserId(UUID userId) {
+        return userId == null ? DUMMY_USER_ID : userId;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -1,0 +1,70 @@
+package com.bean.breaddiary.domain.breadrecord.dto.mapper;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface BreadRecordMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "bread", source = "bread")
+    @Mapping(target = "photoUrl", source = "photoUrl")
+    @Mapping(target = "eatenDate", source = "eatenDate")
+    BreadRecord mapToBreadRecord(
+            CreateBreadRecordRequest request,
+            UUID userId,
+            Bread bread,
+            String photoUrl,
+            LocalDate eatenDate
+    );
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "bread", source = "bread")
+    @Mapping(target = "photoUrl", source = "photoUrl")
+    @Mapping(target = "eatenDate", source = "eatenDate")
+    BreadRecord mapToBreadRecord(
+            CreateNewBreadRecordRequest request,
+            UUID userId,
+            Bread bread,
+            String photoUrl,
+            LocalDate eatenDate
+    );
+
+    @Mapping(target = "breadId", source = "breadRecord.bread.id")
+    @Mapping(target = "stickerNumber", source = "breadRecord.bread.stickerNumber")
+    @Mapping(target = "name", source = "breadRecord.bread.name")
+    @Mapping(target = "breadType", source = "breadRecord.bread.breadType")
+    @Mapping(target = "imageUrl", source = "breadRecord.bread.imageUrl")
+    @Mapping(target = "photoThumbnailUrl", expression = "java(toThumbnailUrl(breadRecord.getPhotoUrl()))")
+    @Mapping(target = "isFirstRecord", source = "isFirstRecord")
+    BreadRecordCreateResponse mapToCreateResponse(
+            BreadRecord breadRecord,
+            Boolean isFirstRecord
+    );
+
+    default String toThumbnailUrl(String photoUrl) {
+        if (photoUrl == null) {
+            return null;
+        }
+
+        int extensionIndex = photoUrl.lastIndexOf('.');
+        if (extensionIndex < 0) {
+            return photoUrl + "_thumb";
+        }
+
+        return photoUrl.substring(0, extensionIndex)
+                + "_thumb"
+                + photoUrl.substring(extensionIndex);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateBreadRecordRequest.java
@@ -1,0 +1,48 @@
+package com.bean.breaddiary.domain.breadrecord.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "기존 카탈로그 빵 기록 생성 요청")
+public class CreateBreadRecordRequest {
+
+    @Schema(description = "카탈로그 빵 ID", example = "550e8400-e29b-41d4-a716-446655440000", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "유효한 빵을 선택해주세요.")
+    private UUID breadId;
+
+    @Schema(description = "빵 사진 파일 (JPEG/PNG/WebP)", type = "string", format = "binary", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "사진은 필수입니다.")
+    private MultipartFile photo;
+
+    @Schema(description = "구매처", example = "르뺑블루 성수점", maxLength = 50)
+    @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
+    private String shopName;
+
+    @Schema(description = "먹은 날짜. 미입력 시 오늘 날짜로 저장", example = "2026-04-16")
+    private LocalDate eatenDate;
+
+    @Schema(description = "별점", example = "5", minimum = "1", maximum = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "별점은 필수입니다.")
+    @Min(value = 1, message = "별점은 1~5 사이 값이어야 합니다.")
+    @Max(value = 5, message = "별점은 1~5 사이 값이어야 합니다.")
+    private Integer rating;
+
+    @Schema(description = "후기", example = "겉은 바삭하고 안은 촉촉해서 완벽했어요.", maxLength = 500)
+    @Size(max = 500, message = "후기는 500자 이내로 입력해주세요.")
+    private String review;
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateNewBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateNewBreadRecordRequest.java
@@ -1,0 +1,56 @@
+package com.bean.breaddiary.domain.breadrecord.dto.request;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "신규 빵 추가 및 첫 기록 생성 요청")
+public class CreateNewBreadRecordRequest {
+
+    @Schema(description = "빵 이름", example = "말차 크로플", maxLength = 30, requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "빵 이름은 필수입니다.")
+    @Size(max = 30, message = "빵 이름은 30자 이내로 입력해주세요.")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = {
+            "PASTRY", "BREAD", "DONUT", "CAKE", "BAGEL", "TART", "OTHER"
+    })
+    @NotNull(message = "올바른 빵 종류를 선택해주세요.")
+    private BreadType breadType;
+
+    @Schema(description = "빵 사진 파일 (JPEG/PNG/WebP)", type = "string", format = "binary", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "사진은 필수입니다.")
+    private MultipartFile photo;
+
+    @Schema(description = "구매처", example = "카페봄봄 합정점", maxLength = 50)
+    @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
+    private String shopName;
+
+    @Schema(description = "먹은 날짜. 미입력 시 오늘 날짜로 저장", example = "2026-04-16")
+    private LocalDate eatenDate;
+
+    @Schema(description = "별점", example = "4", minimum = "1", maximum = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "별점은 필수입니다.")
+    @Min(value = 1, message = "별점은 1~5 사이 값이어야 합니다.")
+    @Max(value = 5, message = "별점은 1~5 사이 값이어야 합니다.")
+    private Integer rating;
+
+    @Schema(description = "후기", example = "말차 맛이 진해서 좋았어요.", maxLength = 500)
+    @Size(max = 500, message = "후기는 500자 이내로 입력해주세요.")
+    private String review;
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordCreateResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordCreateResponse.java
@@ -1,0 +1,62 @@
+package com.bean.breaddiary.domain.breadrecord.dto.response;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 기록 생성 응답")
+public class BreadRecordCreateResponse {
+
+    @Schema(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+    private UUID id;
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    private UUID breadId;
+
+    @Schema(description = "도감 번호", example = "7")
+    private Integer stickerNumber;
+
+    @Schema(description = "원본 사진 URL", example = "https://breaddiary-bucket.s3.ap-northeast-2.amazonaws.com/bread/550e8400/a1b2c3d4.webp")
+    private String photoUrl;
+
+    @Schema(description = "썸네일 사진 URL", example = "https://breaddiary-bucket.s3.ap-northeast-2.amazonaws.com/bread/550e8400/a1b2c3d4_thumb.webp")
+    private String photoThumbnailUrl;
+
+    @Schema(description = "빵 이름", example = "크루아상")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY")
+    private BreadType breadType;
+
+    @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
+    private String imageUrl;
+
+    @Schema(description = "구매처", example = "르뺑블루 성수점")
+    private String shopName;
+
+    @Schema(description = "먹은 날짜", example = "2026-04-16")
+    private LocalDate eatenDate;
+
+    @Schema(description = "별점", example = "5")
+    private Integer rating;
+
+    @Schema(description = "후기", example = "겉은 바삭하고 안은 촉촉해서 완벽했어요.")
+    private String review;
+
+    @Schema(description = "해당 빵의 첫 기록 여부", example = "false")
+    private Boolean isFirstRecord;
+
+    @Schema(description = "기록 생성 일시", example = "2026-04-16T09:30:00")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -1,0 +1,16 @@
+package com.bean.breaddiary.domain.breadrecord.repository;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> {
+
+    List<BreadRecord> findAllByUserId(UUID userId);
+    List<BreadRecord> findAllByUserIdAndBread(UUID userId, Bread bread);
+    long countByUserIdAndBread(UUID userId, Bread bread);
+    boolean existsByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
@@ -1,0 +1,58 @@
+package com.bean.breaddiary.domain.breadrecord.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import com.bean.breaddiary.global.s3.S3UploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BreadRecordComplexService {
+
+    private final BreadService breadService;
+    private final BreadRecordService breadRecordService;
+    private final S3UploadService s3UploadService;
+
+    public BreadRecordCreateResponse createBreadRecord(UUID userId, CreateBreadRecordRequest request) {
+        breadRecordService.validateEatenDate(request.getEatenDate());
+
+        Bread bread = breadService.getBreadById(request.getBreadId());
+        Boolean isFirstRecord = !breadRecordService.existsActiveRecord(userId, bread);
+
+        String photoUrl = s3UploadService.uploadBreadPhoto(userId, request.getPhoto());
+
+        BreadRecord savedRecord = breadRecordService.createBreadRecord(
+                request,
+                userId,
+                bread,
+                photoUrl
+        );
+
+        return breadRecordService.createResponse(savedRecord, isFirstRecord);
+    }
+
+    public BreadRecordCreateResponse createNewBreadRecord(UUID userId, CreateNewBreadRecordRequest request) {
+        breadRecordService.validateEatenDate(request.getEatenDate());
+
+        Bread bread = breadService.createUserBread(request, userId);
+        String photoUrl = s3UploadService.uploadBreadPhoto(userId, request.getPhoto());
+
+        BreadRecord savedRecord = breadRecordService.createBreadRecord(
+                request,
+                userId,
+                bread,
+                photoUrl
+        );
+
+        return breadRecordService.createResponse(savedRecord, true);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
@@ -1,0 +1,89 @@
+package com.bean.breaddiary.domain.breadrecord.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.dto.mapper.BreadRecordMapper;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BreadRecordService {
+
+    private final BreadRecordRepository breadRecordRepository;
+    private final BreadRecordMapper breadRecordMapper;
+
+    public boolean existsActiveRecord(UUID userId, Bread bread) {
+        return breadRecordRepository.existsByUserIdAndBreadAndDeletedAtIsNull(userId, bread);
+    }
+
+    @Transactional
+    public BreadRecord createBreadRecord(
+            CreateBreadRecordRequest request,
+            UUID userId,
+            Bread bread,
+            String photoUrl
+    ) {
+        BreadRecord breadRecord = breadRecordMapper.mapToBreadRecord(
+                request,
+                userId,
+                bread,
+                photoUrl,
+                resolveEatenDate(request.getEatenDate())
+        );
+
+        return breadRecordRepository.save(breadRecord);
+    }
+
+    @Transactional
+    public BreadRecord createBreadRecord(
+            CreateNewBreadRecordRequest request,
+            UUID userId,
+            Bread bread,
+            String photoUrl
+    ) {
+        BreadRecord breadRecord = breadRecordMapper.mapToBreadRecord(
+                request,
+                userId,
+                bread,
+                photoUrl,
+                resolveEatenDate(request.getEatenDate())
+        );
+
+        return breadRecordRepository.save(breadRecord);
+    }
+
+    public BreadRecordCreateResponse createResponse(
+            BreadRecord breadRecord,
+            Boolean isFirstRecord
+    ) {
+        return breadRecordMapper.mapToCreateResponse(
+                breadRecord,
+                isFirstRecord
+        );
+    }
+
+    private LocalDate resolveEatenDate(LocalDate eatenDate) {
+        return eatenDate == null ? LocalDate.now() : eatenDate;
+    }
+
+    public void validateEatenDate(LocalDate eatenDate) {
+        if (eatenDate != null && eatenDate.isAfter(LocalDate.now())) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "미래 날짜는 선택할 수 없습니다."
+            );
+        }
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/s3/S3Config.java
+++ b/src/main/java/com/bean/breaddiary/global/s3/S3Config.java
@@ -1,0 +1,47 @@
+package com.bean.breaddiary.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    @Value("${app.aws.s3.region}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.accessKey:}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey:}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider())
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .build();
+    }
+
+    private AwsCredentialsProvider credentialsProvider() {
+        if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
+            return StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+            );
+        }
+
+        return DefaultCredentialsProvider.create();
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/s3/S3UploadService.java
+++ b/src/main/java/com/bean/breaddiary/global/s3/S3UploadService.java
@@ -1,0 +1,132 @@
+package com.bean.breaddiary.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3UploadService {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+    );
+
+    private final S3Client s3Client;
+
+    @Value("${app.aws.s3.region}")
+    private String region;
+
+    @Value("${app.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${app.aws.s3.public-base-url:}")
+    private String publicBaseUrl;
+
+    @Value("${app.aws.s3.bread-photo-prefix:bread}")
+    private String breadPhotoPrefix;
+
+    public String uploadBreadPhoto(UUID userId, MultipartFile photo) {
+        validateS3Properties();
+        validatePhoto(photo);
+
+        String key = createBreadPhotoKey(userId, photo);
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(photo.getContentType())
+                .contentLength(photo.getSize())
+                .build();
+
+        try {
+            s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(photo.getInputStream(), photo.getSize())
+            );
+        } catch (IOException exception) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 파일을 읽을 수 없습니다.", exception);
+        } catch (S3Exception exception) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.", exception);
+        }
+
+        return createPublicUrl(key);
+    }
+
+    private void validateS3Properties() {
+        if (!StringUtils.hasText(region)) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 region 설정이 필요합니다.");
+        }
+        if (!StringUtils.hasText(bucket)) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 bucket 설정이 필요합니다.");
+        }
+    }
+
+    private void validatePhoto(MultipartFile photo) {
+        if (photo == null || photo.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "사진은 필수입니다.");
+        }
+
+        if (!ALLOWED_CONTENT_TYPES.contains(photo.getContentType())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "사진은 JPEG, PNG, WebP 형식만 업로드할 수 있습니다.");
+        }
+    }
+
+    private String createBreadPhotoKey(UUID userId, MultipartFile photo) {
+        return "%s/%s/%s%s".formatted(
+                normalizePrefix(breadPhotoPrefix),
+                userId,
+                UUID.randomUUID(),
+                resolveExtension(photo.getContentType())
+        );
+    }
+
+    private String resolveExtension(String contentType) {
+        return switch (contentType) {
+            case "image/jpeg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다.");
+        };
+    }
+
+    private String createPublicUrl(String key) {
+        if (StringUtils.hasText(publicBaseUrl)) {
+            return "%s/%s".formatted(removeTrailingSlash(publicBaseUrl), key);
+        }
+
+        return "https://%s.s3.%s.amazonaws.com/%s".formatted(
+                bucket,
+                region,
+                key
+        );
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (!StringUtils.hasText(prefix)) {
+            return "bread";
+        }
+        return removeTrailingSlash(prefix);
+    }
+
+    private String removeTrailingSlash(String value) {
+        String result = value;
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #7 

## 🛠️ 작업 내용

 - build.gradle에 `S3`, `Mapper Struct` 추가.
- 기존 카탈로그 빵 기록 생성
- 신규 빵 추가 후 첫 기록 생성
- S3 연동
- Bread 카탈로그 도메인 기반 구조 추가
- swagger 주석

## 📢 참고 및 특이사항

- 비지니스 로직과 매핑 로직에 대한 책임 분리를 위해 Mapper를 사용했습니다. 
- multipart/form-data 필드명이 기존에는 snake_case였는데 현재 camelCase로 수정했습니다.
  - 이부분 프론트 분들이랑 의논하고 다시 픽스하겠습니다. 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인