### PR TITLE
refactor: replace bread X-USER-ID flow with bearer auth

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
@@ -6,17 +6,18 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
 import com.bean.breaddiary.global.common.ApiResponse;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +35,7 @@ public class BreadController {
 
     @Operation(
             summary = "빵 도감 목록 조회",
-            description = "전체 빵 카탈로그와 현재 유저의 수집 상태를 조회합니다. 비로그인 요청에서는 카탈로그 정보만 반환합니다."
+            description = "전체 빵 카탈로그를 조회합니다. Authorization 헤더가 있으면 현재 사용자 기준 수집 상태를 포함하고, 없으면 비로그인 카탈로그 정보만 반환합니다."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -58,9 +59,9 @@ public class BreadController {
             @RequestParam(value = "cursor", required = false) String cursor,
             @Parameter(description = "페이지당 개수. 기본 20, 최대 50", example = "20")
             @RequestParam(value = "limit", required = false) Integer limit,
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+            @Parameter(hidden = true) HttpServletRequest request
     ) {
+        UUID userId = AuthRequestAttributes.getOptionalUserId(request);
         BreadCatalogListResponse response = breadComplexService.getBreadCatalog(
                 sort,
                 filter,
@@ -76,7 +77,7 @@ public class BreadController {
 
     @Operation(
             summary = "빵 프로필 조회",
-            description = "카탈로그 빵의 마스터 정보와 현재 유저의 해당 빵 기록 통계 및 기록 목록을 조회합니다."
+            description = "카탈로그 빵의 마스터 정보를 조회합니다. Authorization 헤더가 있으면 현재 사용자 기준 기록 통계와 기록 목록을 포함합니다."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -91,9 +92,9 @@ public class BreadController {
     public ResponseEntity<ApiResponse<BreadProfileResponse>> getBreadProfile(
             @Parameter(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
             @PathVariable UUID breadId,
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+            @Parameter(hidden = true) HttpServletRequest request
     ) {
+        UUID userId = AuthRequestAttributes.getOptionalUserId(request);
         BreadProfileResponse response = breadComplexService.getBreadProfile(
                 breadId,
                 userId
@@ -104,7 +105,7 @@ public class BreadController {
 
     @Operation(
             summary = "빵 카탈로그 자동완성",
-            description = "빵 기록 시 사용할 빵 이름 자동완성 목록을 조회합니다. q가 없으면 인기순 기본 목록을 반환합니다."
+            description = "빵 기록 시 사용할 빵 이름 자동완성 목록을 조회합니다. q가 없으면 인기순 기본 목록을 반환하며, Authorization 헤더가 있으면 현재 사용자 기준 기록 수를 포함합니다."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -118,9 +119,9 @@ public class BreadController {
     public ResponseEntity<ApiResponse<BreadAutocompleteResponse>> autocompleteBreads(
             @Parameter(description = "검색어. 미입력 시 인기순 빵 목록을 반환합니다.", example = "크루")
             @RequestParam(value = "q", required = false) String query,
-            @Parameter(description = "임시 사용자 ID. user/auth 연동 전까지 사용합니다.", example = "00000000-0000-0000-0000-000000000001")
-            @RequestHeader(value = "X-USER-ID", required = false) UUID userId
+            @Parameter(hidden = true) HttpServletRequest request
     ) {
+        UUID userId = AuthRequestAttributes.getOptionalUserId(request);
         BreadAutocompleteResponse response = breadComplexService.autocompleteBreads(query, userId);
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
@@ -32,10 +32,19 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        if (!requiresAuthentication(request)) {
+        if (isPublicEndpoint(request)) {
             return true;
         }
 
+        if (isOptionalAuthEndpoint(request) && !hasAuthorizationHeader(request)) {
+            return true;
+        }
+
+        authenticate(request);
+        return true;
+    }
+
+    private void authenticate(HttpServletRequest request) {
         String accessToken = resolveAccessToken(request);
         LocalDateTime now = LocalDateTime.now();
         JwtTokenProvider.JwtTokenClaims claims = jwtTokenProvider.parseToken(accessToken);
@@ -57,43 +66,57 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         request.setAttribute(AuthRequestAttributes.USER_ID, claims.userId());
         request.setAttribute(AuthRequestAttributes.SESSION_ID, claims.sessionId());
-        return true;
     }
 
-    private boolean requiresAuthentication(HttpServletRequest request) {
+    private boolean isPublicEndpoint(HttpServletRequest request) {
         String method = request.getMethod();
         String requestUri = request.getRequestURI();
 
         if (HTTP_OPTIONS.equalsIgnoreCase(method)) {
-            return false;
+            return true;
         }
 
         if ("/error".equals(requestUri)
                 || "/swagger-ui.html".equals(requestUri)
                 || PATH_MATCHER.match("/swagger-ui/**", requestUri)
                 || PATH_MATCHER.match("/v3/api-docs/**", requestUri)) {
-            return false;
+            return true;
         }
 
         if (HTTP_POST.equalsIgnoreCase(method)
                 && ("/auth/toss".equals(requestUri)
                 || "/auth/refresh".equals(requestUri)
                 || "/auth/webhook/toss-unlink".equals(requestUri))) {
-            return false;
+            return true;
+        }
+
+        if (HTTP_POST.equalsIgnoreCase(method) && "/dev/auth/token".equals(requestUri)) {
+            return true;
         }
 
         if (HTTP_GET.equalsIgnoreCase(method) && "/bread-types".equals(requestUri)) {
-            return false;
+            return true;
         }
+
+        return false;
+    }
+
+    private boolean isOptionalAuthEndpoint(HttpServletRequest request) {
+        String method = request.getMethod();
+        String requestUri = request.getRequestURI();
 
         if (HTTP_GET.equalsIgnoreCase(method)
                 && ("/breads".equals(requestUri)
                 || "/breads/autocomplete".equals(requestUri)
                 || PATH_MATCHER.match("/breads/catalog/*", requestUri))) {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
+    }
+
+    private boolean hasAuthorizationHeader(HttpServletRequest request) {
+        return StringUtils.hasText(request.getHeader(HttpHeaders.AUTHORIZATION));
     }
 
     private String resolveAccessToken(HttpServletRequest request) {

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthRequestAttributes.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthRequestAttributes.java
@@ -22,13 +22,31 @@ public final class AuthRequestAttributes {
         return getRequiredUuid(request, SESSION_ID);
     }
 
+    public static UUID getOptionalUserId(HttpServletRequest request) {
+        return getOptionalUuid(request, USER_ID);
+    }
+
+    public static UUID getOptionalSessionId(HttpServletRequest request) {
+        return getOptionalUuid(request, SESSION_ID);
+    }
+
     private static UUID getRequiredUuid(HttpServletRequest request, String attributeName) {
+        UUID value = getOptionalUuid(request, attributeName);
+
+        if (value != null) {
+            return value;
+        }
+
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    }
+
+    private static UUID getOptionalUuid(HttpServletRequest request, String attributeName) {
         Object value = request.getAttribute(attributeName);
 
         if (value instanceof UUID uuid) {
             return uuid;
         }
 
-        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        return null;
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
@@ -4,6 +4,7 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemRespon
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
@@ -56,7 +57,7 @@ class BreadControllerAutocompleteTest {
 
         mockMvc.perform(get("/breads/autocomplete")
                         .param("q", "크루")
-                        .header("X-USER-ID", userId.toString()))
+                        .requestAttr(AuthRequestAttributes.USER_ID, userId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.items[0].bread_id").value(breadId.toString()))

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerCatalogTest.java
@@ -4,6 +4,7 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogListResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
@@ -76,7 +77,7 @@ class BreadControllerCatalogTest {
                         .param("bread_type", "PASTRY")
                         .param("search", "크루")
                         .param("limit", "20")
-                        .header("X-USER-ID", userId.toString()))
+                        .requestAttr(AuthRequestAttributes.USER_ID, userId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.items[0].bread_id").value(breadId.toString()))

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
@@ -5,6 +5,7 @@ import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadComplexService;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
@@ -70,7 +71,7 @@ class BreadControllerProfileTest {
         when(breadComplexService.getBreadProfile(breadId, userId)).thenReturn(response);
 
         mockMvc.perform(get("/breads/catalog/{breadId}", breadId)
-                        .header("X-USER-ID", userId.toString()))
+                        .requestAttr(AuthRequestAttributes.USER_ID, userId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.bread_id").value(breadId.toString()))

--- a/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
+++ b/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
@@ -67,6 +67,69 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void preHandleSkipsLocalDevAuthTokenEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/dev/auth/token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
+    void preHandleAllowsAnonymousRequestForOptionalBreadCatalogEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/breads");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        assertEquals(null, request.getAttribute(AuthRequestAttributes.USER_ID));
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
+    void preHandleAuthenticatesBearerTokenForOptionalBreadCatalogEndpoint() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440030");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440031");
+        LocalDateTime now = LocalDateTime.now();
+        String accessToken = jwtTokenProvider.createAccessToken(
+                userId,
+                sessionId,
+                now,
+                now.plusDays(1)
+        );
+        UserSession userSession = UserSession.builder()
+                .id(sessionId)
+                .userId(userId)
+                .refreshTokenHash("hashed-refresh-token")
+                .currentJti("current-jti")
+                .refreshExpiresAt(now.plusDays(30))
+                .build();
+
+        when(userSessionService.findActiveSession(eq(sessionId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(userSession));
+
+        MockHttpServletRequest request = authorizedRequest("GET", "/breads", accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        assertEquals(userId, request.getAttribute(AuthRequestAttributes.USER_ID));
+        assertEquals(sessionId, request.getAttribute(AuthRequestAttributes.SESSION_ID));
+    }
+
+    @Test
+    void preHandleRejectsInvalidBearerTokenForOptionalBreadCatalogEndpoint() {
+        MockHttpServletRequest request = authorizedRequest("GET", "/breads", "invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> authInterceptor.preHandle(request, response, handlerMethod)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
     void preHandleRejectsMissingBearerTokenForProtectedEndpoint() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/breads/550e8400-e29b-41d4-a716-446655440000");
         MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## 🧩 관련 이슈

- #49 

## 🛠️ 작업 내용
- 임시 `X-USER-ID` 기반 사용자 식별 방식을 제거했습니다
- `Authorization`을 통해서 로그인 유저, 비로그인 유저를 구분할 수 있도록 분기처리 작업 했습니다.

## 📢 참고 및 특이사항
- 없습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인