### PR TITLE
fix: prevent FK failure when deleting user-created bread records

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
@@ -100,9 +100,6 @@ public class BreadRecordComplexService {
         breadRecordService.deleteBreadRecord(breadRecord);
 
         boolean stickerRemoved = !breadRecordService.hasRemainingActiveRecord(userId, bread);
-        if (stickerRemoved && !breadRecordService.existsActiveRecordByBread(bread)) {
-            breadService.deleteIfUserCreated(bread);
-        }
 
         return new BreadRecordDeleteResponse(stickerRemoved);
     }

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexServiceTest.java
@@ -111,19 +111,18 @@ class BreadRecordComplexServiceTest {
     }
 
     @Test
-    void deleteBreadRecordDeletesUserCreatedBreadWhenNoActiveRecordRemains() {
+    void deleteBreadRecordDoesNotDeleteBreadBecauseSoftDeletedRecordStillReferencesIt() {
         Bread bread = createBread(USER_ID);
         BreadRecord breadRecord = createBreadRecord(bread);
 
         when(breadRecordService.getActiveRecordForUser(USER_ID, RECORD_ID)).thenReturn(breadRecord);
         when(breadRecordService.hasRemainingActiveRecord(USER_ID, bread)).thenReturn(false);
-        when(breadRecordService.existsActiveRecordByBread(bread)).thenReturn(false);
 
         BreadRecordDeleteResponse response = breadRecordComplexService.deleteBreadRecord(USER_ID, RECORD_ID);
 
         assertTrue(response.getStickerRemoved());
         verify(breadRecordService).deleteBreadRecord(breadRecord);
-        verify(breadService).deleteIfUserCreated(bread);
+        verify(breadService, never()).deleteIfUserCreated(bread);
     }
 
     private Bread createBread(UUID createdBy) {


### PR DESCRIPTION
## 🧩 관련 이슈

- #51 

## 🛠️ 작업 내용
- 빵의 마지막 기록 삭제 시 `breads` 부모 row를 삭제하려다 발생하던 FK 제약 오류를 수정했습니다.
- `bread_records`는 soft delete 방식으로 유지하고, 삭제 응답의 `sticker_removed` 여부만 반환하도록 정리했습니다.
  - `sticker_removed` 를 `true`로 변경

## 📢 참고 및 특이사항
- 명세서는 물리 삭제로 적혀있어서 이 부분은 PO님이랑 따로 이야기를 해서 수정해보겠습니다
- 빵 도메인 API는 잘 동작하는것을 확인했습니다.(놓친게 없다면..)

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인