### PR TITLE
implement bread autocomplete API

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
@@ -1,0 +1,54 @@
+package com.bean.breaddiary.domain.bread.controller;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "빵 카탈로그 API", description = "빵 카탈로그와 자동완성을 관리하는 API입니다.")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/breads")
+public class BreadController {
+
+    private final BreadComplexService breadComplexService;
+
+    @Operation(
+            summary = "빵 카탈로그 자동완성",
+            description = "빵 기록 시 사용할 빵 이름 자동완성 목록을 조회합니다. q가 없으면 인기순 기본 목록을 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "자동완성 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BreadAutocompleteResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/autocomplete")
+    public ResponseEntity<ApiResponse<BreadAutocompleteResponse>> autocompleteBreads(
+            @Parameter(description = "검색어. 미입력 시 인기순 빵 목록을 반환합니다.", example = "크루")
+            @RequestParam(value = "q", required = false) String query,
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+    ) {
+        BreadAutocompleteResponse response = breadComplexService.autocompleteBreads(query, userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -1,11 +1,15 @@
 package com.bean.breaddiary.domain.bread.dto.mapper;
 
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -18,4 +22,27 @@ public interface BreadMapper {
     @Mapping(target = "imageUrl", source = "imageUrl")
     @Mapping(target = "createdBy", source = "userId")
     Bread mapToBread(CreateNewBreadRecordRequest request, Integer stickerNumber, String imageUrl, UUID userId);
+
+    @Mapping(target = "breadId", source = "bread.id")
+    @Mapping(target = "name", source = "bread.name")
+    @Mapping(target = "breadType", source = "bread.breadType")
+    @Mapping(target = "stickerNumber", source = "bread.stickerNumber")
+    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    @Mapping(target = "eatCount", expression = "java(resolveEatCount(eatCount))")
+    BreadAutocompleteItemResponse mapToAutocompleteItem(Bread bread, Long eatCount);
+
+    default BreadAutocompleteResponse mapToAutocompleteResponse(List<Bread> breads, Map<UUID, Long> eatCounts) {
+        List<BreadAutocompleteItemResponse> items = breads.stream()
+                .map(bread -> mapToAutocompleteItem(
+                        bread,
+                        eatCounts.get(bread.getId())
+                ))
+                .toList();
+
+        return new BreadAutocompleteResponse(items);
+    }
+
+    default Long resolveEatCount(Long eatCount) {
+        return eatCount == null ? 0L : eatCount;
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteItemResponse.java
@@ -1,0 +1,42 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 카탈로그 자동완성 아이템")
+public class BreadAutocompleteItemResponse {
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    @JsonProperty("bread_id")
+    private UUID breadId;
+
+    @Schema(description = "빵 이름", example = "크루아상")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY")
+    @JsonProperty("bread_type")
+    private BreadType breadType;
+
+    @Schema(description = "도감 번호", example = "6")
+    @JsonProperty("sticker_number")
+    private Integer stickerNumber;
+
+    @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @Schema(description = "현재 유저의 해당 빵 기록 수", example = "5")
+    @JsonProperty("eat_count")
+    private Long eatCount;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteResponse.java
@@ -1,0 +1,24 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 카탈로그 자동완성 응답")
+public class BreadAutocompleteResponse {
+
+    @ArraySchema(
+            schema = @Schema(implementation = BreadAutocompleteItemResponse.class),
+            arraySchema = @Schema(description = "자동완성 빵 목록")
+    )
+    private List<BreadAutocompleteItemResponse> items;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -1,8 +1,11 @@
 package com.bean.breaddiary.domain.bread.repository;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +18,17 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
     Optional<Bread> findTopByOrderByStickerNumberDesc();
 
     boolean existsByName(String name);
+
+    List<Bread> findByNameContainingIgnoreCaseOrderByStickerNumberAsc(String name, Pageable pageable);
+
+    @Query("""
+            select b
+            from Bread b
+            left join BreadRecord br
+                on br.bread = b
+                and br.deletedAt is null
+            group by b
+            order by count(br) desc, b.stickerNumber asc
+            """)
+    List<Bread> findPopularOrderByRecordCountDesc(Pageable pageable);
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -1,0 +1,42 @@
+package com.bean.breaddiary.domain.bread.service;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BreadComplexService {
+
+    private final BreadService breadService;
+    private final BreadRecordService breadRecordService;
+
+    public BreadAutocompleteResponse autocompleteBreads(String query, UUID userId) {
+        List<Bread> breads = breadService.searchAutocompleteBreads(query);
+
+        Map<UUID, Long> eatCounts = resolveEatCounts(userId, breads);
+
+        return breadService.createAutocompleteResponse(breads, eatCounts);
+    }
+
+    private Map<UUID, Long> resolveEatCounts(UUID userId, List<Bread> breads) {
+        if (userId == null || breads.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<UUID> breadIds = breads.stream()
+                .map(Bread::getId)
+                .toList();
+
+        return breadRecordService.countActiveRecordsByBreadIds(userId, breadIds);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -1,15 +1,20 @@
 package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.mapper.BreadMapper;
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -17,6 +22,7 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class BreadService {
 
+    private static final int AUTOCOMPLETE_LIMIT = 20;
     private static final String DEFAULT_USER_BREAD_IMAGE_URL =
             "https://cdn.bread-diary.app/catalog/default_user_bread.webp";
 
@@ -33,6 +39,26 @@ public class BreadService {
 
     public boolean existsByName(String name) {
         return breadRepository.existsByName(name);
+    }
+
+    public List<Bread> searchAutocompleteBreads(String query) {
+        Pageable limit = PageRequest.of(0, AUTOCOMPLETE_LIMIT);
+
+        if (query == null || query.isBlank()) {
+            return breadRepository.findPopularOrderByRecordCountDesc(limit);
+        }
+
+        return breadRepository.findByNameContainingIgnoreCaseOrderByStickerNumberAsc(
+                query.trim(),
+                limit
+        );
+    }
+
+    public BreadAutocompleteResponse createAutocompleteResponse(
+            List<Bread> breads,
+            Map<UUID, Long> eatCounts
+    ) {
+        return breadMapper.mapToAutocompleteResponse(breads, eatCounts);
     }
 
     @Transactional

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCountProjection.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCountProjection.java
@@ -1,0 +1,10 @@
+package com.bean.breaddiary.domain.breadrecord.dto.projection;
+
+import java.util.UUID;
+
+public interface BreadRecordCountProjection {
+
+    UUID getBreadId();
+
+    Long getEatCount();
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -2,7 +2,10 @@ package com.bean.breaddiary.domain.breadrecord.repository;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -13,4 +16,17 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
     List<BreadRecord> findAllByUserIdAndBread(UUID userId, Bread bread);
     long countByUserIdAndBread(UUID userId, Bread bread);
     boolean existsByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
+
+    @Query("""
+            select br.bread.id as breadId, count(br) as eatCount
+            from BreadRecord br
+            where br.userId = :userId
+              and br.bread.id in :breadIds
+              and br.deletedAt is null
+            group by br.bread.id
+            """)
+    List<BreadRecordCountProjection> countActiveRecordsByBreadIds(
+            @Param("userId") UUID userId,
+            @Param("breadIds") List<UUID> breadIds
+    );
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
@@ -6,6 +6,7 @@ import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordReque
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
 import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,7 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +31,19 @@ public class BreadRecordService {
 
     public boolean existsActiveRecord(UUID userId, Bread bread) {
         return breadRecordRepository.existsByUserIdAndBreadAndDeletedAtIsNull(userId, bread);
+    }
+
+    public Map<UUID, Long> countActiveRecordsByBreadIds(UUID userId, List<UUID> breadIds) {
+        if (userId == null || breadIds == null || breadIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return breadRecordRepository.countActiveRecordsByBreadIds(userId, breadIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        BreadRecordCountProjection::getBreadId,
+                        BreadRecordCountProjection::getEatCount
+                ));
     }
 
     @Transactional

--- a/src/main/java/com/bean/breaddiary/global/common/ApiResponse.java
+++ b/src/main/java/com/bean/breaddiary/global/common/ApiResponse.java
@@ -1,0 +1,17 @@
+package com.bean.breaddiary.global.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 API 응답")
+public record ApiResponse<T>(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+
+        @Schema(description = "응답 데이터")
+        T data
+) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
@@ -1,0 +1,81 @@
+package com.bean.breaddiary.domain.bread.controller;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BreadControllerAutocompleteTest {
+
+    private BreadComplexService breadComplexService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        breadComplexService = mock(BreadComplexService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new BreadController(breadComplexService))
+                .build();
+    }
+
+    @Test
+    void autocompleteBreadsReturnsSpecResponseWithSnakeCaseFields() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        BreadAutocompleteResponse response = new BreadAutocompleteResponse(List.of(
+                new BreadAutocompleteItemResponse(
+                        breadId,
+                        "크루아상",
+                        BreadType.PASTRY,
+                        6,
+                        "https://cdn.bread-diary.app/breads/croissant.webp",
+                        5L
+                )
+        ));
+
+        when(breadComplexService.autocompleteBreads("크루", userId)).thenReturn(response);
+
+        mockMvc.perform(get("/breads/autocomplete")
+                        .param("q", "크루")
+                        .header("X-USER-ID", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items[0].bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.items[0].name").value("크루아상"))
+                .andExpect(jsonPath("$.data.items[0].bread_type").value("PASTRY"))
+                .andExpect(jsonPath("$.data.items[0].sticker_number").value(6))
+                .andExpect(jsonPath("$.data.items[0].image_url").value("https://cdn.bread-diary.app/breads/croissant.webp"))
+                .andExpect(jsonPath("$.data.items[0].eat_count").value(5))
+                .andExpect(jsonPath("$.data.items[0].breadId").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].breadType").doesNotExist());
+
+        verify(breadComplexService).autocompleteBreads("크루", userId);
+    }
+
+    @Test
+    void autocompleteBreadsAllowsAnonymousRequest() throws Exception {
+        when(breadComplexService.autocompleteBreads(null, null))
+                .thenReturn(new BreadAutocompleteResponse(List.of()));
+
+        mockMvc.perform(get("/breads/autocomplete"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items").isArray());
+
+        verify(breadComplexService).autocompleteBreads(null, null);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
@@ -1,0 +1,74 @@
+package com.bean.breaddiary.domain.bread.service;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class BreadComplexServiceTest {
+
+    private BreadService breadService;
+    private BreadRecordService breadRecordService;
+    private BreadComplexService breadComplexService;
+
+    @BeforeEach
+    void setUp() {
+        breadService = mock(BreadService.class);
+        breadRecordService = mock(BreadRecordService.class);
+        breadComplexService = new BreadComplexService(breadService, breadRecordService);
+    }
+
+    @Test
+    void autocompleteBreadsCombinesBreadSearchAndUserEatCounts() {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        Bread bread = Bread.builder()
+                .id(breadId)
+                .stickerNumber(6)
+                .name("크루아상")
+                .breadType(BreadType.PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/breads/croissant.webp")
+                .build();
+        BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of());
+
+        when(breadService.searchAutocompleteBreads("크루")).thenReturn(List.of(bread));
+        when(breadRecordService.countActiveRecordsByBreadIds(userId, List.of(breadId)))
+                .thenReturn(Map.of(breadId, 5L));
+        when(breadService.createAutocompleteResponse(List.of(bread), Map.of(breadId, 5L)))
+                .thenReturn(expected);
+
+        BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads("크루", userId);
+
+        assertSame(expected, actual);
+        verify(breadService).searchAutocompleteBreads("크루");
+        verify(breadRecordService).countActiveRecordsByBreadIds(userId, List.of(breadId));
+        verify(breadService).createAutocompleteResponse(List.of(bread), Map.of(breadId, 5L));
+    }
+
+    @Test
+    void autocompleteBreadsSkipsEatCountLookupForAnonymousUser() {
+        BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of());
+
+        when(breadService.searchAutocompleteBreads(null)).thenReturn(List.of());
+        when(breadService.createAutocompleteResponse(List.of(), Map.of())).thenReturn(expected);
+
+        BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads(null, null);
+
+        assertSame(expected, actual);
+        verify(breadService).searchAutocompleteBreads(null);
+        verifyNoInteractions(breadRecordService);
+        verify(breadService).createAutocompleteResponse(List.of(), Map.of());
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
@@ -1,0 +1,143 @@
+package com.bean.breaddiary.domain.breadrecord.controller;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
+import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BreadRecordControllerContractTest {
+
+    private static final UUID DUMMY_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private BreadRecordComplexService breadRecordComplexService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        breadRecordComplexService = mock(BreadRecordComplexService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new BreadRecordController(breadRecordComplexService))
+                .build();
+    }
+
+    @Test
+    void createBreadRecordBindsSnakeCaseMultipartFieldsAndSerializesSnakeCaseResponse() throws Exception {
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        BreadRecordCreateResponse response = createResponse(breadId, BreadType.PASTRY, false);
+
+        when(breadRecordComplexService.createBreadRecord(eq(DUMMY_USER_ID), any(CreateBreadRecordRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(multipart("/breads")
+                        .file(new MockMultipartFile(
+                                "photo",
+                                "croissant.webp",
+                                MediaType.IMAGE_JPEG_VALUE,
+                                "photo".getBytes()
+                        ))
+                        .param("bread_id", breadId.toString())
+                        .param("shop_name", "르뺑블루 성수점")
+                        .param("eaten_date", "2026-03-14")
+                        .param("rating", "5")
+                        .param("review", "겉은 바삭하고 안은 촉촉해서 완벽했어요."))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.sticker_number").value(7))
+                .andExpect(jsonPath("$.photo_url").value("https://cdn.bread-diary.app/bread-photos/record.webp"))
+                .andExpect(jsonPath("$.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
+                .andExpect(jsonPath("$.bread_type").value("PASTRY"))
+                .andExpect(jsonPath("$.shop_name").value("르뺑블루 성수점"))
+                .andExpect(jsonPath("$.eaten_date").value("2026-03-14"))
+                .andExpect(jsonPath("$.is_first_record").value(false))
+                .andExpect(jsonPath("$.breadId").doesNotExist())
+                .andExpect(jsonPath("$.shopName").doesNotExist());
+
+        ArgumentCaptor<CreateBreadRecordRequest> requestCaptor =
+                ArgumentCaptor.forClass(CreateBreadRecordRequest.class);
+        verify(breadRecordComplexService).createBreadRecord(eq(DUMMY_USER_ID), requestCaptor.capture());
+
+        CreateBreadRecordRequest request = requestCaptor.getValue();
+        assertEquals(breadId, request.getBreadId());
+        assertEquals("르뺑블루 성수점", request.getShopName());
+        assertEquals(LocalDate.of(2026, 3, 14), request.getEatenDate());
+    }
+
+    @Test
+    void createNewBreadRecordBindsSnakeCaseMultipartFields() throws Exception {
+        UUID breadId = UUID.fromString("c1d2e3f4-a5b6-7890-cdef-ab0123456789");
+        BreadRecordCreateResponse response = createResponse(breadId, BreadType.BAGEL, true);
+
+        when(breadRecordComplexService.createNewBreadRecord(eq(DUMMY_USER_ID), any(CreateNewBreadRecordRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(multipart("/breads/new")
+                        .file(new MockMultipartFile(
+                                "photo",
+                                "bagel.webp",
+                                MediaType.IMAGE_JPEG_VALUE,
+                                "photo".getBytes()
+                        ))
+                        .param("name", "플레인 베이글")
+                        .param("bread_type", "BAGEL")
+                        .param("shop_name", "베이글샵")
+                        .param("eaten_date", "2026-03-15")
+                        .param("rating", "4")
+                        .param("review", "쫄깃했어요."))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.bread_type").value("BAGEL"))
+                .andExpect(jsonPath("$.is_first_record").value(true))
+                .andExpect(jsonPath("$.breadType").doesNotExist());
+
+        ArgumentCaptor<CreateNewBreadRecordRequest> requestCaptor =
+                ArgumentCaptor.forClass(CreateNewBreadRecordRequest.class);
+        verify(breadRecordComplexService).createNewBreadRecord(eq(DUMMY_USER_ID), requestCaptor.capture());
+
+        CreateNewBreadRecordRequest request = requestCaptor.getValue();
+        assertEquals("플레인 베이글", request.getName());
+        assertEquals(BreadType.BAGEL, request.getBreadType());
+        assertEquals("베이글샵", request.getShopName());
+        assertEquals(LocalDate.of(2026, 3, 15), request.getEatenDate());
+    }
+
+    private BreadRecordCreateResponse createResponse(UUID breadId, BreadType breadType, boolean isFirstRecord) {
+        return new BreadRecordCreateResponse(
+                UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+                breadId,
+                7,
+                "https://cdn.bread-diary.app/bread-photos/record.webp",
+                "https://cdn.bread-diary.app/bread-photos/record_thumb.webp",
+                "크루아상",
+                breadType,
+                "https://cdn.bread-diary.app/breads/croissant.webp",
+                "르뺑블루 성수점",
+                LocalDate.of(2026, 3, 14),
+                5,
+                "겉은 바삭하고 안은 촉촉해서 완벽했어요.",
+                isFirstRecord,
+                LocalDateTime.of(2026, 3, 14, 9, 30)
+        );
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #11 

## 🛠️ 작업 내용

- 빵 카탈로그 자동완성 API를 구현했습니다.
- 자동완성 응답 DTO를 추가했습니다.
- 공통 응답 구조를 적용했습니다.

## 📢 참고 및 특이사항

- `q`가 없는 경우 명세서 기준으로 전체 활성 기록 수가 많은 빵부터 반환합니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인