### PR TITLE
feat: implement bread catalog list API

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
@@ -1,6 +1,8 @@
 package com.bean.breaddiary.domain.bread.controller;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
 import com.bean.breaddiary.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +29,48 @@ import java.util.UUID;
 public class BreadController {
 
     private final BreadComplexService breadComplexService;
+
+    @Operation(
+            summary = "빵 도감 목록 조회",
+            description = "전체 빵 카탈로그와 현재 유저의 수집 상태를 조회합니다. 비로그인 요청에서는 카탈로그 정보만 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "빵 도감 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BreadCatalogListResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<BreadCatalogListResponse>> getBreadCatalog(
+            @Parameter(description = "정렬 기준: sticker_number, latest, rating", example = "sticker_number")
+            @RequestParam(value = "sort", required = false) String sort,
+            @Parameter(description = "수집 상태 필터: all, collected, uncollected", example = "all")
+            @RequestParam(value = "filter", required = false) String filter,
+            @Parameter(description = "빵 종류 필터", example = "PASTRY")
+            @RequestParam(value = "bread_type", required = false) BreadType breadType,
+            @Parameter(description = "빵 이름 검색어", example = "크루아상")
+            @RequestParam(value = "search", required = false) String search,
+            @Parameter(description = "페이지네이션 커서", example = "6")
+            @RequestParam(value = "cursor", required = false) String cursor,
+            @Parameter(description = "페이지당 개수. 기본 20, 최대 50", example = "20")
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+    ) {
+        BreadCatalogListResponse response = breadComplexService.getBreadCatalog(
+                sort,
+                filter,
+                breadType,
+                search,
+                cursor,
+                limit,
+                userId
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
     @Operation(
             summary = "빵 카탈로그 자동완성",

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -2,12 +2,17 @@ package com.bean.breaddiary.domain.bread.dto.mapper;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,5 +49,76 @@ public interface BreadMapper {
 
     default Long resolveEatCount(Long eatCount) {
         return eatCount == null ? 0L : eatCount;
+    }
+
+    @Mapping(target = "breadId", source = "bread.id")
+    @Mapping(target = "stickerNumber", source = "bread.stickerNumber")
+    @Mapping(target = "name", source = "bread.name")
+    @Mapping(target = "breadType", source = "bread.breadType")
+    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    @Mapping(target = "isCollected", expression = "java(isCollected(stats))")
+    @Mapping(target = "eatCount", expression = "java(resolveEatCount(stats))")
+    @Mapping(target = "avgRating", expression = "java(resolveAvgRating(stats))")
+    @Mapping(target = "latestPhotoUrl", expression = "java(resolveLatestPhotoUrl(stats))")
+    @Mapping(target = "latestEatenDate", expression = "java(stats == null ? null : stats.latestEatenDate())")
+    BreadCatalogItemResponse mapToCatalogItem(Bread bread, BreadRecordCatalogStats stats);
+
+    default BreadCatalogListResponse mapToCatalogListResponse(
+            List<Bread> breads,
+            Map<UUID, BreadRecordCatalogStats> statsMap,
+            String nextCursor,
+            boolean hasMore,
+            long totalCount
+    ) {
+        List<BreadCatalogItemResponse> items = breads.stream()
+                .map(bread -> mapToCatalogItem(
+                        bread,
+                        statsMap.get(bread.getId())
+                ))
+                .toList();
+
+        return new BreadCatalogListResponse(
+                items,
+                nextCursor,
+                hasMore,
+                totalCount
+        );
+    }
+
+    default Boolean isCollected(BreadRecordCatalogStats stats) {
+        return stats != null && resolveEatCount(stats) > 0;
+    }
+
+    default Long resolveEatCount(BreadRecordCatalogStats stats) {
+        return stats == null || stats.eatCount() == null ? 0L : stats.eatCount();
+    }
+
+    default Double resolveAvgRating(BreadRecordCatalogStats stats) {
+        if (stats == null || stats.avgRating() == null) {
+            return null;
+        }
+
+        return BigDecimal.valueOf(stats.avgRating())
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+
+    default String resolveLatestPhotoUrl(BreadRecordCatalogStats stats) {
+        if (stats == null || stats.latestPhotoUrl() == null) {
+            return null;
+        }
+
+        return toThumbnailUrl(stats.latestPhotoUrl());
+    }
+
+    default String toThumbnailUrl(String photoUrl) {
+        int extensionIndex = photoUrl.lastIndexOf('.');
+        if (extensionIndex < 0) {
+            return photoUrl + "_thumb";
+        }
+
+        return photoUrl.substring(0, extensionIndex)
+                + "_thumb"
+                + photoUrl.substring(extensionIndex);
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogItemResponse.java
@@ -1,0 +1,59 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 도감 목록 아이템")
+public class BreadCatalogItemResponse {
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    @JsonProperty("bread_id")
+    private UUID breadId;
+
+    @Schema(description = "도감 번호", example = "6")
+    @JsonProperty("sticker_number")
+    private Integer stickerNumber;
+
+    @Schema(description = "빵 이름", example = "크루아상")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY")
+    @JsonProperty("bread_type")
+    private BreadType breadType;
+
+    @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @Schema(description = "현재 유저의 수집 여부", example = "true")
+    @JsonProperty("is_collected")
+    private Boolean isCollected;
+
+    @Schema(description = "현재 유저의 해당 빵 기록 수", example = "5")
+    @JsonProperty("eat_count")
+    private Long eatCount;
+
+    @Schema(description = "현재 유저의 해당 빵 평균 별점", example = "4.8", nullable = true)
+    @JsonProperty("avg_rating")
+    private Double avgRating;
+
+    @Schema(description = "현재 유저의 해당 빵 최신 기록 썸네일 URL", example = "https://cdn.bread-diary.app/bread-photos/550e8400/a1b2c3d4_thumb.webp", nullable = true)
+    @JsonProperty("latest_photo_url")
+    private String latestPhotoUrl;
+
+    @Schema(description = "현재 유저의 해당 빵 최신 먹은 날짜", example = "2026-03-14", nullable = true)
+    @JsonProperty("latest_eaten_date")
+    private LocalDate latestEatenDate;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogListResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogListResponse.java
@@ -1,0 +1,37 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 도감 목록 조회 응답")
+public class BreadCatalogListResponse {
+
+    @ArraySchema(
+            schema = @Schema(implementation = BreadCatalogItemResponse.class),
+            arraySchema = @Schema(description = "빵 도감 목록")
+    )
+    private List<BreadCatalogItemResponse> items;
+
+    @Schema(description = "다음 페이지 커서. 다음 페이지가 없으면 null", example = "8", nullable = true)
+    @JsonProperty("next_cursor")
+    private String nextCursor;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    @JsonProperty("has_more")
+    private Boolean hasMore;
+
+    @Schema(description = "필터 적용 후 전체 빵 수", example = "42")
+    @JsonProperty("total_count")
+    private Long totalCount;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -1,9 +1,11 @@
 package com.bean.breaddiary.domain.bread.repository;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,4 +33,16 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
             order by count(br) desc, b.stickerNumber asc
             """)
     List<Bread> findPopularOrderByRecordCountDesc(Pageable pageable);
+
+    @Query("""
+            select b
+            from Bread b
+            where (:search is null or lower(b.name) like lower(concat('%', :search, '%')))
+              and (:breadType is null or b.breadType = :breadType)
+            order by b.stickerNumber asc
+            """)
+    List<Bread> findCatalogCandidates(
+            @Param("search") String search,
+            @Param("breadType") BreadType breadType
+    );
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -1,13 +1,20 @@
 package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -16,6 +23,15 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BreadComplexService {
+
+    private static final String SORT_STICKER_NUMBER = "sticker_number";
+    private static final String SORT_LATEST = "latest";
+    private static final String SORT_RATING = "rating";
+    private static final String FILTER_ALL = "all";
+    private static final String FILTER_COLLECTED = "collected";
+    private static final String FILTER_UNCOLLECTED = "uncollected";
+    private static final int DEFAULT_LIMIT = 20;
+    private static final int MAX_LIMIT = 50;
 
     private final BreadService breadService;
     private final BreadRecordService breadRecordService;
@@ -28,6 +44,41 @@ public class BreadComplexService {
         return breadService.createAutocompleteResponse(breads, eatCounts);
     }
 
+    public BreadCatalogListResponse getBreadCatalog(
+            String sort,
+            String filter,
+            BreadType breadType,
+            String search,
+            String cursor,
+            Integer limit,
+            UUID userId
+    ) {
+        String normalizedSort = normalizeSort(sort);
+        String normalizedFilter = normalizeFilter(filter);
+        int normalizedLimit = normalizeLimit(limit);
+
+        List<Bread> candidates = breadService.findCatalogCandidates(search, breadType);
+        Map<UUID, BreadRecordCatalogStats> statsMap = resolveCatalogStats(userId, candidates);
+
+        List<Bread> filteredBreads = applyFilter(candidates, statsMap, userId, normalizedFilter);
+        List<Bread> sortedBreads = applySort(filteredBreads, statsMap, normalizedSort);
+        List<Bread> cursorAppliedBreads = applyCursor(sortedBreads, statsMap, normalizedSort, cursor);
+        List<Bread> pageBreads = takePage(cursorAppliedBreads, normalizedLimit);
+
+        boolean hasMore = cursorAppliedBreads.size() > normalizedLimit;
+        String nextCursor = hasMore && !pageBreads.isEmpty()
+                ? createNextCursor(pageBreads.get(pageBreads.size() - 1), statsMap, normalizedSort)
+                : null;
+
+        return breadService.createCatalogListResponse(
+                pageBreads,
+                statsMap,
+                nextCursor,
+                hasMore,
+                filteredBreads.size()
+        );
+    }
+
     private Map<UUID, Long> resolveEatCounts(UUID userId, List<Bread> breads) {
         if (userId == null || breads.isEmpty()) {
             return Collections.emptyMap();
@@ -38,5 +89,178 @@ public class BreadComplexService {
                 .toList();
 
         return breadRecordService.countActiveRecordsByBreadIds(userId, breadIds);
+    }
+
+    private Map<UUID, BreadRecordCatalogStats> resolveCatalogStats(UUID userId, List<Bread> breads) {
+        if (userId == null || breads.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<UUID> breadIds = breads.stream()
+                .map(Bread::getId)
+                .toList();
+
+        return breadRecordService.findCatalogStatsByBreadIds(userId, breadIds);
+    }
+
+    private List<Bread> applyFilter(
+            List<Bread> breads,
+            Map<UUID, BreadRecordCatalogStats> statsMap,
+            UUID userId,
+            String filter
+    ) {
+        if (FILTER_ALL.equals(filter)) {
+            return breads;
+        }
+
+        return breads.stream()
+                .filter(bread -> {
+                    boolean isCollected = isCollected(bread, statsMap);
+
+                    if (FILTER_COLLECTED.equals(filter)) {
+                        return userId != null && isCollected;
+                    }
+
+                    if (FILTER_UNCOLLECTED.equals(filter)) {
+                        return !isCollected;
+                    }
+
+                    return true;
+                })
+                .toList();
+    }
+
+    private List<Bread> applySort(
+            List<Bread> breads,
+            Map<UUID, BreadRecordCatalogStats> statsMap,
+            String sort
+    ) {
+        List<Bread> sortedBreads = new ArrayList<>(breads);
+
+        if (SORT_LATEST.equals(sort)) {
+            return sortedBreads.stream()
+                    .filter(bread -> isCollected(bread, statsMap))
+                    .sorted(Comparator
+                            .comparing((Bread bread) -> statsMap.get(bread.getId()).latestEatenDate(), Comparator.reverseOrder())
+                            .thenComparing(bread -> bread.getId().toString()))
+                    .toList();
+        }
+
+        if (SORT_RATING.equals(sort)) {
+            return sortedBreads.stream()
+                    .filter(bread -> isCollected(bread, statsMap))
+                    .sorted(Comparator
+                            .comparing((Bread bread) -> statsMap.get(bread.getId()).avgRating(), Comparator.reverseOrder())
+                            .thenComparing(bread -> bread.getId().toString()))
+                    .toList();
+        }
+
+        sortedBreads.sort(Comparator.comparing(Bread::getStickerNumber));
+        return sortedBreads;
+    }
+
+    private List<Bread> applyCursor(
+            List<Bread> breads,
+            Map<UUID, BreadRecordCatalogStats> statsMap,
+            String sort,
+            String cursor
+    ) {
+        if (cursor == null || cursor.isBlank()) {
+            return breads;
+        }
+
+        if (SORT_STICKER_NUMBER.equals(sort)) {
+            return applyStickerNumberCursor(breads, cursor);
+        }
+
+        return applyCompositeCursor(breads, cursor);
+    }
+
+    private List<Bread> applyStickerNumberCursor(List<Bread> breads, String cursor) {
+        try {
+            int stickerNumberCursor = Integer.parseInt(cursor);
+
+            return breads.stream()
+                    .filter(bread -> bread.getStickerNumber() > stickerNumberCursor)
+                    .toList();
+        } catch (NumberFormatException ignored) {
+            return breads;
+        }
+    }
+
+    private List<Bread> applyCompositeCursor(List<Bread> breads, String cursor) {
+        int separatorIndex = cursor.indexOf('_');
+        if (separatorIndex < 0 || separatorIndex == cursor.length() - 1) {
+            return breads;
+        }
+
+        String breadId = cursor.substring(separatorIndex + 1);
+        for (int index = 0; index < breads.size(); index++) {
+            if (breads.get(index).getId().toString().equals(breadId)) {
+                return breads.subList(index + 1, breads.size());
+            }
+        }
+
+        return breads;
+    }
+
+    private List<Bread> takePage(List<Bread> breads, int limit) {
+        return breads.stream()
+                .limit(limit)
+                .toList();
+    }
+
+    private String createNextCursor(
+            Bread lastBread,
+            Map<UUID, BreadRecordCatalogStats> statsMap,
+            String sort
+    ) {
+        BreadRecordCatalogStats stats = statsMap.get(lastBread.getId());
+
+        if (SORT_LATEST.equals(sort) && stats != null && stats.latestEatenDate() != null) {
+            return stats.latestEatenDate() + "_" + lastBread.getId();
+        }
+
+        if (SORT_RATING.equals(sort) && stats != null && stats.avgRating() != null) {
+            return roundRating(stats.avgRating()) + "_" + lastBread.getId();
+        }
+
+        return String.valueOf(lastBread.getStickerNumber());
+    }
+
+    private boolean isCollected(Bread bread, Map<UUID, BreadRecordCatalogStats> statsMap) {
+        BreadRecordCatalogStats stats = statsMap.get(bread.getId());
+
+        return stats != null && stats.eatCount() != null && stats.eatCount() > 0;
+    }
+
+    private String normalizeSort(String sort) {
+        if (SORT_LATEST.equals(sort) || SORT_RATING.equals(sort)) {
+            return sort;
+        }
+
+        return SORT_STICKER_NUMBER;
+    }
+
+    private String normalizeFilter(String filter) {
+        if (FILTER_COLLECTED.equals(filter) || FILTER_UNCOLLECTED.equals(filter)) {
+            return filter;
+        }
+
+        return FILTER_ALL;
+    }
+
+    private int normalizeLimit(Integer limit) {
+        if (limit == null || limit < 1) {
+            return DEFAULT_LIMIT;
+        }
+
+        return Math.min(limit, MAX_LIMIT);
+    }
+
+    private Double roundRating(Double rating) {
+        return BigDecimal.valueOf(rating)
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -2,8 +2,11 @@ package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.mapper.BreadMapper;
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -61,6 +64,29 @@ public class BreadService {
         return breadMapper.mapToAutocompleteResponse(breads, eatCounts);
     }
 
+    public List<Bread> findCatalogCandidates(String search, BreadType breadType) {
+        return breadRepository.findCatalogCandidates(
+                normalizeSearch(search),
+                breadType
+        );
+    }
+
+    public BreadCatalogListResponse createCatalogListResponse(
+            List<Bread> breads,
+            Map<UUID, BreadRecordCatalogStats> statsMap,
+            String nextCursor,
+            boolean hasMore,
+            long totalCount
+    ) {
+        return breadMapper.mapToCatalogListResponse(
+                breads,
+                statsMap,
+                nextCursor,
+                hasMore,
+                totalCount
+        );
+    }
+
     @Transactional
     public Bread createUserBread(CreateNewBreadRecordRequest request, UUID userId) {
         validateBreadNameNotDuplicated(request.getName());
@@ -88,5 +114,13 @@ public class BreadService {
                     "같은 이름의 빵이 이미 카탈로그에 있습니다."
             );
         }
+    }
+
+    private String normalizeSearch(String search) {
+        if (search == null || search.isBlank()) {
+            return null;
+        }
+
+        return search.trim();
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -1,6 +1,9 @@
 package com.bean.breaddiary.domain.breadrecord.dto.mapper;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStatsProjection;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordLatestPhotoProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
@@ -10,7 +13,10 @@ import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface BreadRecordMapper {
@@ -66,5 +72,30 @@ public interface BreadRecordMapper {
         return photoUrl.substring(0, extensionIndex)
                 + "_thumb"
                 + photoUrl.substring(extensionIndex);
+    }
+
+    default Map<UUID, BreadRecordCatalogStats> mapToCatalogStatsMap(
+            List<BreadRecordCatalogStatsProjection> statsProjections,
+            List<BreadRecordLatestPhotoProjection> latestPhotoProjections
+    ) {
+        Map<UUID, String> latestPhotoUrls = latestPhotoProjections.stream()
+                .collect(Collectors.toMap(
+                        BreadRecordLatestPhotoProjection::getBreadId,
+                        BreadRecordLatestPhotoProjection::getLatestPhotoUrl,
+                        (left, right) -> left
+                ));
+
+        return statsProjections.stream()
+                .map(stats -> new BreadRecordCatalogStats(
+                        stats.getBreadId(),
+                        stats.getEatCount(),
+                        stats.getAvgRating(),
+                        latestPhotoUrls.get(stats.getBreadId()),
+                        stats.getLatestEatenDate()
+                ))
+                .collect(Collectors.toMap(
+                        BreadRecordCatalogStats::breadId,
+                        stats -> stats
+                ));
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCatalogStats.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCatalogStats.java
@@ -1,0 +1,13 @@
+package com.bean.breaddiary.domain.breadrecord.dto.projection;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record BreadRecordCatalogStats(
+        UUID breadId,
+        Long eatCount,
+        Double avgRating,
+        String latestPhotoUrl,
+        LocalDate latestEatenDate
+) {
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCatalogStatsProjection.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCatalogStatsProjection.java
@@ -1,0 +1,15 @@
+package com.bean.breaddiary.domain.breadrecord.dto.projection;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public interface BreadRecordCatalogStatsProjection {
+
+    UUID getBreadId();
+
+    Long getEatCount();
+
+    Double getAvgRating();
+
+    LocalDate getLatestEatenDate();
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordLatestPhotoProjection.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordLatestPhotoProjection.java
@@ -1,0 +1,10 @@
+package com.bean.breaddiary.domain.breadrecord.dto.projection;
+
+import java.util.UUID;
+
+public interface BreadRecordLatestPhotoProjection {
+
+    UUID getBreadId();
+
+    String getLatestPhotoUrl();
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -2,7 +2,9 @@ package com.bean.breaddiary.domain.breadrecord.repository;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStatsProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordLatestPhotoProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,6 +28,42 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
             group by br.bread.id
             """)
     List<BreadRecordCountProjection> countActiveRecordsByBreadIds(
+            @Param("userId") UUID userId,
+            @Param("breadIds") List<UUID> breadIds
+    );
+
+    @Query("""
+            select br.bread.id as breadId,
+                   count(br) as eatCount,
+                   avg(br.rating) as avgRating,
+                   max(br.eatenDate) as latestEatenDate
+            from BreadRecord br
+            where br.userId = :userId
+              and br.bread.id in :breadIds
+              and br.deletedAt is null
+            group by br.bread.id
+            """)
+    List<BreadRecordCatalogStatsProjection> findCatalogStatsByBreadIds(
+            @Param("userId") UUID userId,
+            @Param("breadIds") List<UUID> breadIds
+    );
+
+    @Query("""
+            select br.bread.id as breadId,
+                   br.photoUrl as latestPhotoUrl
+            from BreadRecord br
+            where br.userId = :userId
+              and br.bread.id in :breadIds
+              and br.deletedAt is null
+              and br.createdAt = (
+                  select max(latest.createdAt)
+                  from BreadRecord latest
+                  where latest.userId = :userId
+                    and latest.bread.id = br.bread.id
+                    and latest.deletedAt is null
+              )
+            """)
+    List<BreadRecordLatestPhotoProjection> findLatestPhotoUrlsByBreadIds(
             @Param("userId") UUID userId,
             @Param("breadIds") List<UUID> breadIds
     );

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
@@ -2,6 +2,7 @@ package com.bean.breaddiary.domain.breadrecord.service;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadrecord.dto.mapper.BreadRecordMapper;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
@@ -44,6 +45,17 @@ public class BreadRecordService {
                         BreadRecordCountProjection::getBreadId,
                         BreadRecordCountProjection::getEatCount
                 ));
+    }
+
+    public Map<UUID, BreadRecordCatalogStats> findCatalogStatsByBreadIds(UUID userId, List<UUID> breadIds) {
+        if (userId == null || breadIds == null || breadIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return breadRecordMapper.mapToCatalogStatsMap(
+                breadRecordRepository.findCatalogStatsByBreadIds(userId, breadIds),
+                breadRecordRepository.findLatestPhotoUrlsByBreadIds(userId, breadIds)
+        );
     }
 
     @Transactional

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
@@ -1,0 +1,103 @@
+package com.bean.breaddiary.domain.bread.controller;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BreadControllerCatalogTest {
+
+    private BreadComplexService breadComplexService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        breadComplexService = mock(BreadComplexService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new BreadController(breadComplexService))
+                .build();
+    }
+
+    @Test
+    void getBreadCatalogReturnsSpecResponseWithSnakeCaseFields() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        BreadCatalogListResponse response = new BreadCatalogListResponse(
+                List.of(new BreadCatalogItemResponse(
+                        breadId,
+                        6,
+                        "크루아상",
+                        BreadType.PASTRY,
+                        "https://cdn.bread-diary.app/breads/croissant.webp",
+                        true,
+                        5L,
+                        4.8,
+                        "https://cdn.bread-diary.app/bread-photos/record_thumb.webp",
+                        LocalDate.of(2026, 3, 14)
+                )),
+                "6",
+                true,
+                42L
+        );
+
+        when(breadComplexService.getBreadCatalog(
+                "sticker_number",
+                "collected",
+                BreadType.PASTRY,
+                "크루",
+                null,
+                20,
+                userId
+        )).thenReturn(response);
+
+        mockMvc.perform(get("/breads")
+                        .param("sort", "sticker_number")
+                        .param("filter", "collected")
+                        .param("bread_type", "PASTRY")
+                        .param("search", "크루")
+                        .param("limit", "20")
+                        .header("X-USER-ID", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items[0].bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.items[0].sticker_number").value(6))
+                .andExpect(jsonPath("$.data.items[0].name").value("크루아상"))
+                .andExpect(jsonPath("$.data.items[0].bread_type").value("PASTRY"))
+                .andExpect(jsonPath("$.data.items[0].image_url").value("https://cdn.bread-diary.app/breads/croissant.webp"))
+                .andExpect(jsonPath("$.data.items[0].is_collected").value(true))
+                .andExpect(jsonPath("$.data.items[0].eat_count").value(5))
+                .andExpect(jsonPath("$.data.items[0].avg_rating").value(4.8))
+                .andExpect(jsonPath("$.data.items[0].latest_photo_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
+                .andExpect(jsonPath("$.data.items[0].latest_eaten_date").value("2026-03-14"))
+                .andExpect(jsonPath("$.data.next_cursor").value("6"))
+                .andExpect(jsonPath("$.data.has_more").value(true))
+                .andExpect(jsonPath("$.data.total_count").value(42))
+                .andExpect(jsonPath("$.data.items[0].breadId").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].isCollected").doesNotExist());
+
+        verify(breadComplexService).getBreadCatalog(
+                "sticker_number",
+                "collected",
+                BreadType.PASTRY,
+                "크루",
+                null,
+                20,
+                userId
+        );
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
@@ -1,12 +1,15 @@
 package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -70,5 +73,126 @@ class BreadComplexServiceTest {
         verify(breadService).searchAutocompleteBreads(null);
         verifyNoInteractions(breadRecordService);
         verify(breadService).createAutocompleteResponse(List.of(), Map.of());
+    }
+
+    @Test
+    void getBreadCatalogCreatesAnonymousStickerNumberPage() {
+        Bread firstBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                1,
+                "크루아상",
+                BreadType.PASTRY
+        );
+        Bread secondBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000002"),
+                2,
+                "베이글",
+                BreadType.BAGEL
+        );
+        BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), "1", true, 2L);
+
+        when(breadService.findCatalogCandidates(null, null)).thenReturn(List.of(firstBread, secondBread));
+        when(breadService.createCatalogListResponse(
+                List.of(firstBread),
+                Map.of(),
+                "1",
+                true,
+                2L
+        )).thenReturn(expected);
+
+        BreadCatalogListResponse actual = breadComplexService.getBreadCatalog(
+                "sticker_number",
+                "all",
+                null,
+                null,
+                null,
+                1,
+                null
+        );
+
+        assertSame(expected, actual);
+        verify(breadService).findCatalogCandidates(null, null);
+        verifyNoInteractions(breadRecordService);
+        verify(breadService).createCatalogListResponse(
+                List.of(firstBread),
+                Map.of(),
+                "1",
+                true,
+                2L
+        );
+    }
+
+    @Test
+    void getBreadCatalogAppliesCollectedFilterWithUserStats() {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Bread collectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                1,
+                "크루아상",
+                BreadType.PASTRY
+        );
+        Bread uncollectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000002"),
+                2,
+                "베이글",
+                BreadType.BAGEL
+        );
+        BreadRecordCatalogStats stats = new BreadRecordCatalogStats(
+                collectedBread.getId(),
+                3L,
+                4.666,
+                "https://cdn.bread-diary.app/bread-photos/record.webp",
+                LocalDate.of(2026, 3, 14)
+        );
+        Map<UUID, BreadRecordCatalogStats> statsMap = Map.of(collectedBread.getId(), stats);
+        BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), null, false, 1L);
+
+        when(breadService.findCatalogCandidates("크루", BreadType.PASTRY))
+                .thenReturn(List.of(collectedBread, uncollectedBread));
+        when(breadRecordService.findCatalogStatsByBreadIds(
+                userId,
+                List.of(collectedBread.getId(), uncollectedBread.getId())
+        )).thenReturn(statsMap);
+        when(breadService.createCatalogListResponse(
+                List.of(collectedBread),
+                statsMap,
+                null,
+                false,
+                1L
+        )).thenReturn(expected);
+
+        BreadCatalogListResponse actual = breadComplexService.getBreadCatalog(
+                "sticker_number",
+                "collected",
+                BreadType.PASTRY,
+                "크루",
+                null,
+                20,
+                userId
+        );
+
+        assertSame(expected, actual);
+        verify(breadService).findCatalogCandidates("크루", BreadType.PASTRY);
+        verify(breadRecordService).findCatalogStatsByBreadIds(
+                userId,
+                List.of(collectedBread.getId(), uncollectedBread.getId())
+        );
+        verify(breadService).createCatalogListResponse(
+                List.of(collectedBread),
+                statsMap,
+                null,
+                false,
+                1L
+        );
+    }
+
+    private Bread createBread(UUID id, Integer stickerNumber, String name, BreadType breadType) {
+        return Bread.builder()
+                .id(id)
+                .stickerNumber(stickerNumber)
+                .name(name)
+                .breadType(breadType)
+                .imageUrl("https://cdn.bread-diary.app/breads/" + stickerNumber + ".webp")
+                .build();
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #15 

## 🛠️ 작업 내용

- 도감 목록 응답 DTO를 추가했습니다.
- 페이지네이션 응답 구조를 추가했습니다.
- 쿼리 파라미터 처리를 추가했습니다.
- 로그인/비로그인 요청 처리를 분리했습니다.

## 📢 참고 및 특이사항
- `latest_photo_url`은 DB에 별도 저장하지 않고 `photo_url`에서 `_thumb` suffix를 붙여 응답합니다.
- `sort=latest`, `sort=rating`은 명세서 기준 수집된 빵만 대상으로 처리했습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인