### PR TITLE
fix: prevent thumbnail suffix from applying to bread text fields

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -114,18 +114,7 @@ public interface BreadMapper {
             return null;
         }
 
-        return toThumbnailUrl(stats.getLatestPhotoUrl());
-    }
-
-    default String toThumbnailUrl(String photoUrl) {
-        int extensionIndex = photoUrl.lastIndexOf('.');
-        if (extensionIndex < 0) {
-            return photoUrl + "_thumb";
-        }
-
-        return photoUrl.substring(0, extensionIndex)
-                + "_thumb"
-                + photoUrl.substring(extensionIndex);
+        return com.bean.breaddiary.global.common.ThumbnailUrlUtils.toThumbnailUrl(stats.getLatestPhotoUrl());
     }
 
     @Mapping(target = "breadId", source = "bread.id")

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/mapper/BreadRecordMapper.java
@@ -58,7 +58,7 @@ public interface BreadRecordMapper {
     @Mapping(target = "name", source = "breadRecord.bread.name")
     @Mapping(target = "breadType", source = "breadRecord.bread.breadType")
     @Mapping(target = "imageUrl", source = "breadRecord.bread.imageUrl")
-    @Mapping(target = "photoThumbnailUrl", expression = "java(toThumbnailUrl(breadRecord.getPhotoUrl()))")
+    @Mapping(target = "photoThumbnailUrl", expression = "java(com.bean.breaddiary.global.common.ThumbnailUrlUtils.toThumbnailUrl(breadRecord.getPhotoUrl()))")
     @Mapping(target = "isFirstRecord", source = "isFirstRecord")
     BreadRecordCreateResponse mapToCreateResponse(
             BreadRecord breadRecord,
@@ -71,23 +71,8 @@ public interface BreadRecordMapper {
     @Mapping(target = "breadType", source = "breadRecord.bread.breadType")
     @Mapping(target = "breadTypeLabel", expression = "java(toBreadTypeLabel(breadRecord.getBread().getBreadType()))")
     @Mapping(target = "imageUrl", source = "breadRecord.bread.imageUrl")
-    @Mapping(target = "photoThumbnailUrl", expression = "java(toThumbnailUrl(breadRecord.getPhotoUrl()))")
+    @Mapping(target = "photoThumbnailUrl", expression = "java(com.bean.breaddiary.global.common.ThumbnailUrlUtils.toThumbnailUrl(breadRecord.getPhotoUrl()))")
     BreadRecordDetailResponse mapToDetailResponse(BreadRecord breadRecord);
-
-    default String toThumbnailUrl(String photoUrl) {
-        if (photoUrl == null) {
-            return null;
-        }
-
-        int extensionIndex = photoUrl.lastIndexOf('.');
-        if (extensionIndex < 0) {
-            return photoUrl + "_thumb";
-        }
-
-        return photoUrl.substring(0, extensionIndex)
-                + "_thumb"
-                + photoUrl.substring(extensionIndex);
-    }
 
     default Map<UUID, BreadRecordCatalogStats> mapToCatalogStatsMap(
             List<BreadRecordCatalogStatsProjection> statsProjections,
@@ -114,7 +99,7 @@ public interface BreadRecordMapper {
                 ));
     }
 
-    @Mapping(target = "photoThumbnailUrl", expression = "java(toThumbnailUrl(breadRecord.getPhotoUrl()))")
+    @Mapping(target = "photoThumbnailUrl", expression = "java(com.bean.breaddiary.global.common.ThumbnailUrlUtils.toThumbnailUrl(breadRecord.getPhotoUrl()))")
     BreadProfileRecordResponse mapToProfileRecord(BreadRecord breadRecord);
 
     default List<BreadProfileRecordResponse> mapToProfileRecords(List<BreadRecord> breadRecords) {

--- a/src/main/java/com/bean/breaddiary/global/common/ThumbnailUrlUtils.java
+++ b/src/main/java/com/bean/breaddiary/global/common/ThumbnailUrlUtils.java
@@ -1,0 +1,24 @@
+package com.bean.breaddiary.global.common;
+
+public final class ThumbnailUrlUtils {
+
+    private static final String THUMBNAIL_SUFFIX = "_thumb";
+
+    private ThumbnailUrlUtils() {
+    }
+
+    public static String toThumbnailUrl(String photoUrl) {
+        if (photoUrl == null) {
+            return null;
+        }
+
+        int extensionIndex = photoUrl.lastIndexOf('.');
+        if (extensionIndex < 0) {
+            return photoUrl + THUMBNAIL_SUFFIX;
+        }
+
+        return photoUrl.substring(0, extensionIndex)
+                + THUMBNAIL_SUFFIX
+                + photoUrl.substring(extensionIndex);
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #53 

## 🛠️ 작업 내용

- MapStruct가 썸네일 URL 변환 메서드 도중 thumbnail을 subfix로 붙이는 문제를 수정했습니다.
- 썸네일 URL 변환 로직을 명시적인 유틸로 분리했습니다.

## 📢 참고 및 특이사항
- 유저가 업로드한 실제 사진은 기존처럼 S3에 저장되며 `photo_url`로 사용됩니다.
- cdn은 잘 모르겟는데 PO님이랑 상의해보겠습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인