### PR TITLE
test: add auth refresh mysql integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation platform('org.testcontainers:testcontainers-bom:1.21.3')
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/bean/breaddiary/global/config/ClientConfig.java
+++ b/src/main/java/com/bean/breaddiary/global/config/ClientConfig.java
@@ -1,0 +1,23 @@
+package com.bean.breaddiary.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class ClientConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/service/AuthRefreshMysqlIntegrationTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/AuthRefreshMysqlIntegrationTest.java
@@ -1,0 +1,291 @@
+package com.bean.breaddiary.domain.auth.service;
+
+import com.bean.breaddiary.domain.auth.dto.request.LogoutRequest;
+import com.bean.breaddiary.domain.auth.dto.request.RefreshTokenRequest;
+import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
+import com.bean.breaddiary.domain.auth.entity.UserSession;
+import com.bean.breaddiary.domain.auth.repository.UserSessionRepository;
+import com.bean.breaddiary.domain.bread.repository.BreadRepository;
+import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
+import com.bean.breaddiary.domain.user.entity.User;
+import com.bean.breaddiary.domain.user.repository.UserRepository;
+import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+@SpringBootTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect",
+        "spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver",
+        "app.auth.jwt.secret=test-secret-key",
+        "app.auth.jwt.issuer=bread-diary",
+        "app.auth.toss.base-url=http://localhost:65535",
+        "TOSS_UNLINK_ACCESS_TOKEN=test-unlink-token",
+        "TOSS_WEBHOOK_SECRET=test-webhook-secret",
+        "app.aws.s3.region=ap-northeast-2",
+        "app.aws.s3.bucket=test-bucket",
+        "cloud.aws.credentials.accessKey=test-access-key",
+        "cloud.aws.credentials.secretKey=test-secret-key"
+})
+class AuthRefreshMysqlIntegrationTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("breaddiary_test")
+            .withUsername("appuser")
+            .withPassword("qwer123!@");
+
+    private static final String INITIAL_JTI = "initial-refresh-jti";
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserSessionRepository userSessionRepository;
+
+    @Autowired
+    private BreadRepository breadRepository;
+
+    @Autowired
+    private BreadRecordRepository breadRecordRepository;
+
+    @Autowired
+    private UserWithdrawalService userWithdrawalService;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate transactionTemplate;
+    private ExecutorService executorService;
+
+    @DynamicPropertySource
+    static void registerDatasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+    }
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        executorService = Executors.newFixedThreadPool(2);
+
+        transactionTemplate.executeWithoutResult(status -> {
+            userSessionRepository.deleteAll();
+            breadRecordRepository.deleteAll();
+            breadRepository.deleteAll();
+            userRepository.deleteAll();
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    void findSessionForUpdateAppliesMysqlRowLock() throws Exception {
+        RefreshFixture fixture = createRefreshFixture();
+        CountDownLatch firstTransactionLocked = new CountDownLatch(1);
+        CountDownLatch releaseFirstTransaction = new CountDownLatch(1);
+
+        Future<?> firstLock = executorService.submit(() -> transactionTemplate.executeWithoutResult(status -> {
+            userSessionRepository.findByIdAndRevokedAtIsNullForUpdate(fixture.sessionId())
+                    .orElseThrow();
+            firstTransactionLocked.countDown();
+            await(releaseFirstTransaction);
+        }));
+
+        assertTrue(firstTransactionLocked.await(5, TimeUnit.SECONDS));
+
+        Future<Optional<UserSession>> competingLock = executorService.submit(() -> transactionTemplate.execute(status ->
+                userSessionRepository.findByIdAndRevokedAtIsNullForUpdate(fixture.sessionId())
+        ));
+
+        Thread.sleep(300);
+        assertFalse(competingLock.isDone());
+
+        releaseFirstTransaction.countDown();
+
+        firstLock.get(5, TimeUnit.SECONDS);
+        assertTrue(competingLock.get(5, TimeUnit.SECONDS).isPresent());
+    }
+
+    @Test
+    void concurrentRefreshWithSameTokenAllowsOnlyOneSuccess() throws Exception {
+        RefreshFixture fixture = createRefreshFixture();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        Callable<RefreshResult> refreshAttempt = () -> {
+            startLatch.await();
+            return refresh(fixture.refreshToken());
+        };
+
+        Future<RefreshResult> firstAttempt = executorService.submit(refreshAttempt);
+        Future<RefreshResult> secondAttempt = executorService.submit(refreshAttempt);
+
+        startLatch.countDown();
+
+        List<RefreshResult> results = List.of(
+                firstAttempt.get(10, TimeUnit.SECONDS),
+                secondAttempt.get(10, TimeUnit.SECONDS)
+        );
+
+        long successCount = results.stream()
+                .filter(RefreshResult::success)
+                .count();
+        long conflictCount = results.stream()
+                .filter(result -> HttpStatus.CONFLICT.equals(result.status()))
+                .count();
+
+        assertEquals(1L, successCount);
+        assertEquals(1L, conflictCount);
+    }
+
+    @Test
+    void refreshAfterLogoutFails() {
+        RefreshFixture fixture = createRefreshFixture();
+
+        authService.logout(new LogoutRequest(fixture.refreshToken()));
+
+        RefreshResult result = refresh(fixture.refreshToken());
+
+        assertFalse(result.success());
+        assertEquals(HttpStatus.UNAUTHORIZED, result.status());
+    }
+
+    @Test
+    void refreshAfterWithdrawalFails() {
+        RefreshFixture fixture = createRefreshFixture();
+        User user = userRepository.findById(fixture.userId())
+                .orElseThrow();
+
+        userWithdrawalService.hardDeleteUserData(user);
+
+        RefreshResult result = refresh(fixture.refreshToken());
+
+        assertFalse(result.success());
+        assertEquals(HttpStatus.UNAUTHORIZED, result.status());
+    }
+
+    private RefreshFixture createRefreshFixture() {
+        return transactionTemplate.execute(status -> {
+            User user = userRepository.save(User.builder()
+                    .tossUserKey("toss-user-key-" + UUID.randomUUID())
+                    .nickname("bread-lover")
+                    .email("bread-" + UUID.randomUUID() + "@toss.im")
+                    .build());
+
+            LocalDateTime issuedAt = LocalDateTime.now().minusMinutes(1);
+            LocalDateTime refreshExpiresAt = issuedAt.plusDays(30);
+            UserSession userSession = userSessionRepository.save(UserSession.builder()
+                    .userId(user.getId())
+                    .refreshTokenHash("__PENDING_REFRESH_TOKEN__")
+                    .currentJti("pending-" + UUID.randomUUID())
+                    .refreshExpiresAt(refreshExpiresAt)
+                    .build());
+
+            String refreshToken = jwtTokenProvider.createRefreshToken(
+                    user.getId(),
+                    userSession.getId(),
+                    INITIAL_JTI,
+                    issuedAt,
+                    refreshExpiresAt
+            );
+            userSession.rotateRefreshToken(
+                    hash(refreshToken),
+                    INITIAL_JTI,
+                    refreshExpiresAt
+            );
+
+            return new RefreshFixture(
+                    user.getId(),
+                    userSession.getId(),
+                    refreshToken
+            );
+        });
+    }
+
+    private RefreshResult refresh(String refreshToken) {
+        try {
+            AuthTokenResponse response = authService.refresh(new RefreshTokenRequest(refreshToken));
+            return new RefreshResult(true, null, response.getRefreshToken());
+        } catch (ResponseStatusException exception) {
+            return new RefreshResult(false, exception.getStatusCode(), null);
+        }
+    }
+
+    private String hash(String refreshToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(refreshToken.getBytes(StandardCharsets.UTF_8));
+
+            return Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(digest);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private void await(CountDownLatch latch) {
+        try {
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for lock verification.", exception);
+        }
+    }
+
+    private record RefreshFixture(
+            UUID userId,
+            UUID sessionId,
+            String refreshToken
+    ) {
+    }
+
+    private record RefreshResult(
+            boolean success,
+            HttpStatusCode status,
+            String refreshToken
+    ) {
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #47 

## 🛠️ 작업 내용

- Testcontainers + MySQL 8.0 기반 auth refresh 통합 테스트를 추가했습니다.
- 동일 session row에 대한 refresh 동시 요청 시 실제 row lock으로 직렬화되는지 검증했습니다.
- 동일 refresh token 동시 요청에서 1건만 성공하고, 나머지 요청은 rotation 이후 409 CONFLICT로 실패하는지 검증했습니다.
- logout 이후 refresh 실패, withdrawal 이후 refresh 실패 시나리오를 DB 기반 통합 테스트로 검증했습니다.
- `TossAuthClient`, `JwtTokenProvider`에서 실제로 사용하는 `RestClient.Builder`, `ObjectMapper` 빈 구성을 위해 `ClientConfig`가 운영 코드 기준으로 필요한지 확인했습니다.

## 📢 참고 및 특이사항

- 기존 mock/unit 테스트는 refresh rotation 정책을 검증했지만, 실제 MySQL row lock 대기와 해제는 검증하지 못하고 있었습니다.
- 이번 테스트는 실제 DB 트랜잭션 기준으로 `@Lock(PESSIMISTIC_WRITE)`가 의도대로 동작하는지 확인하는 목적입니다.
- `ClientConfig` 제거 시 `BreadDiaryApplicationTests.contextLoads()`가 실패했고, `RestClient.Builder` 또는 `ObjectMapper` 중 하나만 빠져도 production context가 깨지는 것을 확인했습니다.
- 따라서 `ClientConfig`는 test 전용이 아니라 현재 운영 코드에서도 필요한 설정으로 유지했습니다.
- `@ConditionalOnMissingBean`을 유지해 기존/향후 자동 설정과의 충돌 가능성을 줄였습니다.
- 전체 테스트 통과, `git diff --check` 통과 확인했습니다.
- `gradlew.bat`는 `gradle-wrapper.jar` 부재로 직접 Gradle 배포본 경로를 사용해 실행했습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인