### PR TITLE
feat: add toss auth login flow

### DIFF
--- a/docs/codex-prompts-user/auth-login.txt
+++ b/docs/codex-prompts-user/auth-login.txt
@@ -1,5 +1,5 @@
-현재 작업 브랜치는 feat/<issue-number>-auth-login 이다.
-이 작업은 feat/<issue-number>-auth-session-domain 이 반영된 상태를 기준으로 한다.
+현재 작업 브랜치는 feat/33-auth-login 이다.
+이 작업은 feat/33-auth-session-domain 이 반영된 상태를 기준으로 한다.
 
 기존 bread / breadrecord / user / auth 구현, AGENTS.md, docs/user-part-spec.md를 먼저 읽고 같은 스타일로 최소 수정 방식으로 이어서 작업해라.
 

--- a/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
@@ -1,0 +1,173 @@
+package com.bean.breaddiary.domain.auth.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+
+@Service
+public class TossAuthClient {
+
+    private static final String GENERATE_TOKEN_PATH =
+            "/api-partner/v1/apps-in-toss/user/oauth2/generate-token";
+    private static final String LOGIN_ME_PATH =
+            "/api-partner/v1/apps-in-toss/user/oauth2/login-me";
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public TossAuthClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            @Value("${app.auth.toss.base-url:https://apps-in-toss-api.toss.im}") String baseUrl
+    ) {
+        this.restClient = restClientBuilder
+                .baseUrl(baseUrl)
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    public TossGenerateTokenSuccess exchangeAuthorizationCode(
+            String authorizationCode,
+            String referrer
+    ) {
+        try {
+            TossGenerateTokenResponse response = restClient.post()
+                    .uri(GENERATE_TOKEN_PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new TossGenerateTokenRequest(authorizationCode, referrer))
+                    .retrieve()
+                    .body(TossGenerateTokenResponse.class);
+
+            if (response == null || response.success() == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "토스 토큰 발급에 실패했습니다.");
+            }
+
+            return response.success();
+        } catch (RestClientResponseException exception) {
+            throw convertException(exception, "토스 토큰 발급에 실패했습니다.");
+        }
+    }
+
+    public TossLoginMeSuccess getUserInfo(String tossAccessToken) {
+        try {
+            TossLoginMeResponse response = restClient.get()
+                    .uri(LOGIN_ME_PATH)
+                    .header("Authorization", "Bearer " + tossAccessToken)
+                    .retrieve()
+                    .body(TossLoginMeResponse.class);
+
+            if (response == null || response.success() == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "토스 사용자 정보 조회에 실패했습니다.");
+            }
+
+            return response.success();
+        } catch (RestClientResponseException exception) {
+            throw convertException(exception, "토스 사용자 정보 조회에 실패했습니다.");
+        }
+    }
+
+    private ResponseStatusException convertException(
+            RestClientResponseException exception,
+            String fallbackMessage
+    ) {
+        String errorCode = extractErrorCode(exception.getResponseBodyAsString());
+
+        if ("invalid_grant".equalsIgnoreCase(errorCode)) {
+            return new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 인가 코드가 유효하지 않습니다.",
+                    exception
+            );
+        }
+
+        return new ResponseStatusException(
+                HttpStatus.BAD_GATEWAY,
+                fallbackMessage,
+                exception
+        );
+    }
+
+    private String extractErrorCode(String responseBody) {
+        if (!StringUtils.hasText(responseBody)) {
+            return null;
+        }
+
+        try {
+            TossGrantError tossGrantError = objectMapper.readValue(responseBody, TossGrantError.class);
+            if (StringUtils.hasText(tossGrantError.error())) {
+                return tossGrantError.error();
+            }
+
+            TossGenerateTokenResponse tossResponse = objectMapper.readValue(
+                    responseBody,
+                    TossGenerateTokenResponse.class
+            );
+            return tossResponse.error() == null ? null : tossResponse.error().errorCode();
+        } catch (IOException exception) {
+            return null;
+        }
+    }
+
+    private record TossGenerateTokenRequest(
+            String authorizationCode,
+            String referrer
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static record TossGenerateTokenResponse(
+            String resultType,
+            TossGenerateTokenSuccess success,
+            TossApiError error
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static record TossGenerateTokenSuccess(
+            String accessToken,
+            String refreshToken,
+            String tokenType,
+            Long expiresIn,
+            String scope
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static record TossLoginMeResponse(
+            String resultType,
+            TossLoginMeSuccess success,
+            TossApiError error
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static record TossLoginMeSuccess(
+            JsonNode userKey,
+            String name,
+            String email
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static record TossApiError(
+            String errorCode,
+            String reason
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record TossGrantError(
+            String error
+    ) {
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
@@ -1,0 +1,53 @@
+package com.bean.breaddiary.domain.auth.controller;
+
+import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
+import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
+import com.bean.breaddiary.domain.auth.service.AuthService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인증 API", description = "토스 로그인 인증 API입니다.")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(
+            summary = "토스 로그인",
+            description = "토스 authorization code를 검증하고 자체 Access / Refresh Token을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = AuthTokenResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "토스 인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502", description = "토스 연동 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/toss")
+    public ResponseEntity<ApiResponse<AuthTokenResponse>> loginWithToss(
+            @Valid @RequestBody TossLoginRequest request
+    ) {
+        AuthTokenResponse response = authService.loginWithToss(request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossLoginRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossLoginRequest.java
@@ -1,0 +1,24 @@
+package com.bean.breaddiary.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토스 로그인 요청")
+public class TossLoginRequest {
+
+    @NotBlank
+    @Schema(description = "토스 authorization code", example = "auth-code-example")
+    private String authorizationCode;
+
+    @NotBlank
+    @Schema(description = "토스 referrer", example = "DEFAULT")
+    private String referrer;
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/response/AuthTokenResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/response/AuthTokenResponse.java
@@ -1,0 +1,39 @@
+package com.bean.breaddiary.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "로그인 토큰 응답")
+public class AuthTokenResponse {
+
+    @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    private UUID userId;
+
+    @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9.access.signature")
+    private String accessToken;
+
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9.refresh.signature")
+    private String refreshToken;
+
+    @Schema(description = "토큰 타입", example = "Bearer")
+    private String tokenType;
+
+    @Schema(description = "Access Token 만료 시각", example = "2026-04-19T10:00:00")
+    private LocalDateTime accessTokenExpiresAt;
+
+    @Schema(description = "Refresh Token 만료 시각", example = "2026-05-18T10:00:00")
+    private LocalDateTime refreshTokenExpiresAt;
+
+    @Schema(description = "신규 가입 여부", example = "true")
+    private boolean newUser;
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
@@ -1,0 +1,228 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import com.bean.breaddiary.domain.auth.client.TossAuthClient;
+import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
+import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private static final String TOKEN_TYPE = "Bearer";
+    private static final String PENDING_REFRESH_TOKEN_HASH = "__PENDING_REFRESH_TOKEN__";
+    private static final int NICKNAME_MAX_LENGTH = 30;
+
+    private final UserRepository userRepository;
+    private final UserSessionService userSessionService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TossAuthClient tossAuthClient;
+    private final TossUserInfoDecryptor tossUserInfoDecryptor;
+
+    @Transactional
+    public AuthTokenResponse loginWithToss(TossLoginRequest request) {
+        LocalDateTime issuedAt = LocalDateTime.now();
+
+        TossAuthClient.TossGenerateTokenSuccess tossToken =
+                tossAuthClient.exchangeAuthorizationCode(
+                        request.getAuthorizationCode(),
+                        request.getReferrer()
+                );
+        TossAuthClient.TossLoginMeSuccess tossUserInfo =
+                tossAuthClient.getUserInfo(tossToken.accessToken());
+
+        ResolvedTossProfile tossProfile = resolveTossProfile(tossUserInfo);
+        UserResolution userResolution = findOrCreateUser(tossProfile);
+
+        String refreshJti = UUID.randomUUID().toString();
+        UserSession userSession = userSessionService.createSession(
+                userResolution.user().getId(),
+                PENDING_REFRESH_TOKEN_HASH,
+                refreshJti,
+                issuedAt
+        );
+
+        LocalDateTime accessTokenExpiresAt = userSessionService.calculateAccessTokenExpiresAt(issuedAt);
+        LocalDateTime refreshTokenExpiresAt = userSessionService.calculateRefreshTokenExpiresAt(issuedAt);
+
+        String accessToken = jwtTokenProvider.createAccessToken(
+                userResolution.user().getId(),
+                userSession.getId(),
+                issuedAt,
+                accessTokenExpiresAt
+        );
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                userResolution.user().getId(),
+                userSession.getId(),
+                refreshJti,
+                issuedAt,
+                refreshTokenExpiresAt
+        );
+
+        userSessionService.rotateRefreshToken(
+                userSession,
+                hashRefreshToken(refreshToken),
+                refreshJti,
+                issuedAt
+        );
+
+        return new AuthTokenResponse(
+                userResolution.user().getId(),
+                accessToken,
+                refreshToken,
+                TOKEN_TYPE,
+                accessTokenExpiresAt,
+                refreshTokenExpiresAt,
+                userResolution.newUser()
+        );
+    }
+
+    private ResolvedTossProfile resolveTossProfile(TossAuthClient.TossLoginMeSuccess tossUserInfo) {
+        String tossUserKey = requireText(
+                tossUserInfo.userKey() == null ? null : tossUserInfo.userKey().asText(null),
+                "토스 사용자 키가 없습니다."
+        );
+        String decryptedName = tossUserInfoDecryptor.decryptNullable(tossUserInfo.name());
+        String decryptedEmail = normalizeNullable(tossUserInfoDecryptor.decryptNullable(tossUserInfo.email()));
+
+        return new ResolvedTossProfile(
+                tossUserKey,
+                resolveNickname(decryptedName, null, tossUserKey),
+                decryptedEmail
+        );
+    }
+
+    private UserResolution findOrCreateUser(ResolvedTossProfile tossProfile) {
+        Optional<User> userByTossUserKey = userRepository.findByTossUserKey(tossProfile.tossUserKey());
+        if (userByTossUserKey.isPresent()) {
+            User user = userByTossUserKey.get();
+            synchronizeUser(user, tossProfile);
+            return new UserResolution(user, false);
+        }
+
+        if (StringUtils.hasText(tossProfile.email())) {
+            Optional<User> userByEmail = userRepository.findByEmail(tossProfile.email());
+            if (userByEmail.isPresent()) {
+                User user = userByEmail.get();
+                synchronizeUser(user, tossProfile);
+                return new UserResolution(user, false);
+            }
+        }
+
+        User user = userRepository.save(
+                User.builder()
+                        .tossUserKey(tossProfile.tossUserKey())
+                        .nickname(tossProfile.nickname())
+                        .email(tossProfile.email())
+                        .build()
+        );
+
+        return new UserResolution(user, true);
+    }
+
+    private void synchronizeUser(User user, ResolvedTossProfile tossProfile) {
+        String nickname = resolveNickname(
+                tossProfile.nickname(),
+                user.getNickname(),
+                tossProfile.tossUserKey()
+        );
+        String email = resolveEmail(tossProfile.email(), user.getEmail());
+
+        if (user.isDeleted()) {
+            user.activate(tossProfile.tossUserKey(), nickname, email);
+            return;
+        }
+
+        user.updateFromToss(tossProfile.tossUserKey(), nickname, email);
+    }
+
+    private String resolveEmail(String tossEmail, String existingEmail) {
+        if (StringUtils.hasText(tossEmail)) {
+            return tossEmail;
+        }
+
+        return normalizeNullable(existingEmail);
+    }
+
+    private String resolveNickname(
+            String tossName,
+            String existingNickname,
+            String tossUserKey
+    ) {
+        if (StringUtils.hasText(tossName)) {
+            return truncate(tossName.trim());
+        }
+
+        if (StringUtils.hasText(existingNickname)) {
+            return truncate(existingNickname.trim());
+        }
+
+        String suffix = tossUserKey.length() > 8
+                ? tossUserKey.substring(tossUserKey.length() - 8)
+                : tossUserKey;
+
+        return truncate("toss-" + suffix);
+    }
+
+    private String truncate(String value) {
+        return value.length() <= NICKNAME_MAX_LENGTH
+                ? value
+                : value.substring(0, NICKNAME_MAX_LENGTH);
+    }
+
+    private String requireText(String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            throw new ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_GATEWAY,
+                    message
+            );
+        }
+        return value.trim();
+    }
+
+    private String normalizeNullable(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private String hashRefreshToken(String refreshToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(refreshToken.getBytes(StandardCharsets.UTF_8));
+
+            return Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(digest);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 알고리즘을 찾을 수 없습니다.", exception);
+        }
+    }
+
+    private record ResolvedTossProfile(
+            String tossUserKey,
+            String nickname,
+            String email
+    ) {
+    }
+
+    private record UserResolution(
+            User user,
+            boolean newUser
+    ) {
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/JwtTokenProvider.java
@@ -1,0 +1,238 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class JwtTokenProvider {
+
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
+
+    private final ObjectMapper objectMapper;
+    private final String secret;
+    private final String issuer;
+
+    public JwtTokenProvider(
+            ObjectMapper objectMapper,
+            @Value("${app.auth.jwt.secret:}") String secret,
+            @Value("${app.auth.jwt.issuer:bread-diary}") String issuer
+    ) {
+        this.objectMapper = objectMapper;
+        this.secret = secret;
+        this.issuer = issuer;
+    }
+
+    public String createAccessToken(
+            UUID userId,
+            UUID sessionId,
+            LocalDateTime issuedAt,
+            LocalDateTime expiresAt
+    ) {
+        return createToken(userId, sessionId, "access", null, issuedAt, expiresAt);
+    }
+
+    public String createRefreshToken(
+            UUID userId,
+            UUID sessionId,
+            String jti,
+            LocalDateTime issuedAt,
+            LocalDateTime expiresAt
+    ) {
+        return createToken(userId, sessionId, "refresh", jti, issuedAt, expiresAt);
+    }
+
+    public JwtTokenClaims parseToken(String token) {
+        validateSecretConfigured();
+
+        String[] segments = splitToken(token);
+        String unsignedToken = segments[0] + "." + segments[1];
+        String actualSignature = sign(unsignedToken);
+
+        if (!MessageDigest.isEqual(
+                actualSignature.getBytes(StandardCharsets.UTF_8),
+                segments[2].getBytes(StandardCharsets.UTF_8)
+        )) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+        }
+
+        Map<String, Object> claims = readClaims(segments[1]);
+        validateIssuer(claims.get("iss"));
+
+        return new JwtTokenClaims(
+                UUID.fromString(requiredStringClaim(claims, "sub")),
+                UUID.fromString(requiredStringClaim(claims, "sid")),
+                requiredStringClaim(claims, "type"),
+                optionalStringClaim(claims, "jti"),
+                toLocalDateTime(claims.get("iat")),
+                toLocalDateTime(claims.get("exp"))
+        );
+    }
+
+    private String createToken(
+            UUID userId,
+            UUID sessionId,
+            String type,
+            String jti,
+            LocalDateTime issuedAt,
+            LocalDateTime expiresAt
+    ) {
+        validateSecretConfigured();
+
+        try {
+            String encodedHeader = encodeJson(Map.of(
+                    "alg", "HS256",
+                    "typ", "JWT"
+            ));
+
+            Map<String, Object> claims = new LinkedHashMap<>();
+            claims.put("iss", issuer);
+            claims.put("sub", userId.toString());
+            claims.put("sid", sessionId.toString());
+            claims.put("type", type);
+            claims.put("iat", toEpochSecond(issuedAt));
+            claims.put("exp", toEpochSecond(expiresAt));
+
+            if (StringUtils.hasText(jti)) {
+                claims.put("jti", jti);
+            }
+
+            String encodedPayload = encodeJson(claims);
+            String unsignedToken = encodedHeader + "." + encodedPayload;
+
+            return unsignedToken + "." + sign(unsignedToken);
+        } catch (JsonProcessingException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "JWT 생성에 실패했습니다.",
+                    exception
+            );
+        }
+    }
+
+    private String encodeJson(Map<String, Object> value) throws JsonProcessingException {
+        return URL_ENCODER.encodeToString(
+                objectMapper.writeValueAsBytes(value)
+        );
+    }
+
+    private String[] splitToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰이 비어 있습니다.");
+        }
+
+        String[] segments = token.split("\\.");
+        if (segments.length != 3) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰 형식이 올바르지 않습니다.");
+        }
+        return segments;
+    }
+
+    private Map<String, Object> readClaims(String payloadSegment) {
+        try {
+            return objectMapper.readValue(
+                    URL_DECODER.decode(payloadSegment),
+                    new TypeReference<>() {
+                    }
+            );
+        } catch (IllegalArgumentException | IOException exception) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰 해석에 실패했습니다.", exception);
+        }
+    }
+
+    private String sign(String unsignedToken) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+
+            return URL_ENCODER.encodeToString(
+                    mac.doFinal(unsignedToken.getBytes(StandardCharsets.UTF_8))
+            );
+        } catch (GeneralSecurityException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "JWT 서명 생성에 실패했습니다.",
+                    exception
+            );
+        }
+    }
+
+    private void validateIssuer(Object issuerClaim) {
+        String tokenIssuer = issuerClaim == null ? null : issuerClaim.toString();
+
+        if (!StringUtils.hasText(tokenIssuer) || !issuer.equals(tokenIssuer)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰 발급자가 올바르지 않습니다.");
+        }
+    }
+
+    private String requiredStringClaim(Map<String, Object> claims, String key) {
+        String value = optionalStringClaim(claims, key);
+        if (!StringUtils.hasText(value)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰 claim이 올바르지 않습니다.");
+        }
+        return value;
+    }
+
+    private String optionalStringClaim(Map<String, Object> claims, String key) {
+        Object value = claims.get(key);
+        return value == null ? null : value.toString();
+    }
+
+    private long toEpochSecond(LocalDateTime value) {
+        return value.toEpochSecond(ZoneOffset.UTC);
+    }
+
+    private LocalDateTime toLocalDateTime(Object value) {
+        if (!(value instanceof Number number)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰 시간 claim이 올바르지 않습니다.");
+        }
+
+        return LocalDateTime.ofInstant(
+                Instant.ofEpochSecond(number.longValue()),
+                ZoneOffset.UTC
+        );
+    }
+
+    private void validateSecretConfigured() {
+        if (!StringUtils.hasText(secret)) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "JWT secret 설정이 필요합니다."
+            );
+        }
+    }
+
+    public record JwtTokenClaims(
+            UUID userId,
+            UUID sessionId,
+            String type,
+            String jti,
+            LocalDateTime issuedAt,
+            LocalDateTime expiresAt
+    ) {
+        public boolean isExpiredAt(LocalDateTime now) {
+            LocalDateTime targetTime = now == null ? LocalDateTime.now(ZoneOffset.UTC) : now;
+            return !expiresAt.isAfter(targetTime);
+        }
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/service/TossUserInfoDecryptor.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/TossUserInfoDecryptor.java
@@ -1,0 +1,71 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Service
+public class TossUserInfoDecryptor {
+
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final int GCM_IV_LENGTH_BYTES = 12;
+
+    private final String decryptionKey;
+    private final String additionalAuthenticatedData;
+
+    public TossUserInfoDecryptor(
+            @Value("${app.auth.toss.decryption-key:}") String decryptionKey,
+            @Value("${app.auth.toss.aad:}") String additionalAuthenticatedData
+    ) {
+        this.decryptionKey = decryptionKey;
+        this.additionalAuthenticatedData = additionalAuthenticatedData;
+    }
+
+    public String decryptNullable(String encryptedValue) {
+        if (!StringUtils.hasText(encryptedValue)) {
+            return null;
+        }
+
+        if (!isConfigured()) {
+            return null;
+        }
+
+        try {
+            byte[] decodedCipherText = Base64.getDecoder().decode(encryptedValue);
+            byte[] iv = Arrays.copyOfRange(decodedCipherText, 0, GCM_IV_LENGTH_BYTES);
+            byte[] cipherText = Arrays.copyOfRange(decodedCipherText, GCM_IV_LENGTH_BYTES, decodedCipherText.length);
+
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(
+                    Cipher.DECRYPT_MODE,
+                    new SecretKeySpec(Base64.getDecoder().decode(decryptionKey), "AES"),
+                    new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+            );
+            cipher.updateAAD(additionalAuthenticatedData.getBytes(StandardCharsets.UTF_8));
+
+            String decryptedValue = new String(cipher.doFinal(cipherText), StandardCharsets.UTF_8).trim();
+            return StringUtils.hasText(decryptedValue) ? decryptedValue : null;
+        } catch (IllegalArgumentException | GeneralSecurityException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "토스 사용자 정보 복호화에 실패했습니다.",
+                    exception
+            );
+        }
+    }
+
+    public boolean isConfigured() {
+        return StringUtils.hasText(decryptionKey)
+                && StringUtils.hasText(additionalAuthenticatedData);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/user/entity/User.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/entity/User.java
@@ -27,8 +27,10 @@ import java.util.UUID;
 @Table(
         name = "users",
         indexes = {
+                @Index(name = "idx_users_toss_user_key", columnList = "toss_user_key", unique = true),
                 @Index(name = "idx_users_email", columnList = "email", unique = true),
-                @Index(name = "idx_users_nickname", columnList = "nickname")
+                @Index(name = "idx_users_nickname", columnList = "nickname"),
+                @Index(name = "idx_users_deleted_at", columnList = "deleted_at")
         }
 )
 @EntityListeners(AuditingEntityListener.class)
@@ -46,7 +48,10 @@ public class User {
     @Column(name = "nickname", length = 30, nullable = false)
     private String nickname;
 
-    @Column(name = "email", length = 255, nullable = false, unique = true)
+    @Column(name = "toss_user_key", length = 100, unique = true)
+    private String tossUserKey;
+
+    @Column(name = "email", length = 255, unique = true)
     private String email;
 
     @Column(name = "profile_image_url", length = 500)
@@ -55,6 +60,9 @@ public class User {
     @Column(name = "bio", length = 500)
     private String bio;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -62,4 +70,31 @@ public class User {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void updateFromToss(
+            String tossUserKey,
+            String nickname,
+            String email
+    ) {
+        this.tossUserKey = tossUserKey;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    public void activate(
+            String tossUserKey,
+            String nickname,
+            String email
+    ) {
+        updateFromToss(tossUserKey, nickname, email);
+        this.deletedAt = null;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/repository/UserRepository.java
@@ -3,7 +3,18 @@ package com.bean.breaddiary.domain.user.repository;
 import com.bean.breaddiary.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findByIdAndDeletedAtIsNull(UUID id);
+
+    Optional<User> findByTossUserKeyAndDeletedAtIsNull(String tossUserKey);
+
+    Optional<User> findByTossUserKey(String tossUserKey);
+
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
@@ -31,7 +31,7 @@ public class UserService {
     }
 
     public User getUserById(UUID userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
                         "해당 사용자를 찾을 수 없습니다."

--- a/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,93 @@
+package com.bean.breaddiary.domain.auth.controller;
+
+import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
+import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
+import com.bean.breaddiary.domain.auth.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthControllerTest {
+
+    private AuthService authService;
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        authService = mock(AuthService.class);
+        objectMapper = snakeCaseObjectMapper();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new AuthController(authService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void loginWithTossBindsSnakeCaseRequestAndSerializesSnakeCaseResponse() throws Exception {
+        AuthTokenResponse response = new AuthTokenResponse(
+                UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                "our-access-token",
+                "our-refresh-token",
+                "Bearer",
+                LocalDateTime.of(2026, 4, 19, 10, 0),
+                LocalDateTime.of(2026, 5, 18, 10, 0),
+                true
+        );
+
+        when(authService.loginWithToss(any(TossLoginRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/auth/toss")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "authorization_code": "auth-code",
+                                  "referrer": "DEFAULT"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.user_id").value("550e8400-e29b-41d4-a716-446655440000"))
+                .andExpect(jsonPath("$.data.access_token").value("our-access-token"))
+                .andExpect(jsonPath("$.data.refresh_token").value("our-refresh-token"))
+                .andExpect(jsonPath("$.data.token_type").value("Bearer"))
+                .andExpect(jsonPath("$.data.access_token_expires_at").value("2026-04-19T10:00:00"))
+                .andExpect(jsonPath("$.data.refresh_token_expires_at").value("2026-05-18T10:00:00"))
+                .andExpect(jsonPath("$.data.new_user").value(true))
+                .andExpect(jsonPath("$.data.userId").doesNotExist())
+                .andExpect(jsonPath("$.data.accessToken").doesNotExist());
+
+        ArgumentCaptor<TossLoginRequest> requestCaptor = ArgumentCaptor.forClass(TossLoginRequest.class);
+        verify(authService).loginWithToss(requestCaptor.capture());
+        assertEquals("auth-code", requestCaptor.getValue().getAuthorizationCode());
+        assertEquals("DEFAULT", requestCaptor.getValue().getReferrer());
+    }
+
+    private ObjectMapper snakeCaseObjectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,359 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import com.bean.breaddiary.domain.auth.client.TossAuthClient;
+import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
+import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthServiceTest {
+
+    private UserRepository userRepository;
+    private UserSessionService userSessionService;
+    private JwtTokenProvider jwtTokenProvider;
+    private TossAuthClient tossAuthClient;
+    private TossUserInfoDecryptor tossUserInfoDecryptor;
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userSessionService = mock(UserSessionService.class);
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        tossAuthClient = mock(TossAuthClient.class);
+        tossUserInfoDecryptor = mock(TossUserInfoDecryptor.class);
+        authService = new AuthService(
+                userRepository,
+                userSessionService,
+                jwtTokenProvider,
+                tossAuthClient,
+                tossUserInfoDecryptor
+        );
+    }
+
+    @Test
+    void loginWithTossCreatesNewUserAndIssuesTokens() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        LocalDateTime accessExpiresAt = LocalDateTime.of(2026, 4, 19, 10, 0);
+        LocalDateTime refreshExpiresAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+        TossLoginRequest request = new TossLoginRequest("auth-code", "DEFAULT");
+
+        when(tossAuthClient.exchangeAuthorizationCode("auth-code", "DEFAULT"))
+                .thenReturn(new TossAuthClient.TossGenerateTokenSuccess(
+                        "toss-access-token",
+                        "toss-refresh-token",
+                        "bearer",
+                        3600L,
+                        "profile"
+                ));
+        when(tossAuthClient.getUserInfo("toss-access-token"))
+                .thenReturn(new TossAuthClient.TossLoginMeSuccess(
+                        TextNode.valueOf("toss-user-key-12345678"),
+                        "encrypted-name",
+                        "encrypted-email"
+                ));
+        when(tossUserInfoDecryptor.decryptNullable("encrypted-name"))
+                .thenReturn("Bread Lover");
+        when(tossUserInfoDecryptor.decryptNullable("encrypted-email"))
+                .thenReturn("bread@toss.im");
+        when(userRepository.findByTossUserKey("toss-user-key-12345678"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("bread@toss.im"))
+                .thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class)))
+                .thenAnswer(invocation -> {
+                    User user = invocation.getArgument(0);
+                    return User.builder()
+                            .id(userId)
+                            .tossUserKey(user.getTossUserKey())
+                            .nickname(user.getNickname())
+                            .email(user.getEmail())
+                            .build();
+                });
+        when(userSessionService.createSession(
+                eq(userId),
+                eq("__PENDING_REFRESH_TOKEN__"),
+                anyString(),
+                any(LocalDateTime.class)
+        )).thenReturn(UserSession.builder()
+                .id(sessionId)
+                .userId(userId)
+                .refreshTokenHash("__PENDING_REFRESH_TOKEN__")
+                .currentJti("initial-jti")
+                .refreshExpiresAt(refreshExpiresAt)
+                .build());
+        when(userSessionService.calculateAccessTokenExpiresAt(any(LocalDateTime.class)))
+                .thenReturn(accessExpiresAt);
+        when(userSessionService.calculateRefreshTokenExpiresAt(any(LocalDateTime.class)))
+                .thenReturn(refreshExpiresAt);
+        when(jwtTokenProvider.createAccessToken(
+                eq(userId),
+                eq(sessionId),
+                any(LocalDateTime.class),
+                eq(accessExpiresAt)
+        )).thenReturn("our-access-token");
+        when(jwtTokenProvider.createRefreshToken(
+                eq(userId),
+                eq(sessionId),
+                anyString(),
+                any(LocalDateTime.class),
+                eq(refreshExpiresAt)
+        )).thenReturn("our-refresh-token");
+
+        AuthTokenResponse actual = authService.loginWithToss(request);
+
+        assertEquals(userId, actual.getUserId());
+        assertEquals("our-access-token", actual.getAccessToken());
+        assertEquals("our-refresh-token", actual.getRefreshToken());
+        assertEquals("Bearer", actual.getTokenType());
+        assertEquals(accessExpiresAt, actual.getAccessTokenExpiresAt());
+        assertEquals(refreshExpiresAt, actual.getRefreshTokenExpiresAt());
+        assertTrue(actual.isNewUser());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertEquals("toss-user-key-12345678", userCaptor.getValue().getTossUserKey());
+        assertEquals("Bread Lover", userCaptor.getValue().getNickname());
+        assertEquals("bread@toss.im", userCaptor.getValue().getEmail());
+
+        ArgumentCaptor<String> refreshHashCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userSessionService).rotateRefreshToken(
+                any(UserSession.class),
+                refreshHashCaptor.capture(),
+                anyString(),
+                any(LocalDateTime.class)
+        );
+        assertNotEquals("our-refresh-token", refreshHashCaptor.getValue());
+    }
+
+    @Test
+    void loginWithTossReactivatesDeletedUserFoundByTossUserKey() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440003");
+        LocalDateTime accessExpiresAt = LocalDateTime.of(2026, 4, 19, 10, 0);
+        LocalDateTime refreshExpiresAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+        User deletedUser = User.builder()
+                .id(userId)
+                .tossUserKey("toss-user-key-87654321")
+                .nickname("old-name")
+                .email("old@toss.im")
+                .deletedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build();
+
+        prepareSuccessfulLogin(
+                "toss-user-key-87654321",
+                "Fresh Name",
+                "fresh@toss.im",
+                userId,
+                sessionId,
+                accessExpiresAt,
+                refreshExpiresAt
+        );
+        when(userRepository.findByTossUserKey("toss-user-key-87654321"))
+                .thenReturn(Optional.of(deletedUser));
+
+        AuthTokenResponse actual = authService.loginWithToss(
+                new TossLoginRequest("auth-code", "DEFAULT")
+        );
+
+        assertFalse(actual.isNewUser());
+        assertFalse(deletedUser.isDeleted());
+        assertEquals("Fresh Name", deletedUser.getNickname());
+        assertEquals("fresh@toss.im", deletedUser.getEmail());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void loginWithTossLinksLegacyUserFoundByEmail() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440004");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440005");
+        LocalDateTime accessExpiresAt = LocalDateTime.of(2026, 4, 19, 10, 0);
+        LocalDateTime refreshExpiresAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+        User existingUser = User.builder()
+                .id(userId)
+                .nickname("legacy-user")
+                .email("legacy@toss.im")
+                .build();
+
+        prepareSuccessfulLogin(
+                "toss-user-key-99999999",
+                "legacy-user",
+                "legacy@toss.im",
+                userId,
+                sessionId,
+                accessExpiresAt,
+                refreshExpiresAt
+        );
+        when(userRepository.findByTossUserKey("toss-user-key-99999999"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail("legacy@toss.im"))
+                .thenReturn(Optional.of(existingUser));
+
+        AuthTokenResponse actual = authService.loginWithToss(
+                new TossLoginRequest("auth-code", "DEFAULT")
+        );
+
+        assertFalse(actual.isNewUser());
+        assertEquals("toss-user-key-99999999", existingUser.getTossUserKey());
+        assertEquals("legacy@toss.im", existingUser.getEmail());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void loginWithTossUsesFallbackNicknameWhenDecryptionConfigIsMissing() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440006");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440007");
+        LocalDateTime accessExpiresAt = LocalDateTime.of(2026, 4, 19, 10, 0);
+        LocalDateTime refreshExpiresAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+        when(tossAuthClient.exchangeAuthorizationCode("auth-code", "DEFAULT"))
+                .thenReturn(new TossAuthClient.TossGenerateTokenSuccess(
+                        "toss-access-token",
+                        "toss-refresh-token",
+                        "bearer",
+                        3600L,
+                        "profile"
+                ));
+        when(tossAuthClient.getUserInfo("toss-access-token"))
+                .thenReturn(new TossAuthClient.TossLoginMeSuccess(
+                        TextNode.valueOf("toss-user-key-fallback"),
+                        "encrypted-name",
+                        null
+                ));
+        when(tossUserInfoDecryptor.decryptNullable("encrypted-name"))
+                .thenReturn(null);
+        when(userRepository.findByTossUserKey("toss-user-key-fallback"))
+                .thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class)))
+                .thenAnswer(invocation -> {
+                    User user = invocation.getArgument(0);
+                    return User.builder()
+                            .id(userId)
+                            .tossUserKey(user.getTossUserKey())
+                            .nickname(user.getNickname())
+                            .email(user.getEmail())
+                            .build();
+                });
+        when(userSessionService.createSession(
+                eq(userId),
+                eq("__PENDING_REFRESH_TOKEN__"),
+                anyString(),
+                any(LocalDateTime.class)
+        )).thenReturn(UserSession.builder()
+                .id(sessionId)
+                .userId(userId)
+                .refreshTokenHash("__PENDING_REFRESH_TOKEN__")
+                .currentJti("initial-jti")
+                .refreshExpiresAt(refreshExpiresAt)
+                .build());
+        when(userSessionService.calculateAccessTokenExpiresAt(any(LocalDateTime.class)))
+                .thenReturn(accessExpiresAt);
+        when(userSessionService.calculateRefreshTokenExpiresAt(any(LocalDateTime.class)))
+                .thenReturn(refreshExpiresAt);
+        when(jwtTokenProvider.createAccessToken(
+                eq(userId),
+                eq(sessionId),
+                any(LocalDateTime.class),
+                eq(accessExpiresAt)
+        )).thenReturn("our-access-token");
+        when(jwtTokenProvider.createRefreshToken(
+                eq(userId),
+                eq(sessionId),
+                anyString(),
+                any(LocalDateTime.class),
+                eq(refreshExpiresAt)
+        )).thenReturn("our-refresh-token");
+
+        AuthTokenResponse actual = authService.loginWithToss(
+                new TossLoginRequest("auth-code", "DEFAULT")
+        );
+
+        assertTrue(actual.isNewUser());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertTrue(userCaptor.getValue().getNickname().startsWith("toss-"));
+        assertNull(userCaptor.getValue().getEmail());
+    }
+
+    private void prepareSuccessfulLogin(
+            String tossUserKey,
+            String decryptedName,
+            String decryptedEmail,
+            UUID userId,
+            UUID sessionId,
+            LocalDateTime accessExpiresAt,
+            LocalDateTime refreshExpiresAt
+    ) {
+        when(tossAuthClient.exchangeAuthorizationCode("auth-code", "DEFAULT"))
+                .thenReturn(new TossAuthClient.TossGenerateTokenSuccess(
+                        "toss-access-token",
+                        "toss-refresh-token",
+                        "bearer",
+                        3600L,
+                        "profile"
+                ));
+        when(tossAuthClient.getUserInfo("toss-access-token"))
+                .thenReturn(new TossAuthClient.TossLoginMeSuccess(
+                        TextNode.valueOf(tossUserKey),
+                        "encrypted-name",
+                        "encrypted-email"
+                ));
+        when(tossUserInfoDecryptor.decryptNullable("encrypted-name"))
+                .thenReturn(decryptedName);
+        when(tossUserInfoDecryptor.decryptNullable("encrypted-email"))
+                .thenReturn(decryptedEmail);
+        when(userSessionService.createSession(
+                eq(userId),
+                eq("__PENDING_REFRESH_TOKEN__"),
+                anyString(),
+                any(LocalDateTime.class)
+        )).thenReturn(UserSession.builder()
+                .id(sessionId)
+                .userId(userId)
+                .refreshTokenHash("__PENDING_REFRESH_TOKEN__")
+                .currentJti("initial-jti")
+                .refreshExpiresAt(refreshExpiresAt)
+                .build());
+        when(userSessionService.calculateAccessTokenExpiresAt(any(LocalDateTime.class)))
+                .thenReturn(accessExpiresAt);
+        when(userSessionService.calculateRefreshTokenExpiresAt(any(LocalDateTime.class)))
+                .thenReturn(refreshExpiresAt);
+        when(jwtTokenProvider.createAccessToken(
+                eq(userId),
+                eq(sessionId),
+                any(LocalDateTime.class),
+                eq(accessExpiresAt)
+        )).thenReturn("our-access-token");
+        when(jwtTokenProvider.createRefreshToken(
+                eq(userId),
+                eq(sessionId),
+                anyString(),
+                any(LocalDateTime.class),
+                eq(refreshExpiresAt)
+        )).thenReturn("our-refresh-token");
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/JwtTokenProviderTest.java
@@ -1,0 +1,72 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider(
+                new ObjectMapper(),
+                "test-secret-key",
+                "bread-diary"
+        );
+    }
+
+    @Test
+    void createAndParseAccessTokenContainsRequiredClaims() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        LocalDateTime issuedAt = LocalDateTime.of(2026, 4, 18, 10, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 4, 19, 10, 0);
+
+        String token = jwtTokenProvider.createAccessToken(
+                userId,
+                sessionId,
+                issuedAt,
+                expiresAt
+        );
+        JwtTokenProvider.JwtTokenClaims claims = jwtTokenProvider.parseToken(token);
+
+        assertEquals(userId, claims.userId());
+        assertEquals(sessionId, claims.sessionId());
+        assertEquals("access", claims.type());
+        assertNull(claims.jti());
+        assertEquals(issuedAt, claims.issuedAt());
+        assertEquals(expiresAt, claims.expiresAt());
+    }
+
+    @Test
+    void createAndParseRefreshTokenContainsJti() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440003");
+        LocalDateTime issuedAt = LocalDateTime.of(2026, 4, 18, 10, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 5, 18, 10, 0);
+
+        String token = jwtTokenProvider.createRefreshToken(
+                userId,
+                sessionId,
+                "refresh-jti",
+                issuedAt,
+                expiresAt
+        );
+        JwtTokenProvider.JwtTokenClaims claims = jwtTokenProvider.parseToken(token);
+
+        assertEquals(userId, claims.userId());
+        assertEquals(sessionId, claims.sessionId());
+        assertEquals("refresh", claims.type());
+        assertEquals("refresh-jti", claims.jti());
+        assertTrue(claims.isExpiredAt(LocalDateTime.of(2026, 5, 18, 10, 0)));
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/service/UserServiceTest.java
@@ -49,7 +49,7 @@ class UserServiceTest {
                 .createdAt(LocalDateTime.of(2026, 4, 1, 0, 0))
                 .build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
         when(breadRecordRepository.findUserStatsByUserId(userId))
                 .thenReturn(createProjection(42L, 18L, 4.25));
 
@@ -63,7 +63,7 @@ class UserServiceTest {
         assertEquals(18L, actual.getStats().getUniqueShops());
         assertEquals(4.3, actual.getStats().getAvgRating());
 
-        verify(userRepository).findById(userId);
+        verify(userRepository).findByIdAndDeletedAtIsNull(userId);
         verify(breadRecordRepository).findUserStatsByUserId(userId);
     }
 
@@ -85,7 +85,7 @@ class UserServiceTest {
     void getUserByIdThrowsNotFoundWhenUserDoesNotExist() {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
 
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,


### PR DESCRIPTION
## 🧩 관련 이슈

- #33 

#### 💡 작업 내용

토스 OAuth 기반 로그인/회원가입과 JWT 발급 로직을 구현한다.
이번 작업은 `feat/<issue-number>-auth-login` 브랜치에서 진행하며, `feat/<issue-number>-auth-session-domain` 이 반영된 상태를 기준으로 한다.
기존 `bread / breadrecord / user / auth` 구현과 `AGENTS.md`, `docs/user-part-spec.md`를 먼저 읽고, 현재 프로젝트 스타일에 맞춰 최소 수정 방식으로 이어서 작업한다.

### 📢 참고 사항

- Spring Security는 사용하지 않는다.
- Access Token 만료 시간은 1일이다.
- Refresh Token 만료 시간은 30일이다.
- 로그인 성공 시 Access / Refresh Token을 함께 발급한다.
- 세션은 `UserSession` 기준으로 생성한다.
- refresh token 은 저장 전에 hash 처리한다.
- tossUserKey 는 반드시 저장한다.
- 향후 unlink / withdrawal webhook 처리 시 tossUserKey 로 사용자를 찾을 수 있어야 한다.
- 신규 가입 / 기존 로그인 분기 시 deletedAt 처리 정책을 코드상 자연스럽게 반영한다.
- 아직 refresh / logout / interceptor 는 이번 브랜치에서 과하게 확장하지 않는다.
- Swagger 설명은 필요한 최소 수준만 유지한다.


## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인