### PR TITLE
feat: 회원탈퇴 및 Toss unlink 웹훅 처리 구현

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
@@ -21,19 +21,24 @@ public class TossAuthClient {
             "/api-partner/v1/apps-in-toss/user/oauth2/generate-token";
     private static final String LOGIN_ME_PATH =
             "/api-partner/v1/apps-in-toss/user/oauth2/login-me";
+    private static final String REMOVE_BY_USER_KEY_PATH =
+            "/api-partner/v1/apps-in-toss/user/oauth2/remove-by-user-key";
 
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private final String unlinkAccessToken;
 
     public TossAuthClient(
             RestClient.Builder restClientBuilder,
             ObjectMapper objectMapper,
-            @Value("${app.auth.toss.base-url:https://apps-in-toss-api.toss.im}") String baseUrl
+            @Value("${app.auth.toss.base-url:https://apps-in-toss-api.toss.im}") String baseUrl,
+            @Value("${TOSS_UNLINK_ACCESS_TOKEN:${app.auth.toss.unlink-access-token:}}") String unlinkAccessToken
     ) {
         this.restClient = restClientBuilder
                 .baseUrl(baseUrl)
                 .build();
         this.objectMapper = objectMapper;
+        this.unlinkAccessToken = unlinkAccessToken;
     }
 
     public TossGenerateTokenSuccess exchangeAuthorizationCode(
@@ -73,6 +78,30 @@ public class TossAuthClient {
             return response.success();
         } catch (RestClientResponseException exception) {
             throw convertException(exception, "토스 사용자 정보 조회에 실패했습니다.");
+        }
+    }
+
+    public void unlinkByUserKey(String userKey) {
+        requireUnlinkAccessToken();
+
+        try {
+            TossUnlinkResponse response = restClient.post()
+                    .uri(REMOVE_BY_USER_KEY_PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + unlinkAccessToken)
+                    .body(new TossUnlinkRequest(userKey))
+                    .retrieve()
+                    .body(TossUnlinkResponse.class);
+
+            if (response == null || response.success() == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "토스 연결 끊기에 실패했습니다.");
+            }
+        } catch (RestClientResponseException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_GATEWAY,
+                    "토스 연결 끊기에 실패했습니다.",
+                    exception
+            );
         }
     }
 
@@ -118,9 +147,23 @@ public class TossAuthClient {
         }
     }
 
+    private void requireUnlinkAccessToken() {
+        if (!StringUtils.hasText(unlinkAccessToken)) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "TOSS_UNLINK_ACCESS_TOKEN 설정이 필요합니다."
+            );
+        }
+    }
+
     private record TossGenerateTokenRequest(
             String authorizationCode,
             String referrer
+    ) {
+    }
+
+    private record TossUnlinkRequest(
+            String userKey
     ) {
     }
 
@@ -155,6 +198,14 @@ public class TossAuthClient {
             JsonNode userKey,
             String name,
             String email
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static record TossUnlinkResponse(
+            String resultType,
+            JsonNode success,
+            TossApiError error
     ) {
     }
 

--- a/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
@@ -3,9 +3,12 @@ package com.bean.breaddiary.domain.auth.controller;
 import com.bean.breaddiary.domain.auth.dto.request.LogoutRequest;
 import com.bean.breaddiary.domain.auth.dto.request.RefreshTokenRequest;
 import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
+import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
 import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
 import com.bean.breaddiary.domain.auth.dto.response.LogoutResponse;
+import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
 import com.bean.breaddiary.domain.auth.service.AuthService;
+import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
 import com.bean.breaddiary.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,17 +21,21 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "인증 API", description = "로그인, 토큰 재발급, 로그아웃 API입니다.")
+@Tag(name = "인증 API", description = "로그인, 토큰 재발급, 로그아웃, 토스 웹훅 처리 API입니다.")
 @Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
 
+    private static final String TOSS_WEBHOOK_SECRET_HEADER = "x-toss-webhook-secret";
+
     private final AuthService authService;
+    private final UserWithdrawalService userWithdrawalService;
 
     @Operation(
             summary = "토스 로그인",
@@ -96,6 +103,30 @@ public class AuthController {
     ) {
         return ResponseEntity.ok(
                 ApiResponse.success(authService.logout(request))
+        );
+    }
+
+    @Operation(
+            summary = "토스 연결 해제 웹훅",
+            description = "토스 웹훅 secret을 검증하고 eventType에 따라 세션 정리 또는 사용자 완전 삭제를 수행합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "웹훅 처리 성공",
+                    content = @Content(schema = @Schema(implementation = TossWebhookResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "웹훅 인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 웹훅 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/webhook/toss-unlink")
+    public ResponseEntity<ApiResponse<TossWebhookResponse>> handleTossWebhook(
+            @RequestHeader(TOSS_WEBHOOK_SECRET_HEADER) String webhookSecret,
+            @Valid @RequestBody TossWebhookRequest request
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(userWithdrawalService.handleTossWebhook(webhookSecret, request))
         );
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossWebhookRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossWebhookRequest.java
@@ -1,0 +1,20 @@
+package com.bean.breaddiary.domain.auth.dto.request;
+
+import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TossWebhookRequest {
+
+    @NotBlank(message = "user_key는 필수입니다.")
+    private String userKey;
+
+    @NotNull(message = "event_type은 필수입니다.")
+    private TossWebhookEventType eventType;
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/response/TossWebhookResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/response/TossWebhookResponse.java
@@ -1,0 +1,15 @@
+package com.bean.breaddiary.domain.auth.dto.response;
+
+import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TossWebhookResponse {
+
+    private boolean processed;
+    private TossWebhookEventType eventType;
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/entity/TossWebhookEventType.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/entity/TossWebhookEventType.java
@@ -1,0 +1,7 @@
+package com.bean.breaddiary.domain.auth.entity;
+
+public enum TossWebhookEventType {
+    UNLINK,
+    WITHDRAWAL_TERMS,
+    WITHDRAWAL_TOSS
+}

--- a/src/main/java/com/bean/breaddiary/domain/auth/repository/UserSessionRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/repository/UserSessionRepository.java
@@ -4,6 +4,7 @@ import com.bean.breaddiary.domain.auth.entity.UserSession;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,6 +17,10 @@ public interface UserSessionRepository extends JpaRepository<UserSession, UUID> 
     Optional<UserSession> findByIdAndRevokedAtIsNull(UUID id);
 
     List<UserSession> findAllByUserIdAndRevokedAtIsNull(UUID userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from UserSession userSession where userSession.userId = :userId")
+    void deleteAllByUserId(@Param("userId") UUID userId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/com/bean/breaddiary/domain/auth/service/UserSessionService.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/UserSessionService.java
@@ -87,6 +87,11 @@ public class UserSessionService {
                 .forEach(userSession -> userSession.revoke(targetTime));
     }
 
+    @Transactional
+    public void deleteAllSessions(UUID userId) {
+        userSessionRepository.deleteAllByUserId(userId);
+    }
+
     public LocalDateTime calculateAccessTokenExpiresAt(LocalDateTime issuedAt) {
         return resolveTime(issuedAt).plus(ACCESS_TOKEN_TTL);
     }

--- a/src/main/java/com/bean/breaddiary/domain/bread/entity/Bread.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/entity/Bread.java
@@ -58,4 +58,8 @@ public class Bread {
     public boolean isUserCreated() {
         return createdBy != null;
     }
+
+    public void clearCreator() {
+        this.createdBy = null;
+    }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -19,6 +19,8 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
 
     Optional<Bread> findTopByOrderByStickerNumberDesc();
 
+    List<Bread> findAllByCreatedBy(UUID createdBy);
+
     boolean existsByName(String name);
 
     List<Bread> findByNameContainingIgnoreCaseOrderByStickerNumberAsc(String name, Pageable pageable);

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -7,6 +7,7 @@ import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountPro
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordLatestPhotoProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.UserStatsProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,7 +24,12 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
     long countByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
     long countByUserIdAndBread(UUID userId, Bread bread);
     boolean existsByUserIdAndBreadAndDeletedAtIsNull(UUID userId, Bread bread);
+    boolean existsByBread(Bread bread);
     boolean existsByBreadAndDeletedAtIsNull(Bread bread);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from BreadRecord breadRecord where breadRecord.userId = :userId")
+    void hardDeleteAllByUserId(@Param("userId") UUID userId);
 
     @Query("""
             select br.bread.id as breadId, count(br) as eatCount

--- a/src/main/java/com/bean/breaddiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.bean.breaddiary.domain.user.controller;
 
 import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
+import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
 import com.bean.breaddiary.domain.user.service.UserService;
+import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
 import com.bean.breaddiary.global.common.ApiResponse;
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,13 +16,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
-@Tag(name = "사용자 API", description = "현재 로그인한 사용자 정보를 조회하는 API입니다.")
+@Tag(name = "사용자 API", description = "현재 로그인한 사용자 정보를 조회하고 탈퇴를 처리하는 API입니다.")
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +31,7 @@ import java.util.UUID;
 public class UserController {
 
     private final UserService userService;
+    private final UserWithdrawalService userWithdrawalService;
 
     @Operation(
             summary = "내 프로필 조회",
@@ -49,6 +53,30 @@ public class UserController {
     ) {
         UUID userId = AuthRequestAttributes.getRequiredUserId(request);
         UserMeResponse response = userService.getCurrentUserProfile(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "토스 연결 끊기를 요청한 뒤 콜백을 기다리지 않고 로컬 사용자 데이터를 즉시 완전 삭제합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(schema = @Schema(implementation = UserWithdrawalResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<UserWithdrawalResponse>> withdrawCurrentUser(
+            @Parameter(hidden = true) HttpServletRequest request
+    ) {
+        UUID userId = AuthRequestAttributes.getRequiredUserId(request);
+        UserWithdrawalResponse response = userWithdrawalService.withdrawCurrentUser(userId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserWithdrawalResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserWithdrawalResponse.java
@@ -1,0 +1,13 @@
+package com.bean.breaddiary.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserWithdrawalResponse {
+
+    private boolean withdrawn;
+}

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
@@ -1,0 +1,122 @@
+package com.bean.breaddiary.domain.user.service;
+
+import com.bean.breaddiary.domain.auth.client.TossAuthClient;
+import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
+import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
+import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
+import com.bean.breaddiary.domain.auth.service.UserSessionService;
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.repository.BreadRepository;
+import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
+import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserWithdrawalService {
+
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final BreadRepository breadRepository;
+    private final BreadRecordRepository breadRecordRepository;
+    private final UserSessionService userSessionService;
+    private final TossAuthClient tossAuthClient;
+
+    @Value("${TOSS_WEBHOOK_SECRET:${app.auth.toss.webhook-secret:}}")
+    private String tossWebhookSecret;
+
+    @Transactional
+    public UserWithdrawalResponse withdrawCurrentUser(UUID userId) {
+        User user = userService.getUserById(userId);
+
+        if (StringUtils.hasText(user.getTossUserKey())) {
+            tossAuthClient.unlinkByUserKey(user.getTossUserKey());
+        }
+
+        hardDeleteUserData(user);
+        return new UserWithdrawalResponse(true);
+    }
+
+    @Transactional
+    public TossWebhookResponse handleTossWebhook(
+            String requestWebhookSecret,
+            TossWebhookRequest request
+    ) {
+        validateWebhookSecret(requestWebhookSecret);
+
+        Optional<User> user = userRepository.findByTossUserKey(normalizeText(request.getUserKey()));
+        if (user.isEmpty()) {
+            return new TossWebhookResponse(true, request.getEventType());
+        }
+
+        if (request.getEventType() == TossWebhookEventType.UNLINK) {
+            clearSessionsOnly(user.get().getId());
+            return new TossWebhookResponse(true, request.getEventType());
+        }
+
+        hardDeleteUserData(user.get());
+        return new TossWebhookResponse(true, request.getEventType());
+    }
+
+    @Transactional
+    public void hardDeleteUserData(User user) {
+        UUID userId = user.getId();
+        List<Bread> userCreatedBreads = breadRepository.findAllByCreatedBy(userId);
+
+        breadRecordRepository.hardDeleteAllByUserId(userId);
+
+        for (Bread bread : userCreatedBreads) {
+            if (breadRecordRepository.existsByBread(bread)) {
+                bread.clearCreator();
+                continue;
+            }
+
+            breadRepository.delete(bread);
+        }
+
+        userSessionService.deleteAllSessions(userId);
+        userRepository.delete(user);
+    }
+
+    @Transactional
+    public void clearSessionsOnly(UUID userId) {
+        userSessionService.deleteAllSessions(userId);
+    }
+
+    private void validateWebhookSecret(String requestWebhookSecret) {
+        String configuredSecret = normalizeText(tossWebhookSecret);
+        String incomingSecret = normalizeText(requestWebhookSecret);
+
+        if (!StringUtils.hasText(configuredSecret)) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "TOSS_WEBHOOK_SECRET 설정이 필요합니다."
+            );
+        }
+
+        if (!configuredSecret.equals(incomingSecret)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+    }
+
+    private String normalizeText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
@@ -76,7 +76,9 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
 
         if (HTTP_POST.equalsIgnoreCase(method)
-                && ("/auth/toss".equals(requestUri) || "/auth/refresh".equals(requestUri))) {
+                && ("/auth/toss".equals(requestUri)
+                || "/auth/refresh".equals(requestUri)
+                || "/auth/webhook/toss-unlink".equals(requestUri))) {
             return false;
         }
 

--- a/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
@@ -3,9 +3,13 @@ package com.bean.breaddiary.domain.auth.controller;
 import com.bean.breaddiary.domain.auth.dto.request.LogoutRequest;
 import com.bean.breaddiary.domain.auth.dto.request.RefreshTokenRequest;
 import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
+import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
 import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
 import com.bean.breaddiary.domain.auth.dto.response.LogoutResponse;
+import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
+import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.bean.breaddiary.domain.auth.service.AuthService;
+import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -32,13 +36,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthControllerTest {
 
     private AuthService authService;
+    private UserWithdrawalService userWithdrawalService;
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
         authService = mock(AuthService.class);
+        userWithdrawalService = mock(UserWithdrawalService.class);
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new AuthController(authService))
+                .standaloneSetup(new AuthController(authService, userWithdrawalService))
                 .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
@@ -137,6 +143,34 @@ class AuthControllerTest {
         ArgumentCaptor<LogoutRequest> requestCaptor = ArgumentCaptor.forClass(LogoutRequest.class);
         verify(authService).logout(requestCaptor.capture());
         assertEquals("refresh-token", requestCaptor.getValue().getRefreshToken());
+    }
+
+    @Test
+    void handleTossWebhookBindsSnakeCaseRequestAndSerializesResponse() throws Exception {
+        when(userWithdrawalService.handleTossWebhook(any(String.class), any(TossWebhookRequest.class)))
+                .thenReturn(new TossWebhookResponse(true, TossWebhookEventType.UNLINK));
+
+        mockMvc.perform(post("/auth/webhook/toss-unlink")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("x-toss-webhook-secret", "webhook-secret")
+                        .content("""
+                                {
+                                  "user_key": "toss-user-key-12345678",
+                                  "event_type": "UNLINK"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.processed").value(true))
+                .andExpect(jsonPath("$.data.event_type").value("UNLINK"))
+                .andExpect(jsonPath("$.data.eventType").doesNotExist());
+
+        ArgumentCaptor<TossWebhookRequest> requestCaptor = ArgumentCaptor.forClass(TossWebhookRequest.class);
+        ArgumentCaptor<String> secretCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userWithdrawalService).handleTossWebhook(secretCaptor.capture(), requestCaptor.capture());
+        assertEquals("webhook-secret", secretCaptor.getValue());
+        assertEquals("toss-user-key-12345678", requestCaptor.getValue().getUserKey());
+        assertEquals(TossWebhookEventType.UNLINK, requestCaptor.getValue().getEventType());
     }
 
     private JsonMapper snakeCaseObjectMapper() {

--- a/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
@@ -5,7 +5,9 @@ import com.bean.breaddiary.domain.auth.service.JwtTokenProvider;
 import com.bean.breaddiary.domain.auth.service.UserSessionService;
 import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
 import com.bean.breaddiary.domain.user.dto.response.UserStatsResponse;
+import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
 import com.bean.breaddiary.domain.user.service.UserService;
+import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
 import com.bean.breaddiary.global.interceptor.AuthInterceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,6 +45,7 @@ class UserControllerTest {
     private static final LocalDateTime PROFILE_CREATED_AT = LocalDateTime.of(2026, 4, 1, 0, 0);
 
     private UserService userService;
+    private UserWithdrawalService userWithdrawalService;
     private UserSessionService userSessionService;
     private JwtTokenProvider jwtTokenProvider;
     private MockMvc mockMvc;
@@ -52,6 +56,7 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         userService = mock(UserService.class);
+        userWithdrawalService = mock(UserWithdrawalService.class);
         userSessionService = mock(UserSessionService.class);
         jwtTokenProvider = new JwtTokenProvider(
                 new ObjectMapper(),
@@ -62,7 +67,7 @@ class UserControllerTest {
         accessTokenExpiresAt = tokenIssuedAt.plusDays(1);
         refreshTokenExpiresAt = tokenIssuedAt.plusDays(30);
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new UserController(userService))
+                .standaloneSetup(new UserController(userService, userWithdrawalService))
                 .addInterceptors(new AuthInterceptor(jwtTokenProvider, userSessionService))
                 .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
@@ -107,12 +112,29 @@ class UserControllerTest {
     }
 
     @Test
+    void withdrawCurrentUserReturnsSuccessResponse() throws Exception {
+        when(userSessionService.findActiveSession(eq(SESSION_ID), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(activeSession()));
+        when(userWithdrawalService.withdrawCurrentUser(AUTHENTICATED_USER_ID))
+                .thenReturn(new UserWithdrawalResponse(true));
+
+        mockMvc.perform(delete("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, bearerAccessToken())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.withdrawn").value(true));
+
+        verify(userWithdrawalService).withdrawCurrentUser(AUTHENTICATED_USER_ID);
+    }
+
+    @Test
     void getCurrentUserProfileWithoutAuthenticationReturnsUnauthorized() throws Exception {
         mockMvc.perform(get("/users/me")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());
 
-        verifyNoInteractions(userService, userSessionService);
+        verifyNoInteractions(userService, userWithdrawalService, userSessionService);
     }
 
     @Test
@@ -122,7 +144,7 @@ class UserControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());
 
-        verifyNoInteractions(userService, userSessionService);
+        verifyNoInteractions(userService, userWithdrawalService, userSessionService);
     }
 
     @Test

--- a/src/test/java/com/bean/breaddiary/domain/user/service/UserWithdrawalServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/service/UserWithdrawalServiceTest.java
@@ -1,0 +1,162 @@
+package com.bean.breaddiary.domain.user.service;
+
+import com.bean.breaddiary.domain.auth.client.TossAuthClient;
+import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
+import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
+import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
+import com.bean.breaddiary.domain.auth.service.UserSessionService;
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.entity.BreadType;
+import com.bean.breaddiary.domain.bread.repository.BreadRepository;
+import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
+import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class UserWithdrawalServiceTest {
+
+    private UserService userService;
+    private UserRepository userRepository;
+    private BreadRepository breadRepository;
+    private BreadRecordRepository breadRecordRepository;
+    private UserSessionService userSessionService;
+    private TossAuthClient tossAuthClient;
+    private UserWithdrawalService userWithdrawalService;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
+        userRepository = mock(UserRepository.class);
+        breadRepository = mock(BreadRepository.class);
+        breadRecordRepository = mock(BreadRecordRepository.class);
+        userSessionService = mock(UserSessionService.class);
+        tossAuthClient = mock(TossAuthClient.class);
+        userWithdrawalService = new UserWithdrawalService(
+                userService,
+                userRepository,
+                breadRepository,
+                breadRecordRepository,
+                userSessionService,
+                tossAuthClient
+        );
+        ReflectionTestUtils.setField(userWithdrawalService, "tossWebhookSecret", "webhook-secret");
+    }
+
+    @Test
+    void withdrawCurrentUserUnlinksTossAndHardDeletesLocalData() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        User user = user(userId, "toss-user-key-12345678");
+        Bread breadToKeep = bread(userId, 1, "keep-bread");
+        Bread breadToDelete = bread(userId, 2, "delete-bread");
+
+        when(userService.getUserById(userId)).thenReturn(user);
+        when(breadRepository.findAllByCreatedBy(userId)).thenReturn(List.of(breadToKeep, breadToDelete));
+        when(breadRecordRepository.existsByBread(breadToKeep)).thenReturn(true);
+        when(breadRecordRepository.existsByBread(breadToDelete)).thenReturn(false);
+
+        UserWithdrawalResponse response = userWithdrawalService.withdrawCurrentUser(userId);
+
+        assertTrue(response.isWithdrawn());
+        assertNull(breadToKeep.getCreatedBy());
+        verify(tossAuthClient).unlinkByUserKey("toss-user-key-12345678");
+        verify(breadRecordRepository).hardDeleteAllByUserId(userId);
+        verify(breadRepository).delete(breadToDelete);
+        verify(userSessionService).deleteAllSessions(userId);
+        verify(userRepository).delete(user);
+    }
+
+    @Test
+    void handleTossWebhookUnlinkClearsSessionsOnly() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440010");
+        User user = user(userId, "toss-user-key-unlink");
+
+        when(userRepository.findByTossUserKey("toss-user-key-unlink"))
+                .thenReturn(Optional.of(user));
+
+        TossWebhookResponse response = userWithdrawalService.handleTossWebhook(
+                "webhook-secret",
+                new TossWebhookRequest("toss-user-key-unlink", TossWebhookEventType.UNLINK)
+        );
+
+        assertTrue(response.isProcessed());
+        assertEquals(TossWebhookEventType.UNLINK, response.getEventType());
+        verify(userSessionService).deleteAllSessions(userId);
+        verify(userRepository, never()).delete(user);
+        verifyNoInteractions(tossAuthClient);
+    }
+
+    @Test
+    void handleTossWebhookWithdrawalHardDeletesUserData() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440020");
+        User user = user(userId, "toss-user-key-withdrawal");
+
+        when(userRepository.findByTossUserKey("toss-user-key-withdrawal"))
+                .thenReturn(Optional.of(user));
+        when(breadRepository.findAllByCreatedBy(userId)).thenReturn(List.of());
+
+        TossWebhookResponse response = userWithdrawalService.handleTossWebhook(
+                "webhook-secret",
+                new TossWebhookRequest("toss-user-key-withdrawal", TossWebhookEventType.WITHDRAWAL_TOSS)
+        );
+
+        assertTrue(response.isProcessed());
+        assertEquals(TossWebhookEventType.WITHDRAWAL_TOSS, response.getEventType());
+        verify(breadRecordRepository).hardDeleteAllByUserId(userId);
+        verify(userSessionService).deleteAllSessions(userId);
+        verify(userRepository).delete(user);
+        verifyNoInteractions(tossAuthClient);
+    }
+
+    @Test
+    void handleTossWebhookRejectsInvalidSecret() {
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> userWithdrawalService.handleTossWebhook(
+                        "wrong-secret",
+                        new TossWebhookRequest("toss-user-key", TossWebhookEventType.UNLINK)
+                )
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verifyNoInteractions(userRepository, breadRepository, breadRecordRepository, userSessionService, tossAuthClient);
+    }
+
+    private User user(UUID userId, String tossUserKey) {
+        return User.builder()
+                .id(userId)
+                .tossUserKey(tossUserKey)
+                .nickname("bread-lover")
+                .email("bread@toss.im")
+                .build();
+    }
+
+    private Bread bread(UUID createdBy, int stickerNumber, String name) {
+        return Bread.builder()
+                .id(UUID.randomUUID())
+                .stickerNumber(stickerNumber)
+                .name(name)
+                .breadType(BreadType.PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/catalog/default_user_bread.webp")
+                .createdBy(createdBy)
+                .build();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
+++ b/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
@@ -58,6 +58,15 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void preHandleSkipsWhitelistedTossWebhookEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/webhook/toss-unlink");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
     void preHandleRejectsMissingBearerTokenForProtectedEndpoint() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/breads/550e8400-e29b-41d4-a716-446655440000");
         MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## 🧩 관련 이슈

- #41 

## 🛠️ 작업 내용

- `DELETE /users/me` 회원탈퇴 API를 추가하고 앱 내부 탈퇴 시 Toss 연결 끊기 호출 후 로컬 사용자 데이터를 hard delete 하도록 반영
- 탈퇴 시 해당 사용자의 세션을 함께 정리하도록 구현하고 탈퇴 이후 `/users/me` 조회가 불가능하도록 정책 정합성 반영
- `POST /auth/webhook/toss-unlink` 웹훅 엔드포인트를 추가하고 `x-toss-webhook-secret` 헤더와 `TOSS_WEBHOOK_SECRET` 비교 방식의 인증 처리 반영
- 웹훅 payload 를 `eventType` 기준으로 분기 처리하도록 구현
- `UNLINK` 는 사용자 row 는 유지하고 세션/토큰 정보만 정리하도록 반영
- `WITHDRAWAL_TERMS`, `WITHDRAWAL_TOSS` 는 사용자 데이터를 완전 삭제하도록 반영
- 기존 `ApiResponse` 구조와 한국어 메시지 톤을 유지하면서 최소 수정 방식으로 정리

## 📢 참고 및 특이사항

- 이번 작업은 기존 Basic Auth + userKey/referrer 기준이 아니라 Toss 웹훅 secret 헤더 검증 방식 기준으로 정책을 변경한 작업
- 회원탈퇴는 soft delete 가 아니라 hard delete 기준으로 처리
- 앱 내부 직접 탈퇴는 Toss 콜백을 기다리지 않고 로컬 DB 사용자 데이터를 즉시 삭제
- 웹훅 `UNLINK` 는 사용자 데이터를 유지하고 세션/토큰만 정리하는 점이 `WITHDRAWAL_*` 이벤트와 다름
- 현재 세션 정리는 refresh token 원문 저장이 아닌 구조를 고려해 revoke 또는 삭제 방식으로 처리

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인