### PR TITLE
implement bread type list API

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadTypeController.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadTypeController.java
@@ -1,0 +1,44 @@
+package com.bean.breaddiary.domain.bread.controller;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadTypeListResponse;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "빵 종류 API", description = "빵 종류 목록을 조회하는 API입니다.")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bread-types")
+public class BreadTypeController {
+
+    private final BreadService breadService;
+
+    @Operation(
+            summary = "빵 종류 목록 조회",
+            description = "신규 빵 기록 화면에서 사용할 빵 종류 코드와 한글 라벨 목록을 조회합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "빵 종류 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BreadTypeListResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<BreadTypeListResponse>> getBreadTypes() {
+        BreadTypeListResponse response = breadService.getBreadTypes();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -7,6 +7,8 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadTypeItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadTypeListResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
@@ -141,18 +143,21 @@ public interface BreadMapper {
     );
 
     default String toBreadTypeLabel(BreadType breadType) {
-        if (breadType == null) {
-            return null;
-        }
+        return breadType == null ? null : breadType.getLabel();
+    }
 
-        return switch (breadType) {
-            case PASTRY -> "페이스트리";
-            case BREAD -> "식빵";
-            case DONUT -> "도넛";
-            case CAKE -> "케이크";
-            case BAGEL -> "베이글";
-            case TART -> "타르트";
-            case OTHER -> "기타";
-        };
+    default BreadTypeListResponse mapToBreadTypeListResponse(List<BreadType> breadTypes) {
+        List<BreadTypeItemResponse> items = breadTypes.stream()
+                .map(this::mapToBreadTypeItem)
+                .toList();
+
+        return new BreadTypeListResponse(items);
+    }
+
+    default BreadTypeItemResponse mapToBreadTypeItem(BreadType breadType) {
+        return new BreadTypeItemResponse(
+                breadType.name(),
+                breadType.getLabel()
+        );
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadTypeItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadTypeItemResponse.java
@@ -1,0 +1,21 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 종류 아이템")
+public class BreadTypeItemResponse {
+
+    @Schema(description = "빵 종류 코드", example = "PASTRY")
+    private String code;
+
+    @Schema(description = "빵 종류 한글 표시명", example = "페이스트리")
+    private String label;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadTypeListResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadTypeListResponse.java
@@ -1,0 +1,24 @@
+package com.bean.breaddiary.domain.bread.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "빵 종류 목록 응답")
+public class BreadTypeListResponse {
+
+    @ArraySchema(
+            schema = @Schema(implementation = BreadTypeItemResponse.class),
+            arraySchema = @Schema(description = "빵 종류 목록")
+    )
+    private List<BreadTypeItemResponse> items;
+}

--- a/src/main/java/com/bean/breaddiary/domain/bread/entity/BreadType.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/entity/BreadType.java
@@ -1,11 +1,18 @@
 package com.bean.breaddiary.domain.bread.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum BreadType {
-    PASTRY,
-    BREAD,
-    DONUT,
-    CAKE,
-    BAGEL,
-    TART,
-    OTHER
+    PASTRY("페이스트리"),
+    BREAD("식빵"),
+    DONUT("도넛"),
+    CAKE("케이크"),
+    BAGEL("베이글"),
+    TART("타르트"),
+    OTHER("기타");
+
+    private final String label;
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -6,6 +6,7 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileRecordResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadTypeListResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -99,6 +101,12 @@ public class BreadService {
                 bread,
                 stats,
                 records
+        );
+    }
+
+    public BreadTypeListResponse getBreadTypes() {
+        return breadMapper.mapToBreadTypeListResponse(
+                Arrays.asList(BreadType.values())
         );
     }
 

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -159,18 +159,6 @@ public interface BreadRecordMapper {
     }
 
     default String toBreadTypeLabel(com.bean.breaddiary.domain.bread.entity.BreadType breadType) {
-        if (breadType == null) {
-            return null;
-        }
-
-        return switch (breadType) {
-            case PASTRY -> "페이스트리";
-            case BREAD -> "식빵";
-            case DONUT -> "도넛";
-            case CAKE -> "케이크";
-            case BAGEL -> "베이글";
-            case TART -> "타르트";
-            case OTHER -> "기타";
-        };
+        return breadType == null ? null : breadType.getLabel();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadTypeControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadTypeControllerTest.java
@@ -1,0 +1,73 @@
+package com.bean.breaddiary.domain.bread.controller;
+
+import com.bean.breaddiary.domain.bread.dto.response.BreadTypeItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadTypeListResponse;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BreadTypeControllerTest {
+
+    private BreadService breadService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        breadService = mock(BreadService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new BreadTypeController(breadService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .build();
+    }
+
+    @Test
+    void getBreadTypesReturnsAllBreadTypes() throws Exception {
+        BreadTypeListResponse response = new BreadTypeListResponse(List.of(
+                new BreadTypeItemResponse("PASTRY", "페이스트리"),
+                new BreadTypeItemResponse("BREAD", "식빵"),
+                new BreadTypeItemResponse("DONUT", "도넛"),
+                new BreadTypeItemResponse("CAKE", "케이크"),
+                new BreadTypeItemResponse("BAGEL", "베이글"),
+                new BreadTypeItemResponse("TART", "타르트"),
+                new BreadTypeItemResponse("OTHER", "기타")
+        ));
+
+        when(breadService.getBreadTypes()).thenReturn(response);
+
+        mockMvc.perform(get("/bread-types"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items.length()").value(7))
+                .andExpect(jsonPath("$.data.items[0].code").value("PASTRY"))
+                .andExpect(jsonPath("$.data.items[0].label").value("페이스트리"))
+                .andExpect(jsonPath("$.data.items[1].code").value("BREAD"))
+                .andExpect(jsonPath("$.data.items[1].label").value("식빵"))
+                .andExpect(jsonPath("$.data.items[6].code").value("OTHER"))
+                .andExpect(jsonPath("$.data.items[6].label").value("기타"));
+
+        verify(breadService).getBreadTypes();
+    }
+
+    private ObjectMapper snakeCaseObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #23 

## 🛠️ 작업 내용

- 빵 종류 목록 조회 API를 구현했습니다.
    - `GET /bread-types`
- 빵 종류 목록 응답 DTO를 추가했습니다.
- `BreadType` enum에 한글 라벨을 추가했습니다.
  - `PASTRY` → `페이스트리`
  - `BREAD` → `식빵`
  - `DONUT` → `도넛`
  - `CAKE` → `케이크`
  - `BAGEL` → `베이글`
  - `TART` → `타르트`
  - `OTHER` → `기타`
- 기존 빵 종류 라벨 변환 로직을 `BreadType.getLabel()` 기반으로 정리했습니다.
- `BreadService#getBreadTypes()`를 추가했습니다.
  - DB 조회 없이 `BreadType.values()` 기반으로 응답을 생성합니다.

## 📢 참고 및 특이사항
- 없습니다

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인