### PR TITLE
feat: add user profile service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testCompileOnly 'org.projectlombok:lombok'
+	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/UserStatsProjection.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/UserStatsProjection.java
@@ -1,0 +1,10 @@
+package com.bean.breaddiary.domain.breadrecord.dto.projection;
+
+public interface UserStatsProjection {
+
+    Long getTotalRecords();
+
+    Long getUniqueShops();
+
+    Double getAvgRating();
+}

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -5,6 +5,7 @@ import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStatsProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordLatestPhotoProjection;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.UserStatsProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -72,4 +73,17 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
             @Param("userId") UUID userId,
             @Param("breadIds") List<UUID> breadIds
     );
+
+    @Query("""
+            select count(br) as totalRecords,
+                   count(distinct case
+                       when br.shopName is not null and trim(br.shopName) <> '' then trim(br.shopName)
+                       else null
+                   end) as uniqueShops,
+                   avg(br.rating) as avgRating
+            from BreadRecord br
+            where br.userId = :userId
+              and br.deletedAt is null
+            """)
+    UserStatsProjection findUserStatsByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/mapper/UserMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/mapper/UserMapper.java
@@ -1,0 +1,49 @@
+package com.bean.breaddiary.domain.user.dto.mapper;
+
+import com.bean.breaddiary.domain.breadrecord.dto.projection.UserStatsProjection;
+import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
+import com.bean.breaddiary.domain.user.dto.response.UserStatsResponse;
+import com.bean.breaddiary.domain.user.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UserMapper {
+
+    @Mapping(target = "stats", source = "stats")
+    UserMeResponse mapToUserMeResponse(User user, UserStatsResponse stats);
+
+    default UserStatsResponse mapToUserStatsResponse(UserStatsProjection projection) {
+        if (projection == null) {
+            return new UserStatsResponse(
+                    0L,
+                    0L,
+                    0.0
+            );
+        }
+
+        return new UserStatsResponse(
+                resolveCount(projection.getTotalRecords()),
+                resolveCount(projection.getUniqueShops()),
+                roundRating(projection.getAvgRating())
+        );
+    }
+
+    default Long resolveCount(Long count) {
+        return count == null ? 0L : count;
+    }
+
+    default Double roundRating(Double rating) {
+        if (rating == null) {
+            return 0.0;
+        }
+
+        return BigDecimal.valueOf(rating)
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
@@ -1,0 +1,50 @@
+package com.bean.breaddiary.domain.user.service;
+
+import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
+import com.bean.breaddiary.domain.user.dto.mapper.UserMapper;
+import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
+import com.bean.breaddiary.domain.user.dto.response.UserStatsResponse;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final BreadRecordRepository breadRecordRepository;
+    private final UserMapper userMapper;
+
+    public UserMeResponse getCurrentUserProfile(UUID userId) {
+        User user = getUserById(userId);
+        UserStatsResponse stats = getUserStats(userId);
+
+        return createUserMeResponse(user, stats);
+    }
+
+    public User getUserById(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 사용자를 찾을 수 없습니다."
+                ));
+    }
+
+    public UserStatsResponse getUserStats(UUID userId) {
+        return userMapper.mapToUserStatsResponse(
+                breadRecordRepository.findUserStatsByUserId(userId)
+        );
+    }
+
+    public UserMeResponse createUserMeResponse(User user, UserStatsResponse stats) {
+        return userMapper.mapToUserMeResponse(user, stats);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepositoryTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.bean.breaddiary.domain.breadrecord.repository;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.UserStatsProjection;
+import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
+class BreadRecordRepositoryTest {
+
+    @Autowired
+    private BreadRecordRepository breadRecordRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void findUserStatsByUserIdExcludesNullAndBlankShopNames() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        Bread bread = saveBread();
+
+        saveBreadRecord(userId, bread, "shop-a", 5, null);
+        saveBreadRecord(userId, bread, "   ", 4, null);
+        saveBreadRecord(userId, bread, "", 3, null);
+        saveBreadRecord(userId, bread, null, 2, null);
+        saveBreadRecord(userId, bread, "shop-b", 1, null);
+        saveBreadRecord(userId, bread, "shop-a", 5, null);
+
+        UserStatsProjection stats = breadRecordRepository.findUserStatsByUserId(userId);
+
+        assertNotNull(stats);
+        assertEquals(6L, stats.getTotalRecords());
+        assertEquals(2L, stats.getUniqueShops());
+        assertEquals(3.3333333333333335, stats.getAvgRating());
+    }
+
+    @Test
+    void findUserStatsByUserIdIgnoresSoftDeletedRecords() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        Bread bread = saveBread();
+
+        saveBreadRecord(userId, bread, "shop-live", 5, null);
+        saveBreadRecord(userId, bread, "shop-deleted", 1, LocalDateTime.of(2026, 4, 18, 12, 0));
+
+        UserStatsProjection stats = breadRecordRepository.findUserStatsByUserId(userId);
+
+        assertNotNull(stats);
+        assertEquals(1L, stats.getTotalRecords());
+        assertEquals(1L, stats.getUniqueShops());
+        assertEquals(5.0, stats.getAvgRating());
+    }
+
+    private Bread saveBread() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Bread bread = Bread.builder()
+                .stickerNumber(1)
+                .name("bread-" + suffix)
+                .breadType(BreadType.BREAD)
+                .imageUrl("https://cdn.bread-diary.app/breads/test.webp")
+                .build();
+
+        entityManager.persist(bread);
+        return bread;
+    }
+
+    private void saveBreadRecord(
+            UUID userId,
+            Bread bread,
+            String shopName,
+            int rating,
+            LocalDateTime deletedAt
+    ) {
+        BreadRecord breadRecord = BreadRecord.builder()
+                .userId(userId)
+                .bread(bread)
+                .photoUrl("https://cdn.bread-diary.app/bread-photos/test.webp")
+                .shopName(shopName)
+                .eatenDate(LocalDate.of(2026, 4, 18))
+                .rating(rating)
+                .review("test")
+                .deletedAt(deletedAt)
+                .build();
+
+        entityManager.persist(breadRecord);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/service/UserServiceTest.java
@@ -1,0 +1,117 @@
+package com.bean.breaddiary.domain.user.service;
+
+import com.bean.breaddiary.domain.breadrecord.dto.projection.UserStatsProjection;
+import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
+import com.bean.breaddiary.domain.user.dto.mapper.UserMapper;
+import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
+import com.bean.breaddiary.domain.user.dto.response.UserStatsResponse;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserServiceTest {
+
+    private UserRepository userRepository;
+    private BreadRecordRepository breadRecordRepository;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        breadRecordRepository = mock(BreadRecordRepository.class);
+        UserMapper userMapper = Mappers.getMapper(UserMapper.class);
+        userService = new UserService(userRepository, breadRecordRepository, userMapper);
+    }
+
+    @Test
+    void getCurrentUserProfileCombinesUserAndStats() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        User user = User.builder()
+                .id(userId)
+                .nickname("breadlover")
+                .email("bread@toss.im")
+                .profileImageUrl("https://cdn.breaddex.app/profiles/550e8400.webp")
+                .bio(null)
+                .createdAt(LocalDateTime.of(2026, 4, 1, 0, 0))
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(breadRecordRepository.findUserStatsByUserId(userId))
+                .thenReturn(createProjection(42L, 18L, 4.25));
+
+        UserMeResponse actual = userService.getCurrentUserProfile(userId);
+
+        assertEquals(userId, actual.getId());
+        assertEquals("breadlover", actual.getNickname());
+        assertEquals("bread@toss.im", actual.getEmail());
+        assertNotNull(actual.getStats());
+        assertEquals(42L, actual.getStats().getTotalRecords());
+        assertEquals(18L, actual.getStats().getUniqueShops());
+        assertEquals(4.3, actual.getStats().getAvgRating());
+
+        verify(userRepository).findById(userId);
+        verify(breadRecordRepository).findUserStatsByUserId(userId);
+    }
+
+    @Test
+    void getUserStatsNormalizesNullCountsAndRatingToZero() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+
+        when(breadRecordRepository.findUserStatsByUserId(userId))
+                .thenReturn(createProjection(null, null, null));
+
+        UserStatsResponse actual = userService.getUserStats(userId);
+
+        assertEquals(0L, actual.getTotalRecords());
+        assertEquals(0L, actual.getUniqueShops());
+        assertEquals(0.0, actual.getAvgRating());
+    }
+
+    @Test
+    void getUserByIdThrowsNotFoundWhenUserDoesNotExist() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userService.getUserById(userId)
+        );
+
+        assertEquals(404, exception.getStatusCode().value());
+        assertNotNull(exception.getReason());
+    }
+
+    private UserStatsProjection createProjection(Long totalRecords, Long uniqueShops, Double avgRating) {
+        return new UserStatsProjection() {
+            @Override
+            public Long getTotalRecords() {
+                return totalRecords;
+            }
+
+            @Override
+            public Long getUniqueShops() {
+                return uniqueShops;
+            }
+
+            @Override
+            public Double getAvgRating() {
+                return avgRating;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #26 

## 🛠️ 작업 내용

UserService 추가

필요 시 UserComplexService 분리 여부 검토 및 최소 범위로 적용

X-USER-ID 기반 현재 사용자 조회 로직 구현

사용자 미존재 시 기존 프로젝트 톤에 맞는 예외 처리 적용

BreadRecord 활성 데이터 기준 통계 조회 로직 추가

total_records 계산

unique_shops 계산

avg_rating 계산

deletedAt is null 조건 반영

shopName의 null/blank 처리 기준 정리

/users/me 응답에 사용할 UserMeResponse, UserStatsResponse 조립 로직 구현

기존 breadrecord repository 스타일(derived query / JPQL / projection 등) 확인 후 동일한 방식으로 반영

## 📢 참고 및 특이사항

-

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인