### PR TITLE
feat: implement bread profile API

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
@@ -2,6 +2,7 @@ package com.bean.breaddiary.domain.bread.controller;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
 import com.bean.breaddiary.global.common.ApiResponse;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -66,6 +68,34 @@ public class BreadController {
                 search,
                 cursor,
                 limit,
+                userId
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(
+            summary = "빵 프로필 조회",
+            description = "카탈로그 빵의 마스터 정보와 현재 유저의 해당 빵 기록 통계 및 기록 목록을 조회합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "빵 프로필 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BreadProfileResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 카탈로그를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/catalog/{breadId}")
+    public ResponseEntity<ApiResponse<BreadProfileResponse>> getBreadProfile(
+            @Parameter(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+            @PathVariable UUID breadId,
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+    ) {
+        BreadProfileResponse response = breadComplexService.getBreadProfile(
+                breadId,
                 userId
         );
 

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -4,7 +4,11 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemRespon
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import org.mapstruct.Mapper;
@@ -120,5 +124,35 @@ public interface BreadMapper {
         return photoUrl.substring(0, extensionIndex)
                 + "_thumb"
                 + photoUrl.substring(extensionIndex);
+    }
+
+    @Mapping(target = "breadId", source = "bread.id")
+    @Mapping(target = "stickerNumber", source = "bread.stickerNumber")
+    @Mapping(target = "name", source = "bread.name")
+    @Mapping(target = "breadType", source = "bread.breadType")
+    @Mapping(target = "breadTypeLabel", expression = "java(toBreadTypeLabel(bread.getBreadType()))")
+    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    @Mapping(target = "stats", source = "stats")
+    @Mapping(target = "records", source = "records")
+    BreadProfileResponse mapToProfileResponse(
+            Bread bread,
+            BreadProfileStatsResponse stats,
+            List<BreadProfileRecordResponse> records
+    );
+
+    default String toBreadTypeLabel(BreadType breadType) {
+        if (breadType == null) {
+            return null;
+        }
+
+        return switch (breadType) {
+            case PASTRY -> "페이스트리";
+            case BREAD -> "식빵";
+            case DONUT -> "도넛";
+            case CAKE -> "케이크";
+            case BAGEL -> "베이글";
+            case TART -> "타르트";
+            case OTHER -> "기타";
+        };
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadProfileRecordResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadProfileRecordResponse.java
@@ -1,0 +1,37 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 프로필 기록 목록 아이템")
+public class BreadProfileRecordResponse {
+
+    @Schema(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+    private UUID id;
+
+    @Schema(description = "기록 사진 썸네일 URL", example = "https://cdn.bread-diary.app/bread-photos/record_thumb.webp")
+    private String photoThumbnailUrl;
+
+    @Schema(description = "별점", example = "5")
+    private Integer rating;
+
+    @Schema(description = "구매처", example = "르뺑블루 성수점", nullable = true)
+    private String shopName;
+
+    @Schema(description = "먹은 날짜", example = "2026-03-12")
+    private LocalDate eatenDate;
+
+    @Schema(description = "기록 생성 일시", example = "2026-03-12T09:30:00")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadProfileResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadProfileResponse.java
@@ -1,0 +1,47 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 프로필 조회 응답")
+public class BreadProfileResponse {
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    private UUID breadId;
+
+    @Schema(description = "도감 번호", example = "6")
+    private Integer stickerNumber;
+
+    @Schema(description = "빵 이름", example = "크루아상")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY")
+    private BreadType breadType;
+
+    @Schema(description = "빵 종류 한글 표시명", example = "페이스트리")
+    private String breadTypeLabel;
+
+    @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
+    private String imageUrl;
+
+    @Schema(description = "현재 유저의 해당 빵 통계")
+    private BreadProfileStatsResponse stats;
+
+    @ArraySchema(
+            schema = @Schema(implementation = BreadProfileRecordResponse.class),
+            arraySchema = @Schema(description = "현재 유저의 해당 빵 기록 목록")
+    )
+    private List<BreadProfileRecordResponse> records;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadProfileStatsResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadProfileStatsResponse.java
@@ -1,0 +1,26 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 프로필 통계")
+public class BreadProfileStatsResponse {
+
+    @Schema(description = "현재 유저의 해당 빵 기록 수", example = "5")
+    private Long eatCount;
+
+    @Schema(description = "현재 유저의 해당 빵 평균 별점", example = "4.8", nullable = true)
+    private Double avgRating;
+
+    @Schema(description = "현재 유저가 해당 빵을 처음 기록한 일시", example = "2026-03-14T09:30:00", nullable = true)
+    private LocalDateTime firstRecordedAt;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -2,9 +2,13 @@ package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -76,6 +80,22 @@ public class BreadComplexService {
                 nextCursor,
                 hasMore,
                 filteredBreads.size()
+        );
+    }
+
+    public BreadProfileResponse getBreadProfile(UUID breadId, UUID userId) {
+        Bread bread = breadService.getBreadById(breadId);
+        List<BreadRecord> records = breadRecordService.findActiveRecordsByUserAndBread(
+                userId,
+                bread
+        );
+        BreadProfileStatsResponse stats = breadRecordService.createProfileStats(records);
+        List<BreadProfileRecordResponse> recordResponses = breadRecordService.createProfileRecordResponses(records);
+
+        return breadService.createProfileResponse(
+                bread,
+                stats,
+                recordResponses
         );
     }
 

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -3,6 +3,9 @@ package com.bean.breaddiary.domain.bread.service;
 import com.bean.breaddiary.domain.bread.dto.mapper.BreadMapper;
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
@@ -84,6 +87,18 @@ public class BreadService {
                 nextCursor,
                 hasMore,
                 totalCount
+        );
+    }
+
+    public BreadProfileResponse createProfileResponse(
+            Bread bread,
+            BreadProfileStatsResponse stats,
+            List<BreadProfileRecordResponse> records
+    ) {
+        return breadMapper.mapToProfileResponse(
+                bread,
+                stats,
+                records
         );
     }
 

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -1,6 +1,8 @@
 package com.bean.breaddiary.domain.breadrecord.dto.mapper;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStatsProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordLatestPhotoProjection;
@@ -12,7 +14,10 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -97,5 +102,49 @@ public interface BreadRecordMapper {
                         BreadRecordCatalogStats::getBreadId,
                         stats -> stats
                 ));
+    }
+
+    @Mapping(target = "photoThumbnailUrl", expression = "java(toThumbnailUrl(breadRecord.getPhotoUrl()))")
+    BreadProfileRecordResponse mapToProfileRecord(BreadRecord breadRecord);
+
+    default List<BreadProfileRecordResponse> mapToProfileRecords(List<BreadRecord> breadRecords) {
+        return breadRecords.stream()
+                .map(this::mapToProfileRecord)
+                .toList();
+    }
+
+    default BreadProfileStatsResponse mapToProfileStats(List<BreadRecord> breadRecords) {
+        if (breadRecords.isEmpty()) {
+            return new BreadProfileStatsResponse(
+                    0L,
+                    null,
+                    null
+            );
+        }
+
+        double avgRating = breadRecords.stream()
+                .mapToInt(BreadRecord::getRating)
+                .average()
+                .orElse(0);
+        LocalDateTime firstRecordedAt = breadRecords.stream()
+                .map(BreadRecord::getCreatedAt)
+                .min(LocalDateTime::compareTo)
+                .orElse(null);
+
+        return new BreadProfileStatsResponse(
+                (long) breadRecords.size(),
+                roundRating(avgRating),
+                firstRecordedAt
+        );
+    }
+
+    default Double roundRating(Double rating) {
+        if (rating == null) {
+            return null;
+        }
+
+        return BigDecimal.valueOf(rating)
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -16,6 +16,7 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
 
     List<BreadRecord> findAllByUserId(UUID userId);
     List<BreadRecord> findAllByUserIdAndBread(UUID userId, Bread bread);
+    List<BreadRecord> findAllByUserIdAndBreadAndDeletedAtIsNullOrderByCreatedAtDesc(UUID userId, Bread bread);
     long countByUserIdAndBread(UUID userId, Bread bread);
     boolean existsByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
 

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
@@ -1,6 +1,8 @@
 package com.bean.breaddiary.domain.breadrecord.service;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.mapper.BreadRecordMapper;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
@@ -56,6 +58,25 @@ public class BreadRecordService {
                 breadRecordRepository.findCatalogStatsByBreadIds(userId, breadIds),
                 breadRecordRepository.findLatestPhotoUrlsByBreadIds(userId, breadIds)
         );
+    }
+
+    public List<BreadRecord> findActiveRecordsByUserAndBread(UUID userId, Bread bread) {
+        if (userId == null || bread == null) {
+            return Collections.emptyList();
+        }
+
+        return breadRecordRepository.findAllByUserIdAndBreadAndDeletedAtIsNullOrderByCreatedAtDesc(
+                userId,
+                bread
+        );
+    }
+
+    public BreadProfileStatsResponse createProfileStats(List<BreadRecord> breadRecords) {
+        return breadRecordMapper.mapToProfileStats(breadRecords);
+    }
+
+    public List<BreadProfileRecordResponse> createProfileRecordResponses(List<BreadRecord> breadRecords) {
+        return breadRecordMapper.mapToProfileRecords(breadRecords);
     }
 
     @Transactional

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
@@ -1,0 +1,105 @@
+package com.bean.breaddiary.domain.bread.controller;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BreadControllerProfileTest {
+
+    private BreadComplexService breadComplexService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        breadComplexService = mock(BreadComplexService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new BreadController(breadComplexService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .build();
+    }
+
+    @Test
+    void getBreadProfileReturnsSpecResponseWithSnakeCaseFields() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        UUID recordId = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+        BreadProfileResponse response = new BreadProfileResponse(
+                breadId,
+                6,
+                "크루아상",
+                BreadType.PASTRY,
+                "페이스트리",
+                "https://cdn.bread-diary.app/breads/croissant.webp",
+                new BreadProfileStatsResponse(
+                        5L,
+                        4.8,
+                        LocalDateTime.of(2026, 3, 1, 9, 30)
+                ),
+                List.of(new BreadProfileRecordResponse(
+                        recordId,
+                        "https://cdn.bread-diary.app/bread-photos/record_thumb.webp",
+                        5,
+                        "르뺑블루 성수점",
+                        LocalDate.of(2026, 3, 12),
+                        LocalDateTime.of(2026, 3, 12, 9, 30)
+                ))
+        );
+
+        when(breadComplexService.getBreadProfile(breadId, userId)).thenReturn(response);
+
+        mockMvc.perform(get("/breads/catalog/{breadId}", breadId)
+                        .header("X-USER-ID", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.sticker_number").value(6))
+                .andExpect(jsonPath("$.data.name").value("크루아상"))
+                .andExpect(jsonPath("$.data.bread_type").value("PASTRY"))
+                .andExpect(jsonPath("$.data.bread_type_label").value("페이스트리"))
+                .andExpect(jsonPath("$.data.image_url").value("https://cdn.bread-diary.app/breads/croissant.webp"))
+                .andExpect(jsonPath("$.data.stats.eat_count").value(5))
+                .andExpect(jsonPath("$.data.stats.avg_rating").value(4.8))
+                .andExpect(jsonPath("$.data.stats.first_recorded_at").value("2026-03-01T09:30:00"))
+                .andExpect(jsonPath("$.data.records[0].id").value(recordId.toString()))
+                .andExpect(jsonPath("$.data.records[0].photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
+                .andExpect(jsonPath("$.data.records[0].rating").value(5))
+                .andExpect(jsonPath("$.data.records[0].shop_name").value("르뺑블루 성수점"))
+                .andExpect(jsonPath("$.data.records[0].eaten_date").value("2026-03-12"))
+                .andExpect(jsonPath("$.data.records[0].created_at").value("2026-03-12T09:30:00"))
+                .andExpect(jsonPath("$.data.breadId").doesNotExist())
+                .andExpect(jsonPath("$.data.stats.eatCount").doesNotExist())
+                .andExpect(jsonPath("$.data.records[0].photoThumbnailUrl").doesNotExist());
+
+        verify(breadComplexService).getBreadProfile(breadId, userId);
+    }
+
+    private ObjectMapper snakeCaseObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
@@ -2,9 +2,13 @@ package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -184,6 +188,48 @@ class BreadComplexServiceTest {
                 false,
                 1L
         );
+    }
+
+    @Test
+    void getBreadProfileCombinesBreadAndUserRecords() {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+        Bread bread = createBread(
+                breadId,
+                6,
+                "크루아상",
+                BreadType.PASTRY
+        );
+        BreadRecord record = BreadRecord.builder()
+                .userId(userId)
+                .bread(bread)
+                .photoUrl("https://cdn.bread-diary.app/bread-photos/record.webp")
+                .rating(5)
+                .eatenDate(LocalDate.of(2026, 3, 14))
+                .build();
+        BreadProfileStatsResponse stats = new BreadProfileStatsResponse(
+                1L,
+                5.0,
+                LocalDate.of(2026, 3, 14).atStartOfDay()
+        );
+        List<BreadProfileRecordResponse> recordResponses = List.of(new BreadProfileRecordResponse());
+        BreadProfileResponse expected = new BreadProfileResponse();
+
+        when(breadService.getBreadById(breadId)).thenReturn(bread);
+        when(breadRecordService.findActiveRecordsByUserAndBread(userId, bread))
+                .thenReturn(List.of(record));
+        when(breadRecordService.createProfileStats(List.of(record))).thenReturn(stats);
+        when(breadRecordService.createProfileRecordResponses(List.of(record))).thenReturn(recordResponses);
+        when(breadService.createProfileResponse(bread, stats, recordResponses)).thenReturn(expected);
+
+        BreadProfileResponse actual = breadComplexService.getBreadProfile(breadId, userId);
+
+        assertSame(expected, actual);
+        verify(breadService).getBreadById(breadId);
+        verify(breadRecordService).findActiveRecordsByUserAndBread(userId, bread);
+        verify(breadRecordService).createProfileStats(List.of(record));
+        verify(breadRecordService).createProfileRecordResponses(List.of(record));
+        verify(breadService).createProfileResponse(bread, stats, recordResponses);
     }
 
     private Bread createBread(UUID id, Integer stickerNumber, String name, BreadType breadType) {


### PR DESCRIPTION
## 🧩 관련 이슈

- #19 

## 🛠️ 작업 내용

  - 빵 프로필 응답 DTO를 추가했습니다.
    - `BreadProfileResponse`
    - `BreadProfileStatsResponse`
    - `BreadProfileRecordResponse`

  - 응답에 카탈로그 빵 마스터 정보를 포함했습니다.
    - `bread_id`
    - `sticker_number`
    - `name`
    - `bread_type`
    - `bread_type_label`
    - `image_url`

  - 현재 유저 기준 통계와 기록 목록을 포함했습니다.

  - 비로그인 요청 처리를 추가했습니다.

  - `bread_type_label` 변환을 추가했습니다.
    - `PASTRY` → `페이스트리`
    - `BREAD` → `식빵`
    - `DONUT` → `도넛`
    - `CAKE` → `케이크`
    - `BAGEL` → `베이글`
    - `TART` → `타르트`
    - `OTHER` → `기타`

  - 매핑 책임을 Mapper로 분리했습니다.
    - `BreadMapper`: 빵 프로필 응답 생성, 빵 종류 라벨 변환
    - `BreadRecordMapper`: 기록 목록 응답 생성, 통계 생성


## 📢 참고 및 특이사항

- `level` 필드는 명세서에 포함되어 있지만, MVP 기획서 기준 2차 기능으로 분리되어 있어 이번 구현에서는 제외했습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인