### PR TITLE
test: add user profile auth coverage

### DIFF
--- a/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
@@ -1,24 +1,35 @@
 package com.bean.breaddiary.domain.user.controller;
 
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.auth.service.JwtTokenProvider;
+import com.bean.breaddiary.domain.auth.service.UserSessionService;
 import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
 import com.bean.breaddiary.domain.user.dto.response.UserStatsResponse;
 import com.bean.breaddiary.domain.user.service.UserService;
-import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import com.bean.breaddiary.global.interceptor.AuthInterceptor;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -27,15 +38,32 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class UserControllerTest {
 
     private static final UUID AUTHENTICATED_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final UUID SESSION_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+    private static final LocalDateTime PROFILE_CREATED_AT = LocalDateTime.of(2026, 4, 1, 0, 0);
 
     private UserService userService;
+    private UserSessionService userSessionService;
+    private JwtTokenProvider jwtTokenProvider;
     private MockMvc mockMvc;
+    private LocalDateTime tokenIssuedAt;
+    private LocalDateTime accessTokenExpiresAt;
+    private LocalDateTime refreshTokenExpiresAt;
 
     @BeforeEach
     void setUp() {
         userService = mock(UserService.class);
+        userSessionService = mock(UserSessionService.class);
+        jwtTokenProvider = new JwtTokenProvider(
+                new ObjectMapper(),
+                "test-secret-key",
+                "bread-diary"
+        );
+        tokenIssuedAt = LocalDateTime.now().minusMinutes(1);
+        accessTokenExpiresAt = tokenIssuedAt.plusDays(1);
+        refreshTokenExpiresAt = tokenIssuedAt.plusDays(30);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new UserController(userService))
+                .addInterceptors(new AuthInterceptor(jwtTokenProvider, userSessionService))
                 .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
@@ -44,27 +72,29 @@ class UserControllerTest {
     void getCurrentUserProfileReturnsSnakeCaseResponse() throws Exception {
         UserMeResponse response = new UserMeResponse(
                 AUTHENTICATED_USER_ID,
-                "빵순이",
+                "bread_lover",
                 "bread@toss.im",
                 "https://cdn.bread-diary.app/profiles/me.webp",
-                "오늘도 빵을 먹습니다.",
+                "I always write down my bread diary.",
                 new UserStatsResponse(42L, 18L, 4.2),
-                LocalDateTime.of(2026, 4, 1, 0, 0)
+                PROFILE_CREATED_AT
         );
 
+        when(userSessionService.findActiveSession(eq(SESSION_ID), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(activeSession()));
         when(userService.getCurrentUserProfile(AUTHENTICATED_USER_ID))
                 .thenReturn(response);
 
         mockMvc.perform(get("/users/me")
-                        .requestAttr(AuthRequestAttributes.USER_ID, AUTHENTICATED_USER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, bearerAccessToken())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(AUTHENTICATED_USER_ID.toString()))
-                .andExpect(jsonPath("$.data.nickname").value("빵순이"))
+                .andExpect(jsonPath("$.data.nickname").value("bread_lover"))
                 .andExpect(jsonPath("$.data.email").value("bread@toss.im"))
                 .andExpect(jsonPath("$.data.profile_image_url").value("https://cdn.bread-diary.app/profiles/me.webp"))
-                .andExpect(jsonPath("$.data.bio").value("오늘도 빵을 먹습니다."))
+                .andExpect(jsonPath("$.data.bio").value("I always write down my bread diary."))
                 .andExpect(jsonPath("$.data.stats.total_records").value(42))
                 .andExpect(jsonPath("$.data.stats.unique_shops").value(18))
                 .andExpect(jsonPath("$.data.stats.avg_rating").value(4.2))
@@ -74,6 +104,62 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.stats.totalRecords").doesNotExist());
 
         verify(userService).getCurrentUserProfile(AUTHENTICATED_USER_ID);
+    }
+
+    @Test
+    void getCurrentUserProfileWithoutAuthenticationReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/users/me")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(userService, userSessionService);
+    }
+
+    @Test
+    void getCurrentUserProfileWithInvalidAccessTokenReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(userService, userSessionService);
+    }
+
+    @Test
+    void getCurrentUserProfileReturnsNotFoundWhenUserIsDeleted() throws Exception {
+        when(userSessionService.findActiveSession(eq(SESSION_ID), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(activeSession()));
+        when(userService.getCurrentUserProfile(AUTHENTICATED_USER_ID))
+                .thenThrow(new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 사용자를 찾을 수 없습니다."
+                ));
+
+        mockMvc.perform(get("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearerAccessToken())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(userService).getCurrentUserProfile(AUTHENTICATED_USER_ID);
+    }
+
+    private UserSession activeSession() {
+        return UserSession.builder()
+                .id(SESSION_ID)
+                .userId(AUTHENTICATED_USER_ID)
+                .refreshTokenHash("hashed-refresh-token")
+                .currentJti("current-jti")
+                .refreshExpiresAt(refreshTokenExpiresAt)
+                .build();
+    }
+
+    private String bearerAccessToken() {
+        return "Bearer " + jwtTokenProvider.createAccessToken(
+                AUTHENTICATED_USER_ID,
+                SESSION_ID,
+                tokenIssuedAt,
+                accessTokenExpiresAt
+        );
     }
 
     private JsonMapper snakeCaseObjectMapper() {


### PR DESCRIPTION
## 🧩 관련 이슈

- #40

## 🛠️ 작업 내용

- `/users/me` API에 대한 `UserControllerTest` 또는 프로젝트 스타일에 맞는 테스트를 추가했습니다.
- 정상 조회, 인증 정보 없음, 잘못된 access token 케이스를 검증하도록 반영했습니다.
- 가능한 경우 탈퇴 사용자 조회 실패 케이스도 함께 검증했습니다.
- 응답 구조가 기존 규칙에 맞는지 `ApiResponse` 래퍼와 snake_case 필드 기준으로 검증했습니다.

## 📢 참고 및 특이사항

- 테스트는 기존 프로젝트 스타일을 따르되, 과하게 무거운 full context 대신 가능한 범위에서 slice test 우선으로 구성했습니다.
- 인증 인터셉터는 테스트 목적에 따라 포함하거나 우회하는 방식을 선택했고, `/users/me` 가 access token 기반 인증 흐름과 연결되어 있음을 확인할 수 있도록 구성했습니다.
- JSON path 검증 시 `success`, `data`, `nickname`, `email`, `profile_image_url`, `bio`, `stats` 하위 필드를 중심으로 확인했습니다.
- 회원탈퇴 브랜치에서 사용자 삭제 정책이 반영되면 탈퇴 사용자 조회 실패 케이스를 더 명확하게 확장할 수 있습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인