### PR TITLE
feat: add user profile api

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/controller/UserController.java
@@ -1,0 +1,55 @@
+package com.bean.breaddiary.domain.user.controller;
+
+import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
+import com.bean.breaddiary.domain.user.service.UserService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "사용자 API", description = "현재 로그인한 사용자 정보를 조회하는 API입니다.")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(
+            summary = "내 프로필 조회",
+            description = "인증된 Access Token 기준으로 현재 사용자 프로필과 기록 통계를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "내 프로필 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserMeResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserMeResponse>> getCurrentUserProfile(
+            @Parameter(hidden = true) HttpServletRequest request
+    ) {
+        UUID userId = AuthRequestAttributes.getRequiredUserId(request);
+        UserMeResponse response = userService.getCurrentUserProfile(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
@@ -6,17 +6,16 @@ import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
 import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
 import com.bean.breaddiary.domain.auth.dto.response.LogoutResponse;
 import com.bean.breaddiary.domain.auth.service.AuthService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -40,7 +39,7 @@ class AuthControllerTest {
         authService = mock(AuthService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new AuthController(authService))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -140,10 +139,10 @@ class AuthControllerTest {
         assertEquals("refresh-token", requestCaptor.getValue().getRefreshToken());
     }
 
-    private ObjectMapper snakeCaseObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
@@ -4,15 +4,14 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemRespon
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
 import java.util.UUID;
@@ -34,7 +33,7 @@ class BreadControllerAutocompleteTest {
         breadComplexService = mock(BreadComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadController(breadComplexService))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -85,10 +84,10 @@ class BreadControllerAutocompleteTest {
         verify(breadComplexService).autocompleteBreads(null, null);
     }
 
-    private ObjectMapper snakeCaseObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
@@ -4,15 +4,14 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -35,7 +34,7 @@ class BreadControllerCatalogTest {
         breadComplexService = mock(BreadComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadController(breadComplexService))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -107,10 +106,10 @@ class BreadControllerCatalogTest {
         );
     }
 
-    private ObjectMapper snakeCaseObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
@@ -5,15 +5,14 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,7 +36,7 @@ class BreadControllerProfileTest {
         breadComplexService = mock(BreadComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadController(breadComplexService))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -96,10 +95,10 @@ class BreadControllerProfileTest {
         verify(breadComplexService).getBreadProfile(breadId, userId);
     }
 
-    private ObjectMapper snakeCaseObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadTypeControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadTypeControllerTest.java
@@ -3,15 +3,14 @@ package com.bean.breaddiary.domain.bread.controller;
 import com.bean.breaddiary.domain.bread.dto.response.BreadTypeItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadTypeListResponse;
 import com.bean.breaddiary.domain.bread.service.BreadService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
 
@@ -32,7 +31,7 @@ class BreadTypeControllerTest {
         breadService = mock(BreadService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadTypeController(breadService))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -64,10 +63,10 @@ class BreadTypeControllerTest {
         verify(breadService).getBreadTypes();
     }
 
-    private ObjectMapper snakeCaseObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/controller/BreadRecordControllerContractTest.java
@@ -9,18 +9,17 @@ import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResp
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.service.BreadRecordComplexService;
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -52,7 +51,7 @@ class BreadRecordControllerContractTest {
         breadRecordComplexService = mock(BreadRecordComplexService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new BreadRecordController(breadRecordComplexService))
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(snakeCaseObjectMapper()))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
 
@@ -264,10 +263,10 @@ class BreadRecordControllerContractTest {
         );
     }
 
-    private ObjectMapper snakeCaseObjectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,85 @@
+package com.bean.breaddiary.domain.user.controller;
+
+import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
+import com.bean.breaddiary.domain.user.dto.response.UserStatsResponse;
+import com.bean.breaddiary.domain.user.service.UserService;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerTest {
+
+    private static final UUID AUTHENTICATED_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+    private UserService userService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new UserController(userService))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
+                .build();
+    }
+
+    @Test
+    void getCurrentUserProfileReturnsSnakeCaseResponse() throws Exception {
+        UserMeResponse response = new UserMeResponse(
+                AUTHENTICATED_USER_ID,
+                "빵순이",
+                "bread@toss.im",
+                "https://cdn.bread-diary.app/profiles/me.webp",
+                "오늘도 빵을 먹습니다.",
+                new UserStatsResponse(42L, 18L, 4.2),
+                LocalDateTime.of(2026, 4, 1, 0, 0)
+        );
+
+        when(userService.getCurrentUserProfile(AUTHENTICATED_USER_ID))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/users/me")
+                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(AUTHENTICATED_USER_ID.toString()))
+                .andExpect(jsonPath("$.data.nickname").value("빵순이"))
+                .andExpect(jsonPath("$.data.email").value("bread@toss.im"))
+                .andExpect(jsonPath("$.data.profile_image_url").value("https://cdn.bread-diary.app/profiles/me.webp"))
+                .andExpect(jsonPath("$.data.bio").value("오늘도 빵을 먹습니다."))
+                .andExpect(jsonPath("$.data.stats.total_records").value(42))
+                .andExpect(jsonPath("$.data.stats.unique_shops").value(18))
+                .andExpect(jsonPath("$.data.stats.avg_rating").value(4.2))
+                .andExpect(jsonPath("$.data.created_at").value("2026-04-01T00:00:00"))
+                .andExpect(jsonPath("$.data.profileImageUrl").doesNotExist())
+                .andExpect(jsonPath("$.data.createdAt").doesNotExist())
+                .andExpect(jsonPath("$.data.stats.totalRecords").doesNotExist());
+
+        verify(userService).getCurrentUserProfile(AUTHENTICATED_USER_ID);
+    }
+
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
+    }
+}


### PR DESCRIPTION
현재 작업 브랜치는 feat/40-user-profile-test 이다.
이 작업은 feat/40-user-profile-api 가 반영된 상태를 기준으로 한다.

기존 bread / breadrecord / user / auth 구현, AGENTS.md, docs/user-part-spec.md를 먼저 읽고 같은 스타일로 최소 수정 방식으로 이어서 작업해라.

[작업 전 필수]
1. UserController, UserService, AuthInterceptor 관련 파일을 먼저 읽고 요약해라.
2. 현재 테스트 패키지 구조와 MockMvc 사용 방식을 먼저 확인해라.
3. snake_case 응답 기대와 ApiResponse 구조를 먼저 확인해라.
4. 인증 인터셉터를 테스트에서 어떻게 우회 또는 포함할지 먼저 판단해라.

[이번 브랜치 목표]
/users/me API와 인증 연결에 대한 테스트를 추가한다.

[이번 브랜치에서 구현할 범위]
- UserControllerTest 또는 현재 프로젝트 스타일에 맞는 테스트 추가
- 정상 조회 테스트
- 인증 정보 없음 테스트
- 잘못된 access token 테스트
- 탈퇴 사용자 조회 실패 테스트가 가능하면 포함
- 응답 구조 검증
  - success
  - data
  - nickname
  - email
  - profile_image_url
  - bio
  - stats 하위 필드

[구현 원칙]
- 테스트는 기존 프로젝트 스타일을 따르고 과하게 무겁게 만들지 마라.
- full context 가 꼭 필요하지 않으면 slice test 우선 검토
- snake_case 기대를 깨지 않도록 JSON path 검증을 신중히 해라.

[출력 형식]
1. 참고한 기존 파일 / 패키지 요약
2. 생성 / 수정한 파일 목록
3. 파일별 핵심 변경 요약
   - 어떤 파일을 왜 바꿨는지 1~3줄씩 간략하게
4. 어떤 케이스를 검증했는지 설명
5. 다음 브랜치(회원탈퇴)에서 참고할 포인트

작업 종료 전에 반드시 아래를 출력해라.
1. 이번 브랜치에서 생성한 파일
2. 이번 브랜치에서 수정한 파일
3. 각 파일별 핵심 변경점 한 줄 요약
4. 다음 브랜치 작업자가 먼저 읽어야 할 파일 목록
5. 다음 브랜치에서 이어서 해야 할 핵심 TODO

