### PR TITLE
refactor: standardize response serialization and DTO style

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -60,7 +60,7 @@ public interface BreadMapper {
     @Mapping(target = "eatCount", expression = "java(resolveEatCount(stats))")
     @Mapping(target = "avgRating", expression = "java(resolveAvgRating(stats))")
     @Mapping(target = "latestPhotoUrl", expression = "java(resolveLatestPhotoUrl(stats))")
-    @Mapping(target = "latestEatenDate", expression = "java(stats == null ? null : stats.latestEatenDate())")
+    @Mapping(target = "latestEatenDate", expression = "java(stats == null ? null : stats.getLatestEatenDate())")
     BreadCatalogItemResponse mapToCatalogItem(Bread bread, BreadRecordCatalogStats stats);
 
     default BreadCatalogListResponse mapToCatalogListResponse(
@@ -90,25 +90,25 @@ public interface BreadMapper {
     }
 
     default Long resolveEatCount(BreadRecordCatalogStats stats) {
-        return stats == null || stats.eatCount() == null ? 0L : stats.eatCount();
+        return stats == null || stats.getEatCount() == null ? 0L : stats.getEatCount();
     }
 
     default Double resolveAvgRating(BreadRecordCatalogStats stats) {
-        if (stats == null || stats.avgRating() == null) {
+        if (stats == null || stats.getAvgRating() == null) {
             return null;
         }
 
-        return BigDecimal.valueOf(stats.avgRating())
+        return BigDecimal.valueOf(stats.getAvgRating())
                 .setScale(1, RoundingMode.HALF_UP)
                 .doubleValue();
     }
 
     default String resolveLatestPhotoUrl(BreadRecordCatalogStats stats) {
-        if (stats == null || stats.latestPhotoUrl() == null) {
+        if (stats == null || stats.getLatestPhotoUrl() == null) {
             return null;
         }
 
-        return toThumbnailUrl(stats.latestPhotoUrl());
+        return toThumbnailUrl(stats.getLatestPhotoUrl());
     }
 
     default String toThumbnailUrl(String photoUrl) {

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteItemResponse.java
@@ -1,7 +1,6 @@
 package com.bean.breaddiary.domain.bread.dto.response;
 
 import com.bean.breaddiary.domain.bread.entity.BreadType;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,25 +17,20 @@ import java.util.UUID;
 public class BreadAutocompleteItemResponse {
 
     @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
-    @JsonProperty("bread_id")
     private UUID breadId;
 
     @Schema(description = "빵 이름", example = "크루아상")
     private String name;
 
     @Schema(description = "빵 종류", example = "PASTRY")
-    @JsonProperty("bread_type")
     private BreadType breadType;
 
     @Schema(description = "도감 번호", example = "6")
-    @JsonProperty("sticker_number")
     private Integer stickerNumber;
 
     @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
-    @JsonProperty("image_url")
     private String imageUrl;
 
     @Schema(description = "현재 유저의 해당 빵 기록 수", example = "5")
-    @JsonProperty("eat_count")
     private Long eatCount;
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogItemResponse.java
@@ -1,7 +1,6 @@
 package com.bean.breaddiary.domain.bread.dto.response;
 
 import com.bean.breaddiary.domain.bread.entity.BreadType;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,41 +18,32 @@ import java.util.UUID;
 public class BreadCatalogItemResponse {
 
     @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
-    @JsonProperty("bread_id")
     private UUID breadId;
 
     @Schema(description = "도감 번호", example = "6")
-    @JsonProperty("sticker_number")
     private Integer stickerNumber;
 
     @Schema(description = "빵 이름", example = "크루아상")
     private String name;
 
     @Schema(description = "빵 종류", example = "PASTRY")
-    @JsonProperty("bread_type")
     private BreadType breadType;
 
     @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
-    @JsonProperty("image_url")
     private String imageUrl;
 
     @Schema(description = "현재 유저의 수집 여부", example = "true")
-    @JsonProperty("is_collected")
     private Boolean isCollected;
 
     @Schema(description = "현재 유저의 해당 빵 기록 수", example = "5")
-    @JsonProperty("eat_count")
     private Long eatCount;
 
     @Schema(description = "현재 유저의 해당 빵 평균 별점", example = "4.8", nullable = true)
-    @JsonProperty("avg_rating")
     private Double avgRating;
 
     @Schema(description = "현재 유저의 해당 빵 최신 기록 썸네일 URL", example = "https://cdn.bread-diary.app/bread-photos/550e8400/a1b2c3d4_thumb.webp", nullable = true)
-    @JsonProperty("latest_photo_url")
     private String latestPhotoUrl;
 
     @Schema(description = "현재 유저의 해당 빵 최신 먹은 날짜", example = "2026-03-14", nullable = true)
-    @JsonProperty("latest_eaten_date")
     private LocalDate latestEatenDate;
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogListResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadCatalogListResponse.java
@@ -1,6 +1,5 @@
 package com.bean.breaddiary.domain.bread.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -24,14 +23,11 @@ public class BreadCatalogListResponse {
     private List<BreadCatalogItemResponse> items;
 
     @Schema(description = "다음 페이지 커서. 다음 페이지가 없으면 null", example = "8", nullable = true)
-    @JsonProperty("next_cursor")
     private String nextCursor;
 
     @Schema(description = "다음 페이지 존재 여부", example = "true")
-    @JsonProperty("has_more")
     private Boolean hasMore;
 
     @Schema(description = "필터 적용 후 전체 빵 수", example = "42")
-    @JsonProperty("total_count")
     private Long totalCount;
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -141,7 +141,7 @@ public class BreadComplexService {
             return sortedBreads.stream()
                     .filter(bread -> isCollected(bread, statsMap))
                     .sorted(Comparator
-                            .comparing((Bread bread) -> statsMap.get(bread.getId()).latestEatenDate(), Comparator.reverseOrder())
+                            .comparing((Bread bread) -> statsMap.get(bread.getId()).getLatestEatenDate(), Comparator.reverseOrder())
                             .thenComparing(bread -> bread.getId().toString()))
                     .toList();
         }
@@ -150,7 +150,7 @@ public class BreadComplexService {
             return sortedBreads.stream()
                     .filter(bread -> isCollected(bread, statsMap))
                     .sorted(Comparator
-                            .comparing((Bread bread) -> statsMap.get(bread.getId()).avgRating(), Comparator.reverseOrder())
+                            .comparing((Bread bread) -> statsMap.get(bread.getId()).getAvgRating(), Comparator.reverseOrder())
                             .thenComparing(bread -> bread.getId().toString()))
                     .toList();
         }
@@ -217,12 +217,12 @@ public class BreadComplexService {
     ) {
         BreadRecordCatalogStats stats = statsMap.get(lastBread.getId());
 
-        if (SORT_LATEST.equals(sort) && stats != null && stats.latestEatenDate() != null) {
-            return stats.latestEatenDate() + "_" + lastBread.getId();
+        if (SORT_LATEST.equals(sort) && stats != null && stats.getLatestEatenDate() != null) {
+            return stats.getLatestEatenDate() + "_" + lastBread.getId();
         }
 
-        if (SORT_RATING.equals(sort) && stats != null && stats.avgRating() != null) {
-            return roundRating(stats.avgRating()) + "_" + lastBread.getId();
+        if (SORT_RATING.equals(sort) && stats != null && stats.getAvgRating() != null) {
+            return roundRating(stats.getAvgRating()) + "_" + lastBread.getId();
         }
 
         return String.valueOf(lastBread.getStickerNumber());
@@ -231,7 +231,7 @@ public class BreadComplexService {
     private boolean isCollected(Bread bread, Map<UUID, BreadRecordCatalogStats> statsMap) {
         BreadRecordCatalogStats stats = statsMap.get(bread.getId());
 
-        return stats != null && stats.eatCount() != null && stats.eatCount() > 0;
+        return stats != null && stats.getEatCount() != null && stats.getEatCount() > 0;
     }
 
     private String normalizeSort(String sort) {

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -94,7 +94,7 @@ public interface BreadRecordMapper {
                         stats.getLatestEatenDate()
                 ))
                 .collect(Collectors.toMap(
-                        BreadRecordCatalogStats::breadId,
+                        BreadRecordCatalogStats::getBreadId,
                         stats -> stats
                 ));
     }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCatalogStats.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/BreadRecordCatalogStats.java
@@ -1,13 +1,24 @@
 package com.bean.breaddiary.domain.breadrecord.dto.projection;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDate;
 import java.util.UUID;
 
-public record BreadRecordCatalogStats(
-        UUID breadId,
-        Long eatCount,
-        Double avgRating,
-        String latestPhotoUrl,
-        LocalDate latestEatenDate
-) {
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BreadRecordCatalogStats {
+
+    private UUID breadId;
+
+    private Long eatCount;
+
+    private Double avgRating;
+
+    private String latestPhotoUrl;
+
+    private LocalDate latestEatenDate;
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateBreadRecordRequest.java
@@ -1,6 +1,5 @@
 package com.bean.breaddiary.domain.breadrecord.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -23,7 +22,6 @@ import java.util.UUID;
 public class CreateBreadRecordRequest {
 
     @Schema(description = "카탈로그 빵 ID", example = "550e8400-e29b-41d4-a716-446655440000", requiredMode = Schema.RequiredMode.REQUIRED)
-    @JsonProperty("bread_id")
     @NotNull(message = "유효한 빵을 선택해주세요.")
     private UUID breadId;
 
@@ -32,12 +30,10 @@ public class CreateBreadRecordRequest {
     private MultipartFile photo;
 
     @Schema(description = "구매처", example = "르뺑블루 성수점", maxLength = 50)
-    @JsonProperty("shop_name")
     @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
     private String shopName;
 
     @Schema(description = "먹은 날짜. 미입력 시 오늘 날짜로 저장", example = "2026-04-16")
-    @JsonProperty("eaten_date")
     private LocalDate eatenDate;
 
     @Schema(description = "별점", example = "5", minimum = "1", maximum = "5", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateNewBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/CreateNewBreadRecordRequest.java
@@ -1,7 +1,6 @@
 package com.bean.breaddiary.domain.breadrecord.dto.request;
 
 import com.bean.breaddiary.domain.bread.entity.BreadType;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -31,7 +30,6 @@ public class CreateNewBreadRecordRequest {
     @Schema(description = "빵 종류", example = "PASTRY", requiredMode = Schema.RequiredMode.REQUIRED, allowableValues = {
             "PASTRY", "BREAD", "DONUT", "CAKE", "BAGEL", "TART", "OTHER"
     })
-    @JsonProperty("bread_type")
     @NotNull(message = "올바른 빵 종류를 선택해주세요.")
     private BreadType breadType;
 
@@ -40,12 +38,10 @@ public class CreateNewBreadRecordRequest {
     private MultipartFile photo;
 
     @Schema(description = "구매처", example = "카페봄봄 합정점", maxLength = 50)
-    @JsonProperty("shop_name")
     @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
     private String shopName;
 
     @Schema(description = "먹은 날짜. 미입력 시 오늘 날짜로 저장", example = "2026-04-16")
-    @JsonProperty("eaten_date")
     private LocalDate eatenDate;
 
     @Schema(description = "별점", example = "4", minimum = "1", maximum = "5", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordCreateResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordCreateResponse.java
@@ -1,7 +1,6 @@
 package com.bean.breaddiary.domain.breadrecord.dto.response;
 
 import com.bean.breaddiary.domain.bread.entity.BreadType;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,38 +22,30 @@ public class BreadRecordCreateResponse {
     private UUID id;
 
     @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
-    @JsonProperty("bread_id")
     private UUID breadId;
 
     @Schema(description = "도감 번호", example = "7")
-    @JsonProperty("sticker_number")
     private Integer stickerNumber;
 
     @Schema(description = "원본 사진 URL", example = "https://breaddiary-bucket.s3.ap-northeast-2.amazonaws.com/bread/550e8400/a1b2c3d4.webp")
-    @JsonProperty("photo_url")
     private String photoUrl;
 
     @Schema(description = "썸네일 사진 URL", example = "https://breaddiary-bucket.s3.ap-northeast-2.amazonaws.com/bread/550e8400/a1b2c3d4_thumb.webp")
-    @JsonProperty("photo_thumbnail_url")
     private String photoThumbnailUrl;
 
     @Schema(description = "빵 이름", example = "크루아상")
     private String name;
 
     @Schema(description = "빵 종류", example = "PASTRY")
-    @JsonProperty("bread_type")
     private BreadType breadType;
 
     @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
-    @JsonProperty("image_url")
     private String imageUrl;
 
     @Schema(description = "구매처", example = "르뺑블루 성수점")
-    @JsonProperty("shop_name")
     private String shopName;
 
     @Schema(description = "먹은 날짜", example = "2026-04-16")
-    @JsonProperty("eaten_date")
     private LocalDate eatenDate;
 
     @Schema(description = "별점", example = "5")
@@ -64,10 +55,8 @@ public class BreadRecordCreateResponse {
     private String review;
 
     @Schema(description = "해당 빵의 첫 기록 여부", example = "false")
-    @JsonProperty("is_first_record")
     private Boolean isFirstRecord;
 
     @Schema(description = "기록 생성 일시", example = "2026-04-16T09:30:00")
-    @JsonProperty("created_at")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/bean/breaddiary/global/common/ApiResponse.java
+++ b/src/main/java/com/bean/breaddiary/global/common/ApiResponse.java
@@ -1,15 +1,23 @@
 package com.bean.breaddiary.global.common;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Schema(description = "공통 API 응답")
-public record ApiResponse<T>(
-        @Schema(description = "요청 성공 여부", example = "true")
-        boolean success,
+public class ApiResponse<T> {
 
-        @Schema(description = "응답 데이터")
-        T data
-) {
+    @Schema(description = "요청 성공 여부", example = "true")
+    private boolean success;
+
+    @Schema(description = "응답 데이터")
+    private T data;
 
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(true, data);

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
@@ -4,8 +4,13 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemRespon
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -29,6 +34,7 @@ class BreadControllerAutocompleteTest {
         breadComplexService = mock(BreadComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadController(breadComplexService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -77,5 +83,12 @@ class BreadControllerAutocompleteTest {
                 .andExpect(jsonPath("$.data.items").isArray());
 
         verify(breadComplexService).autocompleteBreads(null, null);
+    }
+
+    private ObjectMapper snakeCaseObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
@@ -4,8 +4,13 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -30,6 +35,7 @@ class BreadControllerCatalogTest {
         breadComplexService = mock(BreadComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadController(breadComplexService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -99,5 +105,12 @@ class BreadControllerCatalogTest {
                 20,
                 userId
         );
+    }
+
+    private ObjectMapper snakeCaseObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
@@ -5,10 +5,15 @@ import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordReque
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -39,6 +44,7 @@ class BreadRecordControllerContractTest {
         breadRecordComplexService = mock(BreadRecordComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadRecordController(breadRecordComplexService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -141,5 +147,12 @@ class BreadRecordControllerContractTest {
                 isFirstRecord,
                 LocalDateTime.of(2026, 3, 14, 9, 30)
         );
+    }
+
+    private ObjectMapper snakeCaseObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #17 

## 🛠️ 작업 내용

 - DTO 필드마다 반복되던 `@JsonProperty`를 제거했습니다.
  - `snake_case` 응답 규칙은 Jackson naming strategy 설정으로 처리하도록 정리했습니다.
  - multipart `@ModelAttribute` 요청 DTO의 snake_case setter alias는 유지했습니다.
  - Java `record` 타입을 Lombok class로 변경했습니다.

## 📢 참고 및 특이사항

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인