### PR TITLE
fix: align bread record API field names with v1 spec

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
@@ -54,7 +54,7 @@ public class BreadRecordController {
      */
     @Operation(
             summary = "기존 빵 기록 생성",
-            description = "카탈로그에 이미 존재하는 빵에 대해 새 기록을 생성합니다. multipart/form-data 필드명은 camelCase를 사용합니다."
+            description = "카탈로그에 이미 존재하는 빵에 대해 새 기록을 생성합니다. multipart/form-data 필드명은 명세서와 동일하게 snake_case를 사용합니다."
     )
     @ApiResponses({
             @ApiResponse(
@@ -89,7 +89,7 @@ public class BreadRecordController {
      */
     @Operation(
             summary = "신규 빵 추가 및 기록 생성",
-            description = "카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다. multipart/form-data 필드명은 camelCase를 사용합니다."
+            description = "카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다. multipart/form-data 필드명은 명세서와 동일하게 snake_case를 사용합니다."
     )
     @ApiResponses({
             @ApiResponse(

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateBreadRecordRequest.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.breadrecord.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -22,6 +23,7 @@ import java.util.UUID;
 public class CreateBreadRecordRequest {
 
     @Schema(description = "카탈로그 빵 ID", example = "550e8400-e29b-41d4-a716-446655440000", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("bread_id")
     @NotNull(message = "유효한 빵을 선택해주세요.")
     private UUID breadId;
 
@@ -30,10 +32,12 @@ public class CreateBreadRecordRequest {
     private MultipartFile photo;
 
     @Schema(description = "구매처", example = "르뺑블루 성수점", maxLength = 50)
+    @JsonProperty("shop_name")
     @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
     private String shopName;
 
     @Schema(description = "먹은 날짜. 미입력 시 오늘 날짜로 저장", example = "2026-04-16")
+    @JsonProperty("eaten_date")
     private LocalDate eatenDate;
 
     @Schema(description = "별점", example = "5", minimum = "1", maximum = "5", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -45,4 +49,16 @@ public class CreateBreadRecordRequest {
     @Schema(description = "후기", example = "겉은 바삭하고 안은 촉촉해서 완벽했어요.", maxLength = 500)
     @Size(max = 500, message = "후기는 500자 이내로 입력해주세요.")
     private String review;
+
+    public void setBread_id(UUID breadId) {
+        this.breadId = breadId;
+    }
+
+    public void setShop_name(String shopName) {
+        this.shopName = shopName;
+    }
+
+    public void setEaten_date(LocalDate eatenDate) {
+        this.eatenDate = eatenDate;
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateNewBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateNewBreadRecordRequest.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.domain.breadrecord.dto.request;
 
 import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -30,6 +31,7 @@ public class CreateNewBreadRecordRequest {
     @Schema(description = "빵 종류", example = "PASTRY", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = {
             "PASTRY", "BREAD", "DONUT", "CAKE", "BAGEL", "TART", "OTHER"
     })
+    @JsonProperty("bread_type")
     @NotNull(message = "올바른 빵 종류를 선택해주세요.")
     private BreadType breadType;
 
@@ -38,10 +40,12 @@ public class CreateNewBreadRecordRequest {
     private MultipartFile photo;
 
     @Schema(description = "구매처", example = "카페봄봄 합정점", maxLength = 50)
+    @JsonProperty("shop_name")
     @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
     private String shopName;
 
     @Schema(description = "먹은 날짜. 미입력 시 오늘 날짜로 저장", example = "2026-04-16")
+    @JsonProperty("eaten_date")
     private LocalDate eatenDate;
 
     @Schema(description = "별점", example = "4", minimum = "1", maximum = "5", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -53,4 +57,16 @@ public class CreateNewBreadRecordRequest {
     @Schema(description = "후기", example = "말차 맛이 진해서 좋았어요.", maxLength = 500)
     @Size(max = 500, message = "후기는 500자 이내로 입력해주세요.")
     private String review;
+
+    public void setBread_type(BreadType breadType) {
+        this.breadType = breadType;
+    }
+
+    public void setShop_name(String shopName) {
+        this.shopName = shopName;
+    }
+
+    public void setEaten_date(LocalDate eatenDate) {
+        this.eatenDate = eatenDate;
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordCreateResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordCreateResponse.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.domain.breadrecord.dto.response;
 
 import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,30 +23,38 @@ public class BreadRecordCreateResponse {
     private UUID id;
 
     @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    @JsonProperty("bread_id")
     private UUID breadId;
 
     @Schema(description = "도감 번호", example = "7")
+    @JsonProperty("sticker_number")
     private Integer stickerNumber;
 
     @Schema(description = "원본 사진 URL", example = "https://breaddiary-bucket.s3.ap-northeast-2.amazonaws.com/bread/550e8400/a1b2c3d4.webp")
+    @JsonProperty("photo_url")
     private String photoUrl;
 
     @Schema(description = "썸네일 사진 URL", example = "https://breaddiary-bucket.s3.ap-northeast-2.amazonaws.com/bread/550e8400/a1b2c3d4_thumb.webp")
+    @JsonProperty("photo_thumbnail_url")
     private String photoThumbnailUrl;
 
     @Schema(description = "빵 이름", example = "크루아상")
     private String name;
 
     @Schema(description = "빵 종류", example = "PASTRY")
+    @JsonProperty("bread_type")
     private BreadType breadType;
 
     @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
+    @JsonProperty("image_url")
     private String imageUrl;
 
     @Schema(description = "구매처", example = "르뺑블루 성수점")
+    @JsonProperty("shop_name")
     private String shopName;
 
     @Schema(description = "먹은 날짜", example = "2026-04-16")
+    @JsonProperty("eaten_date")
     private LocalDate eatenDate;
 
     @Schema(description = "별점", example = "5")
@@ -55,8 +64,10 @@ public class BreadRecordCreateResponse {
     private String review;
 
     @Schema(description = "해당 빵의 첫 기록 여부", example = "false")
+    @JsonProperty("is_first_record")
     private Boolean isFirstRecord;
 
     @Schema(description = "기록 생성 일시", example = "2026-04-16T09:30:00")
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #9 

## 🛠️ 작업 내용

- 빵 기록 생성 응답 DTO의 JSON 필드명을 명세서 기준 snake_case로 직렬화되도록 수정했습니다.
- Swagger/OpenAPI 설명에서 multipart 필드명이 `camelCase`가 아닌 `snake_case`임을 명시했습니다.

## 📢 참고 및 특이사항

- 없습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인