### PR TITLE
chore: align bread API responses

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
@@ -4,11 +4,11 @@ import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordReque
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
+import com.bean.breaddiary.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -57,17 +57,17 @@ public class BreadRecordController {
             description = "카탈로그에 이미 존재하는 빵에 대해 새 기록을 생성합니다. multipart/form-data 필드명은 명세서와 동일하게 snake_case를 사용합니다."
     )
     @ApiResponses({
-            @ApiResponse(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "201",
                     description = "빵 기록 생성 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordCreateResponse.class))
             ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "빵 카탈로그를 찾을 수 없음"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 카탈로그를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<BreadRecordCreateResponse> createBreadRecord(
+    public ResponseEntity<ApiResponse<BreadRecordCreateResponse>> createBreadRecord(
             @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
             @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
             @Valid @ModelAttribute CreateBreadRecordRequest request
@@ -77,7 +77,8 @@ public class BreadRecordController {
                 request
         );
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
@@ -92,17 +93,17 @@ public class BreadRecordController {
             description = "카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다. multipart/form-data 필드명은 명세서와 동일하게 snake_case를 사용합니다."
     )
     @ApiResponses({
-            @ApiResponse(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "201",
                     description = "신규 빵 및 기록 생성 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordCreateResponse.class))
             ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "409", description = "중복된 빵 이름"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "중복된 빵 이름"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PostMapping(path = "/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<BreadRecordCreateResponse> createNewBreadRecord(
+    public ResponseEntity<ApiResponse<BreadRecordCreateResponse>> createNewBreadRecord(
             @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
             @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
             @Valid @ModelAttribute CreateNewBreadRecordRequest request
@@ -112,7 +113,8 @@ public class BreadRecordController {
                 request
         );
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     private UUID resolveUserId(UUID userId) {

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
@@ -63,16 +63,17 @@ class BreadRecordControllerContractTest {
                         .param("rating", "5")
                         .param("review", "겉은 바삭하고 안은 촉촉해서 완벽했어요."))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.bread_id").value(breadId.toString()))
-                .andExpect(jsonPath("$.sticker_number").value(7))
-                .andExpect(jsonPath("$.photo_url").value("https://cdn.bread-diary.app/bread-photos/record.webp"))
-                .andExpect(jsonPath("$.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
-                .andExpect(jsonPath("$.bread_type").value("PASTRY"))
-                .andExpect(jsonPath("$.shop_name").value("르뺑블루 성수점"))
-                .andExpect(jsonPath("$.eaten_date").value("2026-03-14"))
-                .andExpect(jsonPath("$.is_first_record").value(false))
-                .andExpect(jsonPath("$.breadId").doesNotExist())
-                .andExpect(jsonPath("$.shopName").doesNotExist());
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.sticker_number").value(7))
+                .andExpect(jsonPath("$.data.photo_url").value("https://cdn.bread-diary.app/bread-photos/record.webp"))
+                .andExpect(jsonPath("$.data.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
+                .andExpect(jsonPath("$.data.bread_type").value("PASTRY"))
+                .andExpect(jsonPath("$.data.shop_name").value("르뺑블루 성수점"))
+                .andExpect(jsonPath("$.data.eaten_date").value("2026-03-14"))
+                .andExpect(jsonPath("$.data.is_first_record").value(false))
+                .andExpect(jsonPath("$.data.breadId").doesNotExist())
+                .andExpect(jsonPath("$.data.shopName").doesNotExist());
 
         ArgumentCaptor<CreateBreadRecordRequest> requestCaptor =
                 ArgumentCaptor.forClass(CreateBreadRecordRequest.class);
@@ -106,10 +107,11 @@ class BreadRecordControllerContractTest {
                         .param("rating", "4")
                         .param("review", "쫄깃했어요."))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.bread_id").value(breadId.toString()))
-                .andExpect(jsonPath("$.bread_type").value("BAGEL"))
-                .andExpect(jsonPath("$.is_first_record").value(true))
-                .andExpect(jsonPath("$.breadType").doesNotExist());
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.bread_type").value("BAGEL"))
+                .andExpect(jsonPath("$.data.is_first_record").value(true))
+                .andExpect(jsonPath("$.data.breadType").doesNotExist());
 
         ArgumentCaptor<CreateNewBreadRecordRequest> requestCaptor =
                 ArgumentCaptor.forClass(CreateNewBreadRecordRequest.class);


### PR DESCRIPTION
## 🧩 관련 이슈

- #13 

## 🛠️ 작업 내용

- 기존 작업했던 API의 응답 형태를 명세서에 맞춰서 응답을 반환하도록 수정했습니다.
- **변경 전**
```
  {
    "id": "...",
    "bread_id": "...",
    "sticker_number": 7
  }
```
- **변경 후**
```
  {
    "success": true,
    "data": {
      "id": "...",
      "bread_id": "...",
      "sticker_number": 7
    }
  }
```

## 📢 참고 및 특이사항

- 없습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인