### PR TITLE
test: add auth refresh concurrency coverage

### DIFF
--- a/src/test/java/com/bean/breaddiary/domain/auth/service/AuthServiceConcurrencyTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/AuthServiceConcurrencyTest.java
@@ -1,0 +1,260 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import com.bean.breaddiary.domain.auth.client.TossAuthClient;
+import com.bean.breaddiary.domain.auth.dto.request.LogoutRequest;
+import com.bean.breaddiary.domain.auth.dto.request.RefreshTokenRequest;
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+class AuthServiceConcurrencyTest {
+
+    private static final UUID USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final UUID SESSION_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+    private static final String CURRENT_JTI = "current-refresh-jti";
+
+    private UserRepository userRepository;
+    private UserSessionService userSessionService;
+    private JwtTokenProvider jwtTokenProvider;
+    private AuthService authService;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userSessionService = mock(UserSessionService.class);
+        jwtTokenProvider = new JwtTokenProvider(
+                new ObjectMapper(),
+                "test-secret-key",
+                "bread-diary"
+        );
+        authService = new AuthService(
+                userRepository,
+                userSessionService,
+                jwtTokenProvider,
+                mock(TossAuthClient.class),
+                mock(TossUserInfoDecryptor.class)
+        );
+        executorService = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    void concurrentRefreshWithSameTokenAllowsOnlyOneSuccess() throws Exception {
+        LocalDateTime issuedAt = LocalDateTime.now().minusMinutes(1);
+        LocalDateTime refreshTokenExpiresAt = issuedAt.plusDays(30);
+        String refreshToken = createRefreshToken(issuedAt, refreshTokenExpiresAt);
+        UserSession userSession = activeSession(refreshToken, refreshTokenExpiresAt);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch firstRotationDoneLatch = new CountDownLatch(1);
+        AtomicInteger findOrder = new AtomicInteger();
+
+        when(userSessionService.findSessionForUpdate(SESSION_ID)).thenAnswer(invocation -> {
+            if (findOrder.incrementAndGet() == 1) {
+                return Optional.of(userSession);
+            }
+
+            assertTrue(firstRotationDoneLatch.await(2, TimeUnit.SECONDS));
+            return Optional.of(userSession);
+        });
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID))
+                .thenReturn(Optional.of(activeUser()));
+        when(userSessionService.calculateAccessTokenExpiresAt(any(LocalDateTime.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0, LocalDateTime.class).plusDays(1));
+        when(userSessionService.calculateRefreshTokenExpiresAt(any(LocalDateTime.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0, LocalDateTime.class).plusDays(30));
+        doAnswer(invocation -> {
+            String refreshTokenHash = invocation.getArgument(1, String.class);
+            String currentJti = invocation.getArgument(2, String.class);
+            LocalDateTime rotatedAt = invocation.getArgument(3, LocalDateTime.class);
+
+            userSession.rotateRefreshToken(
+                    refreshTokenHash,
+                    currentJti,
+                    rotatedAt.plusDays(30)
+            );
+            firstRotationDoneLatch.countDown();
+            return null;
+        }).when(userSessionService).rotateRefreshToken(
+                eq(userSession),
+                anyString(),
+                anyString(),
+                any(LocalDateTime.class)
+        );
+
+        Callable<RefreshAttemptResult> refreshAttempt = () -> {
+            startLatch.await();
+            return refresh(refreshToken);
+        };
+
+        Future<RefreshAttemptResult> firstFuture = executorService.submit(refreshAttempt);
+        Future<RefreshAttemptResult> secondFuture = executorService.submit(refreshAttempt);
+
+        startLatch.countDown();
+
+        List<RefreshAttemptResult> results = List.of(
+                firstFuture.get(3, TimeUnit.SECONDS),
+                secondFuture.get(3, TimeUnit.SECONDS)
+        );
+
+        long successCount = results.stream()
+                .filter(RefreshAttemptResult::success)
+                .count();
+        long conflictCount = results.stream()
+                .filter(result -> HttpStatus.CONFLICT.equals(result.status()))
+                .count();
+
+        assertEquals(1L, successCount);
+        assertEquals(1L, conflictCount);
+        verify(userSessionService, times(1)).rotateRefreshToken(
+                eq(userSession),
+                anyString(),
+                anyString(),
+                any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    void refreshAfterLogoutFailsBecauseSessionIsRevoked() {
+        LocalDateTime issuedAt = LocalDateTime.now().minusMinutes(1);
+        LocalDateTime refreshTokenExpiresAt = issuedAt.plusDays(30);
+        String refreshToken = createRefreshToken(issuedAt, refreshTokenExpiresAt);
+        UserSession userSession = activeSession(refreshToken, refreshTokenExpiresAt);
+
+        when(userSessionService.findSessionForUpdate(SESSION_ID))
+                .thenReturn(Optional.of(userSession), Optional.empty());
+
+        authService.logout(new LogoutRequest(refreshToken));
+
+        ResponseStatusException exception = assertRefreshThrows(refreshToken);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(userSessionService).revokeSession(eq(userSession), any(LocalDateTime.class));
+    }
+
+    @Test
+    void refreshAfterWithdrawalFailsBecauseSessionWasDeleted() {
+        LocalDateTime issuedAt = LocalDateTime.now().minusMinutes(1);
+        LocalDateTime refreshTokenExpiresAt = issuedAt.plusDays(30);
+        String refreshToken = createRefreshToken(issuedAt, refreshTokenExpiresAt);
+
+        when(userSessionService.findSessionForUpdate(SESSION_ID))
+                .thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertRefreshThrows(refreshToken);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(userSessionService, never()).rotateRefreshToken(
+                any(UserSession.class),
+                anyString(),
+                anyString(),
+                any(LocalDateTime.class)
+        );
+    }
+
+    private RefreshAttemptResult refresh(String refreshToken) {
+        try {
+            authService.refresh(new RefreshTokenRequest(refreshToken));
+            return new RefreshAttemptResult(true, null);
+        } catch (ResponseStatusException exception) {
+            return new RefreshAttemptResult(false, (HttpStatus) exception.getStatusCode());
+        }
+    }
+
+    private ResponseStatusException assertRefreshThrows(String refreshToken) {
+        try {
+            authService.refresh(new RefreshTokenRequest(refreshToken));
+        } catch (ResponseStatusException exception) {
+            return exception;
+        }
+
+        throw new AssertionError("refresh 요청이 실패해야 합니다.");
+    }
+
+    private String createRefreshToken(LocalDateTime issuedAt, LocalDateTime refreshTokenExpiresAt) {
+        return jwtTokenProvider.createRefreshToken(
+                USER_ID,
+                SESSION_ID,
+                CURRENT_JTI,
+                issuedAt,
+                refreshTokenExpiresAt
+        );
+    }
+
+    private UserSession activeSession(String refreshToken, LocalDateTime refreshTokenExpiresAt) {
+        return UserSession.builder()
+                .id(SESSION_ID)
+                .userId(USER_ID)
+                .refreshTokenHash(hash(refreshToken))
+                .currentJti(CURRENT_JTI)
+                .refreshExpiresAt(refreshTokenExpiresAt)
+                .build();
+    }
+
+    private User activeUser() {
+        return User.builder()
+                .id(USER_ID)
+                .tossUserKey("toss-user-key")
+                .nickname("bread-lover")
+                .email("bread@toss.im")
+                .build();
+    }
+
+    private String hash(String refreshToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(refreshToken.getBytes(StandardCharsets.UTF_8));
+
+            return Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(digest);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private record RefreshAttemptResult(
+            boolean success,
+            HttpStatus status
+    ) {
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/service/UserSessionServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/UserSessionServiceTest.java
@@ -99,6 +99,24 @@ class UserSessionServiceTest {
     }
 
     @Test
+    void findSessionForUpdateUsesLockedRepositoryMethod() {
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440012");
+        UserSession activeSession = createSession(
+                sessionId,
+                LocalDateTime.of(2026, 4, 28, 10, 0),
+                null
+        );
+
+        when(userSessionRepository.findByIdAndRevokedAtIsNullForUpdate(sessionId))
+                .thenReturn(Optional.of(activeSession));
+
+        Optional<UserSession> actual = userSessionService.findSessionForUpdate(sessionId);
+
+        assertTrue(actual.isPresent());
+        verify(userSessionRepository).findByIdAndRevokedAtIsNullForUpdate(sessionId);
+    }
+
+    @Test
     void rotateRefreshTokenUpdatesHashJtiAndRefreshExpiry() {
         LocalDateTime rotatedAt = LocalDateTime.of(2026, 4, 18, 10, 0);
         UserSession userSession = createSession(


### PR DESCRIPTION
## 🧩 관련 이슈

- #이슈번호

## 🛠️ 작업 내용

- refresh token 동시 요청 상황에서 1건만 성공하고, rotation 이후 재사용 요청은 실패하는 동시성 테스트를 추가했습니다.
- 로그아웃 이후 refresh 실패, 회원탈퇴 이후 refresh 실패 시나리오를 함께 검증했습니다.
- `findSessionForUpdate()`가 잠금용 repository 메서드로 위임되는지 확인하는 테스트를 보강했습니다.

## 📢 참고 및 특이사항

- 이번 작업은 실제 MySQL row lock 경합을 직접 검증하는 통합 테스트가 아니라, 서비스 레벨에서 `PESSIMISTIC_WRITE` 이후 순차 처리 정책을 mock 기반으로 재현한 테스트입니다.
- 동일 refresh token 재사용 시 첫 요청의 rotation 이후 두 번째 요청이 `currentJti` 불일치로 실패하는 흐름을 검증했습니다.
- `gradle test --tests "com.bean.breaddiary.domain.auth.service.AuthServiceConcurrencyTest" --tests "com.bean.breaddiary.domain.auth.service.UserSessionServiceTest" --tests "com.bean.breaddiary.domain.auth.service.AuthServiceTest" --tests "com.bean.breaddiary.domain.user.service.UserWithdrawalServiceTest"` 기준 `BUILD SUCCESSFUL` 확인했습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인