### PR TITLE
feat: add auth access token interceptor

### DIFF
--- a/docs/codex-prompts-user/auth-interceptor.txt
+++ b/docs/codex-prompts-user/auth-interceptor.txt
@@ -1,5 +1,5 @@
-현재 작업 브랜치는 feat/<issue-number>-auth-interceptor 이다.
-이 작업은 feat/<issue-number>-auth-refresh-logout 이 반영된 상태를 기준으로 한다.
+현재 작업 브랜치는 feat/36-auth-interceptor 이다.
+이 작업은 feat/36-auth-refresh-logout 이 반영된 상태를 기준으로 한다.
 
 기존 bread / breadrecord / user / auth 구현, AGENTS.md, docs/user-part-spec.md를 먼저 읽고 같은 스타일로 최소 수정 방식으로 이어서 작업해라.
 

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordController.java
@@ -3,44 +3,36 @@ package com.bean.breaddiary.domain.breadrecord.controller;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
-import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
 import com.bean.breaddiary.global.common.ApiResponse;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
-/**
- * packageName    : com.bean.breaddiary.domain.breadrecord.controller<br>
- * fileName       : BreadRecordController.java<br>
- * description    : BreadRecord entity 요청을 처리하는 controller 클래스입니다.<br>
- * ===========================================================<br>
- * DATE              AUTHOR             NOTE<br>
- * -----------------------------------------------------------<br>
- * 26.04.16          haelim             최초 생성<br>
- */
 @Tag(name = "빵 기록 API", description = "빵 기록을 관리하는 API입니다.")
 @Validated
 @RestController
@@ -48,13 +40,11 @@ import java.util.UUID;
 @RequestMapping("/breads")
 public class BreadRecordController {
 
-    private static final UUID DUMMY_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
-
     private final BreadRecordComplexService breadRecordComplexService;
 
     @Operation(
             summary = "개별 빵 기록 상세 조회",
-            description = "빵 기록 ID 기준으로 개별 기록 상세와 카탈로그 빵 정보를 조회합니다."
+            description = "빵 기록 ID 기준으로 개별 기록 상세를 조회합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -62,6 +52,7 @@ public class BreadRecordController {
                     description = "빵 기록 상세 조회 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordDetailResponse.class))
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 기록을 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
@@ -70,27 +61,19 @@ public class BreadRecordController {
     public ResponseEntity<ApiResponse<BreadRecordDetailResponse>> getBreadRecord(
             @Parameter(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
             @PathVariable UUID recordId,
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+            @Parameter(hidden = true) HttpServletRequest request
     ) {
         BreadRecordDetailResponse response = breadRecordComplexService.getBreadRecord(
-                resolveUserId(userId),
+                resolveUserId(request),
                 recordId
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /**
-     * 카탈로그에 존재하는 빵에 대해 새 기록을 생성합니다.
-     *
-     * @param userId 임시 사용자 ID
-     * @param request 기존 빵 기록 생성 요청
-     * @return 생성된 빵 기록 정보
-     */
     @Operation(
             summary = "기존 빵 기록 생성",
-            description = "카탈로그에 이미 존재하는 빵에 대해 새 기록을 생성합니다. multipart/form-data 필드명은 명세서와 동일하게 snake_case를 사용합니다."
+            description = "카탈로그에 있는 빵으로 기록을 생성합니다. multipart/form-data 필드는 snake_case를 사용합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -98,35 +81,28 @@ public class BreadRecordController {
                     description = "빵 기록 생성 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordCreateResponse.class))
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 카탈로그를 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<BreadRecordCreateResponse>> createBreadRecord(
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
-            @Valid @ModelAttribute CreateBreadRecordRequest request
+            @Parameter(hidden = true) HttpServletRequest request,
+            @Valid @ModelAttribute CreateBreadRecordRequest createBreadRecordRequest
     ) {
         BreadRecordCreateResponse response = breadRecordComplexService.createBreadRecord(
-                resolveUserId(userId),
-                request
+                resolveUserId(request),
+                createBreadRecordRequest
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
     }
 
-    /**
-     * 카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다.
-     *
-     * @param userId 임시 사용자 ID
-     * @param request 신규 빵 기록 생성 요청
-     * @return 생성된 빵 기록 정보
-     */
     @Operation(
             summary = "신규 빵 추가 및 기록 생성",
-            description = "카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다. multipart/form-data 필드명은 명세서와 동일하게 snake_case를 사용합니다."
+            description = "카탈로그에 없는 신규 빵을 추가하고 첫 기록을 생성합니다. multipart/form-data 필드는 snake_case를 사용합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -134,19 +110,19 @@ public class BreadRecordController {
                     description = "신규 빵 및 기록 생성 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordCreateResponse.class))
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "중복된 빵 이름"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PostMapping(path = "/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<BreadRecordCreateResponse>> createNewBreadRecord(
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
-            @Valid @ModelAttribute CreateNewBreadRecordRequest request
+            @Parameter(hidden = true) HttpServletRequest request,
+            @Valid @ModelAttribute CreateNewBreadRecordRequest createNewBreadRecordRequest
     ) {
         BreadRecordCreateResponse response = breadRecordComplexService.createNewBreadRecord(
-                resolveUserId(userId),
-                request
+                resolveUserId(request),
+                createNewBreadRecordRequest
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -155,7 +131,7 @@ public class BreadRecordController {
 
     @Operation(
             summary = "개별 빵 기록 수정",
-            description = "빵 기록 ID 기준으로 변경된 필드만 수정합니다. bread_id, name, bread_type은 수정할 수 없습니다."
+            description = "빵 기록 ID 기준으로 변경한 필드만 수정합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -163,6 +139,7 @@ public class BreadRecordController {
                     description = "빵 기록 수정 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordDetailResponse.class))
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 기록을 찾을 수 없음"),
@@ -172,14 +149,13 @@ public class BreadRecordController {
     public ResponseEntity<ApiResponse<BreadRecordDetailResponse>> updateBreadRecord(
             @Parameter(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
             @PathVariable UUID recordId,
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId,
-            @Valid @ModelAttribute UpdateBreadRecordRequest request
+            @Parameter(hidden = true) HttpServletRequest request,
+            @Valid @ModelAttribute UpdateBreadRecordRequest updateBreadRecordRequest
     ) {
         BreadRecordDetailResponse response = breadRecordComplexService.updateBreadRecord(
-                resolveUserId(userId),
+                resolveUserId(request),
                 recordId,
-                request
+                updateBreadRecordRequest
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -187,7 +163,7 @@ public class BreadRecordController {
 
     @Operation(
             summary = "개별 빵 기록 삭제",
-            description = "빵 기록 ID 기준으로 기록을 소프트 삭제하고 스티커 제거 여부를 반환합니다."
+            description = "빵 기록 ID 기준으로 기록을 삭제하고 스티커 제거 여부를 반환합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -195,6 +171,7 @@ public class BreadRecordController {
                     description = "빵 기록 삭제 성공",
                     content = @Content(schema = @Schema(implementation = BreadRecordDeleteResponse.class))
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "빵 기록을 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
@@ -203,18 +180,17 @@ public class BreadRecordController {
     public ResponseEntity<ApiResponse<BreadRecordDeleteResponse>> deleteBreadRecord(
             @Parameter(description = "빵 기록 ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
             @PathVariable UUID recordId,
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+            @Parameter(hidden = true) HttpServletRequest request
     ) {
         BreadRecordDeleteResponse response = breadRecordComplexService.deleteBreadRecord(
-                resolveUserId(userId),
+                resolveUserId(request),
                 recordId
         );
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    private UUID resolveUserId(UUID userId) {
-        return userId == null ? DUMMY_USER_ID : userId;
+    private UUID resolveUserId(HttpServletRequest request) {
+        return AuthRequestAttributes.getRequiredUserId(request);
     }
 }

--- a/src/main/java/com/bean/breaddiary/global/config/WebConfig.java
+++ b/src/main/java/com/bean/breaddiary/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.bean.breaddiary.global.config;
+
+import com.bean.breaddiary.global.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**");
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
@@ -1,0 +1,133 @@
+package com.bean.breaddiary.global.interceptor;
+
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.auth.service.JwtTokenProvider;
+import com.bean.breaddiary.domain.auth.service.UserSessionService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ACCESS_TOKEN_TYPE = "access";
+    private static final String HTTP_GET = "GET";
+    private static final String HTTP_OPTIONS = "OPTIONS";
+    private static final String HTTP_POST = "POST";
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserSessionService userSessionService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (!requiresAuthentication(request)) {
+            return true;
+        }
+
+        String accessToken = resolveAccessToken(request);
+        LocalDateTime now = LocalDateTime.now();
+        JwtTokenProvider.JwtTokenClaims claims = jwtTokenProvider.parseToken(accessToken);
+
+        validateAccessToken(claims, now);
+
+        UserSession userSession = userSessionService.findActiveSession(claims.sessionId(), now)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        "유효한 세션이 없습니다."
+                ));
+
+        if (!userSession.getUserId().equals(claims.userId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "세션 사용자 정보가 올바르지 않습니다."
+            );
+        }
+
+        request.setAttribute(AuthRequestAttributes.USER_ID, claims.userId());
+        request.setAttribute(AuthRequestAttributes.SESSION_ID, claims.sessionId());
+        return true;
+    }
+
+    private boolean requiresAuthentication(HttpServletRequest request) {
+        String method = request.getMethod();
+        String requestUri = request.getRequestURI();
+
+        if (HTTP_OPTIONS.equalsIgnoreCase(method)) {
+            return false;
+        }
+
+        if ("/error".equals(requestUri)
+                || "/swagger-ui.html".equals(requestUri)
+                || PATH_MATCHER.match("/swagger-ui/**", requestUri)
+                || PATH_MATCHER.match("/v3/api-docs/**", requestUri)) {
+            return false;
+        }
+
+        if (HTTP_POST.equalsIgnoreCase(method)
+                && ("/auth/toss".equals(requestUri) || "/auth/refresh".equals(requestUri))) {
+            return false;
+        }
+
+        if (HTTP_GET.equalsIgnoreCase(method) && "/bread-types".equals(requestUri)) {
+            return false;
+        }
+
+        if (HTTP_GET.equalsIgnoreCase(method)
+                && ("/breads".equals(requestUri)
+                || "/breads/autocomplete".equals(requestUri)
+                || PATH_MATCHER.match("/breads/catalog/*", requestUri))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "Bearer Access Token이 필요합니다."
+            );
+        }
+
+        String accessToken = authorizationHeader.substring(BEARER_PREFIX.length()).trim();
+        if (!StringUtils.hasText(accessToken)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "Bearer Access Token이 비어 있습니다."
+            );
+        }
+
+        return accessToken;
+    }
+
+    private void validateAccessToken(JwtTokenProvider.JwtTokenClaims claims, LocalDateTime now) {
+        if (!ACCESS_TOKEN_TYPE.equals(claims.type())) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "Access Token만 사용할 수 있습니다."
+            );
+        }
+
+        if (claims.isExpiredAt(now)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "Access Token이 만료되었습니다."
+            );
+        }
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthRequestAttributes.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthRequestAttributes.java
@@ -1,0 +1,34 @@
+package com.bean.breaddiary.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+public final class AuthRequestAttributes {
+
+    public static final String USER_ID = "authenticatedUserId";
+    public static final String SESSION_ID = "authenticatedSessionId";
+
+    private AuthRequestAttributes() {
+    }
+
+    public static UUID getRequiredUserId(HttpServletRequest request) {
+        return getRequiredUuid(request, USER_ID);
+    }
+
+    public static UUID getRequiredSessionId(HttpServletRequest request) {
+        return getRequiredUuid(request, SESSION_ID);
+    }
+
+    private static UUID getRequiredUuid(HttpServletRequest request, String attributeName) {
+        Object value = request.getAttribute(attributeName);
+
+        if (value instanceof UUID uuid) {
+            return uuid;
+        }
+
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
@@ -4,10 +4,11 @@ import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
-import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -39,13 +40,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class BreadRecordControllerContractTest {
 
-    private static final UUID DUMMY_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID AUTHENTICATED_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID RECORD_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    private static final UUID BREAD_ID = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
 
     private BreadRecordComplexService breadRecordComplexService;
     private MockMvc mockMvc;
-
-    private static final UUID RECORD_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-    private static final UUID BREAD_ID = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
 
     @BeforeEach
     void setUp() {
@@ -61,10 +61,11 @@ class BreadRecordControllerContractTest {
         UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
         BreadRecordCreateResponse response = createResponse(breadId, BreadType.PASTRY, false);
 
-        when(breadRecordComplexService.createBreadRecord(eq(DUMMY_USER_ID), any(CreateBreadRecordRequest.class)))
+        when(breadRecordComplexService.createBreadRecord(eq(AUTHENTICATED_USER_ID), any(CreateBreadRecordRequest.class)))
                 .thenReturn(response);
 
         mockMvc.perform(multipart("/breads")
+                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID)
                         .file(new MockMultipartFile(
                                 "photo",
                                 "croissant.webp",
@@ -72,10 +73,10 @@ class BreadRecordControllerContractTest {
                                 "photo".getBytes()
                         ))
                         .param("bread_id", breadId.toString())
-                        .param("shop_name", "르뺑블루 성수점")
+                        .param("shop_name", "루트브레드 성수점")
                         .param("eaten_date", "2026-03-14")
                         .param("rating", "5")
-                        .param("review", "겉은 바삭하고 안은 촉촉해서 완벽했어요."))
+                        .param("review", "겉은 바삭하고 속이 촉촉해서 만족했어요"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.bread_id").value(breadId.toString()))
@@ -83,7 +84,7 @@ class BreadRecordControllerContractTest {
                 .andExpect(jsonPath("$.data.photo_url").value("https://cdn.bread-diary.app/bread-photos/record.webp"))
                 .andExpect(jsonPath("$.data.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
                 .andExpect(jsonPath("$.data.bread_type").value("PASTRY"))
-                .andExpect(jsonPath("$.data.shop_name").value("르뺑블루 성수점"))
+                .andExpect(jsonPath("$.data.shop_name").value("루트브레드 성수점"))
                 .andExpect(jsonPath("$.data.eaten_date").value("2026-03-14"))
                 .andExpect(jsonPath("$.data.is_first_record").value(false))
                 .andExpect(jsonPath("$.data.breadId").doesNotExist())
@@ -91,11 +92,11 @@ class BreadRecordControllerContractTest {
 
         ArgumentCaptor<CreateBreadRecordRequest> requestCaptor =
                 ArgumentCaptor.forClass(CreateBreadRecordRequest.class);
-        verify(breadRecordComplexService).createBreadRecord(eq(DUMMY_USER_ID), requestCaptor.capture());
+        verify(breadRecordComplexService).createBreadRecord(eq(AUTHENTICATED_USER_ID), requestCaptor.capture());
 
         CreateBreadRecordRequest request = requestCaptor.getValue();
         assertEquals(breadId, request.getBreadId());
-        assertEquals("르뺑블루 성수점", request.getShopName());
+        assertEquals("루트브레드 성수점", request.getShopName());
         assertEquals(LocalDate.of(2026, 3, 14), request.getEatenDate());
     }
 
@@ -104,10 +105,11 @@ class BreadRecordControllerContractTest {
         UUID breadId = UUID.fromString("c1d2e3f4-a5b6-7890-cdef-ab0123456789");
         BreadRecordCreateResponse response = createResponse(breadId, BreadType.BAGEL, true);
 
-        when(breadRecordComplexService.createNewBreadRecord(eq(DUMMY_USER_ID), any(CreateNewBreadRecordRequest.class)))
+        when(breadRecordComplexService.createNewBreadRecord(eq(AUTHENTICATED_USER_ID), any(CreateNewBreadRecordRequest.class)))
                 .thenReturn(response);
 
         mockMvc.perform(multipart("/breads/new")
+                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID)
                         .file(new MockMultipartFile(
                                 "photo",
                                 "bagel.webp",
@@ -116,10 +118,10 @@ class BreadRecordControllerContractTest {
                         ))
                         .param("name", "플레인 베이글")
                         .param("bread_type", "BAGEL")
-                        .param("shop_name", "베이글샵")
+                        .param("shop_name", "베이글집")
                         .param("eaten_date", "2026-03-15")
                         .param("rating", "4")
-                        .param("review", "쫄깃했어요."))
+                        .param("review", "쫀득했어요"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.bread_id").value(breadId.toString()))
@@ -129,12 +131,12 @@ class BreadRecordControllerContractTest {
 
         ArgumentCaptor<CreateNewBreadRecordRequest> requestCaptor =
                 ArgumentCaptor.forClass(CreateNewBreadRecordRequest.class);
-        verify(breadRecordComplexService).createNewBreadRecord(eq(DUMMY_USER_ID), requestCaptor.capture());
+        verify(breadRecordComplexService).createNewBreadRecord(eq(AUTHENTICATED_USER_ID), requestCaptor.capture());
 
         CreateNewBreadRecordRequest request = requestCaptor.getValue();
         assertEquals("플레인 베이글", request.getName());
         assertEquals(BreadType.BAGEL, request.getBreadType());
-        assertEquals("베이글샵", request.getShopName());
+        assertEquals("베이글집", request.getShopName());
         assertEquals(LocalDate.of(2026, 3, 15), request.getEatenDate());
     }
 
@@ -142,9 +144,10 @@ class BreadRecordControllerContractTest {
     void getBreadRecordReturnsSpecResponseWithSnakeCaseFields() throws Exception {
         BreadRecordDetailResponse response = createDetailResponse();
 
-        when(breadRecordComplexService.getBreadRecord(DUMMY_USER_ID, RECORD_ID)).thenReturn(response);
+        when(breadRecordComplexService.getBreadRecord(AUTHENTICATED_USER_ID, RECORD_ID)).thenReturn(response);
 
-        mockMvc.perform(get("/breads/{recordId}", RECORD_ID))
+        mockMvc.perform(get("/breads/{recordId}", RECORD_ID)
+                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(RECORD_ID.toString()))
@@ -156,25 +159,26 @@ class BreadRecordControllerContractTest {
                 .andExpect(jsonPath("$.data.image_url").value("https://cdn.bread-diary.app/breads/croissant.webp"))
                 .andExpect(jsonPath("$.data.photo_url").value("https://cdn.bread-diary.app/bread-photos/record.webp"))
                 .andExpect(jsonPath("$.data.photo_thumbnail_url").value("https://cdn.bread-diary.app/bread-photos/record_thumb.webp"))
-                .andExpect(jsonPath("$.data.shop_name").value("르뺑블루 성수점"))
+                .andExpect(jsonPath("$.data.shop_name").value("루트브레드 성수점"))
                 .andExpect(jsonPath("$.data.eaten_date").value("2026-03-14"))
                 .andExpect(jsonPath("$.data.rating").value(5))
-                .andExpect(jsonPath("$.data.review").value("겉은 바삭하고 안은 촉촉해서 완벽했어요."))
+                .andExpect(jsonPath("$.data.review").value("겉은 바삭하고 속이 촉촉해서 만족했어요"))
                 .andExpect(jsonPath("$.data.created_at").value("2026-03-14T09:30:00"))
                 .andExpect(jsonPath("$.data.updated_at").value("2026-03-14T10:15:00"))
                 .andExpect(jsonPath("$.data.breadId").doesNotExist());
 
-        verify(breadRecordComplexService).getBreadRecord(DUMMY_USER_ID, RECORD_ID);
+        verify(breadRecordComplexService).getBreadRecord(AUTHENTICATED_USER_ID, RECORD_ID);
     }
 
     @Test
     void updateBreadRecordBindsSnakeCaseMultipartFields() throws Exception {
         BreadRecordDetailResponse response = createDetailResponse();
 
-        when(breadRecordComplexService.updateBreadRecord(eq(DUMMY_USER_ID), eq(RECORD_ID), any(UpdateBreadRecordRequest.class)))
+        when(breadRecordComplexService.updateBreadRecord(eq(AUTHENTICATED_USER_ID), eq(RECORD_ID), any(UpdateBreadRecordRequest.class)))
                 .thenReturn(response);
 
         mockMvc.perform(multipart("/breads/{recordId}", RECORD_ID)
+                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID)
                         .file(new MockMultipartFile(
                                 "photo",
                                 "croissant.webp",
@@ -197,7 +201,7 @@ class BreadRecordControllerContractTest {
 
         ArgumentCaptor<UpdateBreadRecordRequest> requestCaptor =
                 ArgumentCaptor.forClass(UpdateBreadRecordRequest.class);
-        verify(breadRecordComplexService).updateBreadRecord(eq(DUMMY_USER_ID), eq(RECORD_ID), requestCaptor.capture());
+        verify(breadRecordComplexService).updateBreadRecord(eq(AUTHENTICATED_USER_ID), eq(RECORD_ID), requestCaptor.capture());
 
         UpdateBreadRecordRequest request = requestCaptor.getValue();
         assertEquals("", request.getShopName());
@@ -208,16 +212,17 @@ class BreadRecordControllerContractTest {
 
     @Test
     void deleteBreadRecordReturnsStickerRemoved() throws Exception {
-        when(breadRecordComplexService.deleteBreadRecord(DUMMY_USER_ID, RECORD_ID))
+        when(breadRecordComplexService.deleteBreadRecord(AUTHENTICATED_USER_ID, RECORD_ID))
                 .thenReturn(new BreadRecordDeleteResponse(true));
 
-        mockMvc.perform(delete("/breads/{recordId}", RECORD_ID))
+        mockMvc.perform(delete("/breads/{recordId}", RECORD_ID)
+                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.sticker_removed").value(true))
                 .andExpect(jsonPath("$.data.stickerRemoved").doesNotExist());
 
-        verify(breadRecordComplexService).deleteBreadRecord(DUMMY_USER_ID, RECORD_ID);
+        verify(breadRecordComplexService).deleteBreadRecord(AUTHENTICATED_USER_ID, RECORD_ID);
     }
 
     private BreadRecordCreateResponse createResponse(UUID breadId, BreadType breadType, boolean isFirstRecord) {
@@ -230,10 +235,10 @@ class BreadRecordControllerContractTest {
                 "크루아상",
                 breadType,
                 "https://cdn.bread-diary.app/breads/croissant.webp",
-                "르뺑블루 성수점",
+                "루트브레드 성수점",
                 LocalDate.of(2026, 3, 14),
                 5,
-                "겉은 바삭하고 안은 촉촉해서 완벽했어요.",
+                "겉은 바삭하고 속이 촉촉해서 만족했어요",
                 isFirstRecord,
                 LocalDateTime.of(2026, 3, 14, 9, 30)
         );
@@ -250,10 +255,10 @@ class BreadRecordControllerContractTest {
                 "https://cdn.bread-diary.app/breads/croissant.webp",
                 "https://cdn.bread-diary.app/bread-photos/record.webp",
                 "https://cdn.bread-diary.app/bread-photos/record_thumb.webp",
-                "르뺑블루 성수점",
+                "루트브레드 성수점",
                 LocalDate.of(2026, 3, 14),
                 5,
-                "겉은 바삭하고 안은 촉촉해서 완벽했어요.",
+                "겉은 바삭하고 속이 촉촉해서 만족했어요",
                 LocalDateTime.of(2026, 3, 14, 9, 30),
                 LocalDateTime.of(2026, 3, 14, 10, 15)
         );

--- a/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
+++ b/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
@@ -1,0 +1,171 @@
+package com.bean.breaddiary.global.interceptor;
+
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.auth.service.JwtTokenProvider;
+import com.bean.breaddiary.domain.auth.service.UserSessionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AuthInterceptorTest {
+
+    private UserSessionService userSessionService;
+    private JwtTokenProvider jwtTokenProvider;
+    private AuthInterceptor authInterceptor;
+    private HandlerMethod handlerMethod;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        userSessionService = mock(UserSessionService.class);
+        jwtTokenProvider = new JwtTokenProvider(
+                new ObjectMapper(),
+                "test-secret-key",
+                "bread-diary"
+        );
+        authInterceptor = new AuthInterceptor(jwtTokenProvider, userSessionService);
+
+        Method handleMethod = DummyController.class.getDeclaredMethod("handle");
+        handlerMethod = new HandlerMethod(new DummyController(), handleMethod);
+    }
+
+    @Test
+    void preHandleSkipsWhitelistedBreadTypesEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/bread-types");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
+    void preHandleRejectsMissingBearerTokenForProtectedEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/breads/550e8400-e29b-41d4-a716-446655440000");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> authInterceptor.preHandle(request, response, handlerMethod)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void preHandleRejectsRefreshTokenOnProtectedEndpoint() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                userId,
+                sessionId,
+                "refresh-jti",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+
+        MockHttpServletRequest request = authorizedRequest(
+                "GET",
+                "/breads/550e8400-e29b-41d4-a716-446655440000",
+                refreshToken
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> authInterceptor.preHandle(request, response, handlerMethod)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void preHandleRejectsWhenSessionIsNotActive() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440010");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440011");
+        String accessToken = jwtTokenProvider.createAccessToken(
+                userId,
+                sessionId,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1)
+        );
+
+        when(userSessionService.findActiveSession(eq(sessionId), any(LocalDateTime.class)))
+                .thenReturn(Optional.empty());
+
+        MockHttpServletRequest request = authorizedRequest("POST", "/breads", accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> authInterceptor.preHandle(request, response, handlerMethod)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
+    void preHandleStoresAuthenticatedUserAttributesForValidAccessToken() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440020");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440021");
+        LocalDateTime now = LocalDateTime.now();
+        String accessToken = jwtTokenProvider.createAccessToken(
+                userId,
+                sessionId,
+                now,
+                now.plusDays(1)
+        );
+
+        UserSession userSession = UserSession.builder()
+                .id(sessionId)
+                .userId(userId)
+                .refreshTokenHash("hashed-refresh-token")
+                .currentJti("current-jti")
+                .refreshExpiresAt(now.plusDays(30))
+                .build();
+
+        when(userSessionService.findActiveSession(eq(sessionId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(userSession));
+
+        MockHttpServletRequest request = authorizedRequest(
+                "GET",
+                "/breads/550e8400-e29b-41d4-a716-446655440020",
+                accessToken
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        assertEquals(userId, request.getAttribute(AuthRequestAttributes.USER_ID));
+        assertEquals(sessionId, request.getAttribute(AuthRequestAttributes.SESSION_ID));
+    }
+
+    private MockHttpServletRequest authorizedRequest(String method, String uri, String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, uri);
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        return request;
+    }
+
+    private static class DummyController {
+        @SuppressWarnings("unused")
+        public void handle() {
+        }
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #36

## 🛠️ 작업 내용

- Spring Security 없이 Bearer Access Token 기반 인증 인터셉터를 구현했습니다.
- `Authorization: Bearer <token>` 파싱, access token 검증, token type 검증(access만 허용) 로직을 반영했습니다.
- request attribute 에 현재 사용자 정보(`userId`, `sessionId`)를 저장하도록 연결했습니다.
- 인증 제외 경로(`/auth/toss`, `/auth/refresh`, `/bread-types` 등) whitelist 를 정리하고 interceptor 등록까지 반영했습니다.

## 📢 참고 및 특이사항

- 기존 global 패키지 구조와 예외 응답 흐름을 최대한 유지하면서 최소 수정 방식으로 반영했습니다.
- refresh token 은 일반 API 인증에 사용할 수 없도록 type 검증으로 제한했습니다.
- 기존 bread / breadrecord / user API 가 크게 깨지지 않도록 인증 의존 지점만 자연스럽게 연결했습니다.
- 이번 PR에서는 `/users/me` 확장이나 추가 인증 정책 확장은 포함하지 않았습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인