### PR TITLE
feat: implement bread record detail APIs

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/entity/Bread.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/entity/Bread.java
@@ -55,4 +55,7 @@ public class Bread {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    public boolean isUserCreated() {
+        return createdBy != null;
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -103,6 +103,13 @@ public class BreadService {
     }
 
     @Transactional
+    public void deleteIfUserCreated(Bread bread) {
+        if (bread != null && bread.isUserCreated()) {
+            breadRepository.delete(bread);
+        }
+    }
+
+    @Transactional
     public Bread createUserBread(CreateNewBreadRecordRequest request, UUID userId) {
         validateBreadNameNotDuplicated(request.getName());
 

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
@@ -2,6 +2,9 @@ package com.bean.breaddiary.domain.breadrecord.controller;
 
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
 import com.bean.breaddiary.global.common.ApiResponse;
@@ -18,7 +21,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,6 +51,35 @@ public class BreadRecordController {
     private static final UUID DUMMY_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
     private final BreadRecordComplexService breadRecordComplexService;
+
+    @Operation(
+            summary = "개별 빵 기록 상세 조회",
+            description = "빵 기록 ID 기준으로 개별 기록 상세와 카탈로그 빵 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "빵 기록 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BreadRecordDetailResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 기록을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{recordId}")
+    public ResponseEntity<ApiResponse<BreadRecordDetailResponse>> getBreadRecord(
+            @Parameter(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+            @PathVariable UUID recordId,
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+    ) {
+        BreadRecordDetailResponse response = breadRecordComplexService.getBreadRecord(
+                resolveUserId(userId),
+                recordId
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
     /**
      * 카탈로그에 존재하는 빵에 대해 새 기록을 생성합니다.
@@ -115,6 +151,67 @@ public class BreadRecordController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
+    }
+
+    @Operation(
+            summary = "개별 빵 기록 수정",
+            description = "빵 기록 ID 기준으로 변경된 필드만 수정합니다. bread_id, name, bread_type은 수정할 수 없습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "빵 기록 수정 성공",
+                    content = @Content(schema = @Schema(implementation = BreadRecordDetailResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 기록을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PutMapping(path = "/{recordId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<BreadRecordDetailResponse>> updateBreadRecord(
+            @Parameter(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+            @PathVariable UUID recordId,
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
+            @Valid @ModelAttribute UpdateBreadRecordRequest request
+    ) {
+        BreadRecordDetailResponse response = breadRecordComplexService.updateBreadRecord(
+                resolveUserId(userId),
+                recordId,
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(
+            summary = "개별 빵 기록 삭제",
+            description = "빵 기록 ID 기준으로 기록을 소프트 삭제하고 스티커 제거 여부를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "빵 기록 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = BreadRecordDeleteResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 기록을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/{recordId}")
+    public ResponseEntity<ApiResponse<BreadRecordDeleteResponse>> deleteBreadRecord(
+            @Parameter(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+            @PathVariable UUID recordId,
+            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
+            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+    ) {
+        BreadRecordDeleteResponse response = breadRecordComplexService.deleteBreadRecord(
+                resolveUserId(userId),
+                recordId
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     private UUID resolveUserId(UUID userId) {

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -8,6 +8,7 @@ import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogS
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordLatestPhotoProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import org.mapstruct.Mapper;
@@ -63,6 +64,15 @@ public interface BreadRecordMapper {
             BreadRecord breadRecord,
             Boolean isFirstRecord
     );
+
+    @Mapping(target = "breadId", source = "breadRecord.bread.id")
+    @Mapping(target = "stickerNumber", source = "breadRecord.bread.stickerNumber")
+    @Mapping(target = "name", source = "breadRecord.bread.name")
+    @Mapping(target = "breadType", source = "breadRecord.bread.breadType")
+    @Mapping(target = "breadTypeLabel", expression = "java(toBreadTypeLabel(breadRecord.getBread().getBreadType()))")
+    @Mapping(target = "imageUrl", source = "breadRecord.bread.imageUrl")
+    @Mapping(target = "photoThumbnailUrl", expression = "java(toThumbnailUrl(breadRecord.getPhotoUrl()))")
+    BreadRecordDetailResponse mapToDetailResponse(BreadRecord breadRecord);
 
     default String toThumbnailUrl(String photoUrl) {
         if (photoUrl == null) {
@@ -146,5 +156,21 @@ public interface BreadRecordMapper {
         return BigDecimal.valueOf(rating)
                 .setScale(1, RoundingMode.HALF_UP)
                 .doubleValue();
+    }
+
+    default String toBreadTypeLabel(com.bean.breaddiary.domain.bread.entity.BreadType breadType) {
+        if (breadType == null) {
+            return null;
+        }
+
+        return switch (breadType) {
+            case PASTRY -> "페이스트리";
+            case BREAD -> "식빵";
+            case DONUT -> "도넛";
+            case CAKE -> "케이크";
+            case BAGEL -> "베이글";
+            case TART -> "타르트";
+            case OTHER -> "기타";
+        };
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/UpdateBreadRecordRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/request/UpdateBreadRecordRequest.java
@@ -1,0 +1,48 @@
+package com.bean.breaddiary.domain.breadrecord.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 기록 수정 요청")
+public class UpdateBreadRecordRequest {
+
+    @Schema(description = "새 빵 사진 파일. 변경 시에만 전송", type = "string", format = "binary")
+    private MultipartFile photo;
+
+    @Schema(description = "구매처. 빈 문자열 전송 시 null로 초기화", example = "르뺑블루 성수점", maxLength = 50)
+    @Size(max = 50, message = "구매처는 50자 이내로 입력해주세요.")
+    private String shopName;
+
+    @Schema(description = "먹은 날짜", example = "2026-04-16")
+    private LocalDate eatenDate;
+
+    @Schema(description = "별점", example = "5", minimum = "1", maximum = "5")
+    @Min(value = 1, message = "별점은 1~5 사이 값이어야 합니다.")
+    @Max(value = 5, message = "별점은 1~5 사이 값이어야 합니다.")
+    private Integer rating;
+
+    @Schema(description = "후기. 빈 문자열 전송 시 null로 초기화", example = "겉은 바삭하고 안은 촉촉해서 완벽했어요.", maxLength = 500)
+    @Size(max = 500, message = "후기는 500자 이내로 입력해주세요.")
+    private String review;
+
+    public void setShop_name(String shopName) {
+        this.shopName = shopName;
+    }
+
+    public void setEaten_date(LocalDate eatenDate) {
+        this.eatenDate = eatenDate;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordDeleteResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordDeleteResponse.java
@@ -1,0 +1,18 @@
+package com.bean.breaddiary.domain.breadrecord.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 기록 삭제 응답")
+public class BreadRecordDeleteResponse {
+
+    @Schema(description = "마지막 기록 삭제로 스티커가 제거되었는지 여부", example = "false")
+    private Boolean stickerRemoved;
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordDetailResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/response/BreadRecordDetailResponse.java
@@ -1,0 +1,65 @@
+package com.bean.breaddiary.domain.breadrecord.dto.response;
+
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 기록 상세 응답")
+public class BreadRecordDetailResponse {
+
+    @Schema(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+    private UUID id;
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    private UUID breadId;
+
+    @Schema(description = "도감 번호", example = "7")
+    private Integer stickerNumber;
+
+    @Schema(description = "빵 이름", example = "크루아상")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY")
+    private BreadType breadType;
+
+    @Schema(description = "빵 종류 한글 표시명", example = "페이스트리")
+    private String breadTypeLabel;
+
+    @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/croissant.webp")
+    private String imageUrl;
+
+    @Schema(description = "원본 사진 URL", example = "https://cdn.bread-diary.app/bread-photos/record.webp")
+    private String photoUrl;
+
+    @Schema(description = "썸네일 사진 URL", example = "https://cdn.bread-diary.app/bread-photos/record_thumb.webp")
+    private String photoThumbnailUrl;
+
+    @Schema(description = "구매처", example = "르뺑블루 성수점", nullable = true)
+    private String shopName;
+
+    @Schema(description = "먹은 날짜", example = "2026-03-14")
+    private LocalDate eatenDate;
+
+    @Schema(description = "별점", example = "5")
+    private Integer rating;
+
+    @Schema(description = "후기", example = "겉은 바삭하고 안은 촉촉해서 완벽했어요.", nullable = true)
+    private String review;
+
+    @Schema(description = "기록 생성 일시", example = "2026-03-14T09:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "기록 수정 일시", example = "2026-03-14T10:15:00")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/entity/BreadRecord.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/entity/BreadRecord.java
@@ -83,4 +83,21 @@ public class BreadRecord {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    public void update(
+            String photoUrl,
+            String shopName,
+            LocalDate eatenDate,
+            Integer rating,
+            String review
+    ) {
+        this.photoUrl = photoUrl;
+        this.shopName = shopName;
+        this.eatenDate = eatenDate;
+        this.rating = rating;
+        this.review = review;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -10,15 +10,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> {
 
+    Optional<BreadRecord> findByIdAndDeletedAtIsNull(UUID id);
     List<BreadRecord> findAllByUserId(UUID userId);
     List<BreadRecord> findAllByUserIdAndBread(UUID userId, Bread bread);
     List<BreadRecord> findAllByUserIdAndBreadAndDeletedAtIsNullOrderByCreatedAtDesc(UUID userId, Bread bread);
+    long countByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
     long countByUserIdAndBread(UUID userId, Bread bread);
     boolean existsByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
+    boolean existsByBreadAndDeletedAtIsNull(Bread bread);
 
     @Query("""
             select br.bread.id as breadId, count(br) as eatCount

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
@@ -4,12 +4,16 @@ import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.service.BreadService;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import com.bean.breaddiary.global.s3.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -54,5 +58,60 @@ public class BreadRecordComplexService {
         );
 
         return breadRecordService.createResponse(savedRecord, true);
+    }
+
+    public BreadRecordDetailResponse getBreadRecord(UUID userId, UUID recordId) {
+        BreadRecord breadRecord = breadRecordService.getActiveRecordForUser(
+                userId,
+                recordId
+        );
+
+        return breadRecordService.createDetailResponse(breadRecord);
+    }
+
+    public BreadRecordDetailResponse updateBreadRecord(
+            UUID userId,
+            UUID recordId,
+            UpdateBreadRecordRequest request
+    ) {
+        breadRecordService.validateEatenDate(request.getEatenDate());
+
+        BreadRecord breadRecord = breadRecordService.getActiveRecordForUser(
+                userId,
+                recordId
+        );
+        String photoUrl = uploadPhotoIfPresent(userId, request.getPhoto());
+        BreadRecord updatedRecord = breadRecordService.updateBreadRecord(
+                breadRecord,
+                request,
+                photoUrl
+        );
+
+        return breadRecordService.createDetailResponse(updatedRecord);
+    }
+
+    public BreadRecordDeleteResponse deleteBreadRecord(UUID userId, UUID recordId) {
+        BreadRecord breadRecord = breadRecordService.getActiveRecordForUser(
+                userId,
+                recordId
+        );
+        Bread bread = breadRecord.getBread();
+
+        breadRecordService.deleteBreadRecord(breadRecord);
+
+        boolean stickerRemoved = !breadRecordService.hasRemainingActiveRecord(userId, bread);
+        if (stickerRemoved && !breadRecordService.existsActiveRecordByBread(bread)) {
+            breadService.deleteIfUserCreated(bread);
+        }
+
+        return new BreadRecordDeleteResponse(stickerRemoved);
+    }
+
+    private String uploadPhotoIfPresent(UUID userId, MultipartFile photo) {
+        if (photo == null || photo.isEmpty()) {
+            return null;
+        }
+
+        return s3UploadService.uploadBreadPhoto(userId, photo);
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
@@ -7,7 +7,9 @@ import com.bean.breaddiary.domain.breadrecord.dto.mapper.BreadRecordMapper;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
 import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
@@ -34,6 +36,22 @@ public class BreadRecordService {
 
     public boolean existsActiveRecord(UUID userId, Bread bread) {
         return breadRecordRepository.existsByUserIdAndBreadAndDeletedAtIsNull(userId, bread);
+    }
+
+    public boolean existsActiveRecordByBread(Bread bread) {
+        return breadRecordRepository.existsByBreadAndDeletedAtIsNull(bread);
+    }
+
+    public BreadRecord getActiveRecordForUser(UUID userId, UUID recordId) {
+        BreadRecord breadRecord = breadRecordRepository.findByIdAndDeletedAtIsNull(recordId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 빵 기록을 찾을 수 없습니다."
+                ));
+
+        validateOwner(userId, breadRecord);
+
+        return breadRecord;
     }
 
     public Map<UUID, Long> countActiveRecordsByBreadIds(UUID userId, List<UUID> breadIds) {
@@ -77,6 +95,37 @@ public class BreadRecordService {
 
     public List<BreadProfileRecordResponse> createProfileRecordResponses(List<BreadRecord> breadRecords) {
         return breadRecordMapper.mapToProfileRecords(breadRecords);
+    }
+
+    @Transactional
+    public BreadRecord updateBreadRecord(
+            BreadRecord breadRecord,
+            UpdateBreadRecordRequest request,
+            String photoUrl
+    ) {
+        breadRecord.update(
+                resolvePhotoUrl(breadRecord, photoUrl),
+                resolveNullableText(breadRecord.getShopName(), request.getShopName()),
+                request.getEatenDate() == null ? breadRecord.getEatenDate() : request.getEatenDate(),
+                request.getRating() == null ? breadRecord.getRating() : request.getRating(),
+                resolveNullableText(breadRecord.getReview(), request.getReview())
+        );
+
+        return breadRecordRepository.save(breadRecord);
+    }
+
+    @Transactional
+    public void deleteBreadRecord(BreadRecord breadRecord) {
+        breadRecord.delete();
+        breadRecordRepository.save(breadRecord);
+    }
+
+    public boolean hasRemainingActiveRecord(UUID userId, Bread bread) {
+        return breadRecordRepository.countByUserIdAndBreadAndDeletedAtIsNull(userId, bread) > 0;
+    }
+
+    public BreadRecordDetailResponse createDetailResponse(BreadRecord breadRecord) {
+        return breadRecordMapper.mapToDetailResponse(breadRecord);
     }
 
     @Transactional
@@ -136,5 +185,30 @@ public class BreadRecordService {
                     "미래 날짜는 선택할 수 없습니다."
             );
         }
+    }
+
+    private void validateOwner(UUID userId, BreadRecord breadRecord) {
+        if (!breadRecord.getUserId().equals(userId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "해당 빵 기록에 접근할 수 없습니다."
+            );
+        }
+    }
+
+    private String resolvePhotoUrl(BreadRecord breadRecord, String photoUrl) {
+        return photoUrl == null ? breadRecord.getPhotoUrl() : photoUrl;
+    }
+
+    private String resolveNullableText(String currentValue, String requestedValue) {
+        if (requestedValue == null) {
+            return currentValue;
+        }
+
+        if (requestedValue.isBlank()) {
+            return null;
+        }
+
+        return requestedValue;
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
@@ -3,6 +3,9 @@ package com.bean.breaddiary.domain.breadrecord.controller;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +31,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,6 +43,9 @@ class BreadRecordControllerContractTest {
 
     private BreadRecordComplexService breadRecordComplexService;
     private MockMvc mockMvc;
+
+    private static final UUID RECORD_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    private static final UUID BREAD_ID = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
 
     @BeforeEach
     void setUp() {
@@ -130,6 +138,88 @@ class BreadRecordControllerContractTest {
         assertEquals(LocalDate.of(2026, 3, 15), request.getEatenDate());
     }
 
+    @Test
+    void getBreadRecordReturnsSpecResponseWithSnakeCaseFields() throws Exception {
+        BreadRecordDetailResponse response = createDetailResponse();
+
+        when(breadRecordComplexService.getBreadRecord(DUMMY_USER_ID, RECORD_ID)).thenReturn(response);
+
+        mockMvc.perform(get("/breads/{recordId}", RECORD_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(RECORD_ID.toString()))
+                .andExpect(jsonPath("$.data.bread_id").value(BREAD_ID.toString()))
+                .andExpect(jsonPath("$.data.sticker_number").value(7))
+                .andExpect(jsonPath("$.data.name").value("크루아상"))
+                .andExpect(jsonPath("$.data.bread_type").value("PASTRY"))
+                .andExpect(jsonPath("$.data.bread_type_label").value("페이스트리"))
+                .andExpect(jsonPath("$.data.image_url").value("https://cdn.bread-diary.app/breads/croissant.webp"))
+                .andExpect(jsonPath("$.data.photo_url").value("https://cdn.bread-diary.app/bread-photos/record.webp"))
+                .andExpect(jsonPath("$.data.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
+                .andExpect(jsonPath("$.data.shop_name").value("르뺑블루 성수점"))
+                .andExpect(jsonPath("$.data.eaten_date").value("2026-03-14"))
+                .andExpect(jsonPath("$.data.rating").value(5))
+                .andExpect(jsonPath("$.data.review").value("겉은 바삭하고 안은 촉촉해서 완벽했어요."))
+                .andExpect(jsonPath("$.data.created_at").value("2026-03-14T09:30:00"))
+                .andExpect(jsonPath("$.data.updated_at").value("2026-03-14T10:15:00"))
+                .andExpect(jsonPath("$.data.breadId").doesNotExist());
+
+        verify(breadRecordComplexService).getBreadRecord(DUMMY_USER_ID, RECORD_ID);
+    }
+
+    @Test
+    void updateBreadRecordBindsSnakeCaseMultipartFields() throws Exception {
+        BreadRecordDetailResponse response = createDetailResponse();
+
+        when(breadRecordComplexService.updateBreadRecord(eq(DUMMY_USER_ID), eq(RECORD_ID), any(UpdateBreadRecordRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(multipart("/breads/{recordId}", RECORD_ID)
+                        .file(new MockMultipartFile(
+                                "photo",
+                                "croissant.webp",
+                                MediaType.IMAGE_JPEG_VALUE,
+                                "photo".getBytes()
+                        ))
+                        .param("shop_name", "")
+                        .param("eaten_date", "2026-03-14")
+                        .param("rating", "5")
+                        .param("review", "")
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(RECORD_ID.toString()))
+                .andExpect(jsonPath("$.data.bread_id").value(BREAD_ID.toString()))
+                .andExpect(jsonPath("$.data.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"));
+
+        ArgumentCaptor<UpdateBreadRecordRequest> requestCaptor =
+                ArgumentCaptor.forClass(UpdateBreadRecordRequest.class);
+        verify(breadRecordComplexService).updateBreadRecord(eq(DUMMY_USER_ID), eq(RECORD_ID), requestCaptor.capture());
+
+        UpdateBreadRecordRequest request = requestCaptor.getValue();
+        assertEquals("", request.getShopName());
+        assertEquals(LocalDate.of(2026, 3, 14), request.getEatenDate());
+        assertEquals(5, request.getRating());
+        assertEquals("", request.getReview());
+    }
+
+    @Test
+    void deleteBreadRecordReturnsStickerRemoved() throws Exception {
+        when(breadRecordComplexService.deleteBreadRecord(DUMMY_USER_ID, RECORD_ID))
+                .thenReturn(new BreadRecordDeleteResponse(true));
+
+        mockMvc.perform(delete("/breads/{recordId}", RECORD_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.sticker_removed").value(true))
+                .andExpect(jsonPath("$.data.stickerRemoved").doesNotExist());
+
+        verify(breadRecordComplexService).deleteBreadRecord(DUMMY_USER_ID, RECORD_ID);
+    }
+
     private BreadRecordCreateResponse createResponse(UUID breadId, BreadType breadType, boolean isFirstRecord) {
         return new BreadRecordCreateResponse(
                 UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
@@ -146,6 +236,26 @@ class BreadRecordControllerContractTest {
                 "겉은 바삭하고 안은 촉촉해서 완벽했어요.",
                 isFirstRecord,
                 LocalDateTime.of(2026, 3, 14, 9, 30)
+        );
+    }
+
+    private BreadRecordDetailResponse createDetailResponse() {
+        return new BreadRecordDetailResponse(
+                RECORD_ID,
+                BREAD_ID,
+                7,
+                "크루아상",
+                BreadType.PASTRY,
+                "페이스트리",
+                "https://cdn.bread-diary.app/breads/croissant.webp",
+                "https://cdn.bread-diary.app/bread-photos/record.webp",
+                "https://cdn.bread-diary.app/bread-photos/record_thumb.webp",
+                "르뺑블루 성수점",
+                LocalDate.of(2026, 3, 14),
+                5,
+                "겉은 바삭하고 안은 촉촉해서 완벽했어요.",
+                LocalDateTime.of(2026, 3, 14, 9, 30),
+                LocalDateTime.of(2026, 3, 14, 10, 15)
         );
     }
 

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexServiceTest.java
@@ -1,0 +1,152 @@
+package com.bean.breaddiary.domain.breadrecord.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import com.bean.breaddiary.global.s3.S3UploadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BreadRecordComplexServiceTest {
+
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID RECORD_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+    private BreadService breadService;
+    private BreadRecordService breadRecordService;
+    private S3UploadService s3UploadService;
+    private BreadRecordComplexService breadRecordComplexService;
+
+    @BeforeEach
+    void setUp() {
+        breadService = mock(BreadService.class);
+        breadRecordService = mock(BreadRecordService.class);
+        s3UploadService = mock(S3UploadService.class);
+        breadRecordComplexService = new BreadRecordComplexService(
+                breadService,
+                breadRecordService,
+                s3UploadService
+        );
+    }
+
+    @Test
+    void updateBreadRecordUploadsPhotoWhenPhotoExists() {
+        BreadRecord breadRecord = createBreadRecord(createBread(null));
+        UpdateBreadRecordRequest request = new UpdateBreadRecordRequest(
+                new MockMultipartFile("photo", "photo.webp", "image/webp", "photo".getBytes()),
+                "르뺑블루",
+                LocalDate.of(2026, 3, 14),
+                5,
+                "맛있어요."
+        );
+        BreadRecord updatedRecord = createBreadRecord(breadRecord.getBread());
+        BreadRecordDetailResponse expected = new BreadRecordDetailResponse();
+
+        when(breadRecordService.getActiveRecordForUser(USER_ID, RECORD_ID)).thenReturn(breadRecord);
+        when(s3UploadService.uploadBreadPhoto(USER_ID, request.getPhoto()))
+                .thenReturn("https://cdn.bread-diary.app/bread-photos/new.webp");
+        when(breadRecordService.updateBreadRecord(
+                breadRecord,
+                request,
+                "https://cdn.bread-diary.app/bread-photos/new.webp"
+        )).thenReturn(updatedRecord);
+        when(breadRecordService.createDetailResponse(updatedRecord)).thenReturn(expected);
+
+        BreadRecordDetailResponse actual = breadRecordComplexService.updateBreadRecord(
+                USER_ID,
+                RECORD_ID,
+                request
+        );
+
+        assertSame(expected, actual);
+        verify(breadRecordService).validateEatenDate(LocalDate.of(2026, 3, 14));
+        verify(s3UploadService).uploadBreadPhoto(USER_ID, request.getPhoto());
+        verify(breadRecordService).updateBreadRecord(
+                breadRecord,
+                request,
+                "https://cdn.bread-diary.app/bread-photos/new.webp"
+        );
+    }
+
+    @Test
+    void updateBreadRecordKeepsPhotoWhenPhotoIsMissing() {
+        BreadRecord breadRecord = createBreadRecord(createBread(null));
+        UpdateBreadRecordRequest request = new UpdateBreadRecordRequest(
+                null,
+                null,
+                null,
+                4,
+                null
+        );
+        BreadRecordDetailResponse expected = new BreadRecordDetailResponse();
+
+        when(breadRecordService.getActiveRecordForUser(USER_ID, RECORD_ID)).thenReturn(breadRecord);
+        when(breadRecordService.updateBreadRecord(breadRecord, request, null)).thenReturn(breadRecord);
+        when(breadRecordService.createDetailResponse(breadRecord)).thenReturn(expected);
+
+        BreadRecordDetailResponse actual = breadRecordComplexService.updateBreadRecord(
+                USER_ID,
+                RECORD_ID,
+                request
+        );
+
+        assertSame(expected, actual);
+        verify(s3UploadService, never()).uploadBreadPhoto(USER_ID, request.getPhoto());
+        verify(breadRecordService).updateBreadRecord(breadRecord, request, null);
+    }
+
+    @Test
+    void deleteBreadRecordDeletesUserCreatedBreadWhenNoActiveRecordRemains() {
+        Bread bread = createBread(USER_ID);
+        BreadRecord breadRecord = createBreadRecord(bread);
+
+        when(breadRecordService.getActiveRecordForUser(USER_ID, RECORD_ID)).thenReturn(breadRecord);
+        when(breadRecordService.hasRemainingActiveRecord(USER_ID, bread)).thenReturn(false);
+        when(breadRecordService.existsActiveRecordByBread(bread)).thenReturn(false);
+
+        BreadRecordDeleteResponse response = breadRecordComplexService.deleteBreadRecord(USER_ID, RECORD_ID);
+
+        assertTrue(response.getStickerRemoved());
+        verify(breadRecordService).deleteBreadRecord(breadRecord);
+        verify(breadService).deleteIfUserCreated(bread);
+    }
+
+    private Bread createBread(UUID createdBy) {
+        return Bread.builder()
+                .id(UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789"))
+                .stickerNumber(7)
+                .name("크루아상")
+                .breadType(BreadType.PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/breads/croissant.webp")
+                .createdBy(createdBy)
+                .build();
+    }
+
+    private BreadRecord createBreadRecord(Bread bread) {
+        return BreadRecord.builder()
+                .id(RECORD_ID)
+                .userId(USER_ID)
+                .bread(bread)
+                .photoUrl("https://cdn.bread-diary.app/bread-photos/record.webp")
+                .shopName("르뺑블루")
+                .eatenDate(LocalDate.of(2026, 3, 14))
+                .rating(5)
+                .review("맛있어요.")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #21 

## 🛠️ 작업 내용

- 개별 빵 기록 조회/수정/삭제 API를 구현했습니다.
- 개별 기록 상세 응답 DTO를 추가했습니다.
- 개별 기록 수정 요청 DTO를 추가했습니다.
- 개별 기록 삭제 응답 DTO를 추가했습니다.
- 개별 기록 상세 응답에 카탈로그 빵 정보를 포함했습니다.`
- 개별 기록 상세 응답에 기록 정보를 포함했습니다.
- 수정 API에서 부분 수정 로직을 구현했습니다.
- 삭제 API에서 소프트 삭제 및 스티커 제거 여부 반환을 구현했습니다.
- 본인 기록만 조회/수정/삭제 가능하도록 소유권 검증을 추가했습니다.
  - 없는 기록/삭제된 기록: `404`
  - 다른 유저 기록 접근: `403`

## 📢 참고 및 특이사항

- 없습니다

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인