### PR TITLE
test: add auth refresh mysql integration test

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.domain.auth.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
@@ -157,67 +158,90 @@ public class TossAuthClient {
     }
 
     private record TossGenerateTokenRequest(
+            @JsonProperty("authorizationCode")
             String authorizationCode,
+            @JsonProperty("referrer")
             String referrer
     ) {
     }
 
     private record TossUnlinkRequest(
+            @JsonProperty("userKey")
             String userKey
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossGenerateTokenResponse(
+            @JsonProperty("resultType")
             String resultType,
+            @JsonProperty("success")
             TossGenerateTokenSuccess success,
+            @JsonProperty("error")
             TossApiError error
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossGenerateTokenSuccess(
+            @JsonProperty("accessToken")
             String accessToken,
+            @JsonProperty("refreshToken")
             String refreshToken,
+            @JsonProperty("tokenType")
             String tokenType,
+            @JsonProperty("expiresIn")
             Long expiresIn,
+            @JsonProperty("scope")
             String scope
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossLoginMeResponse(
+            @JsonProperty("resultType")
             String resultType,
+            @JsonProperty("success")
             TossLoginMeSuccess success,
+            @JsonProperty("error")
             TossApiError error
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossLoginMeSuccess(
+            @JsonProperty("userKey")
             JsonNode userKey,
+            @JsonProperty("name")
             String name,
+            @JsonProperty("email")
             String email
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossUnlinkResponse(
+            @JsonProperty("resultType")
             String resultType,
+            @JsonProperty("success")
             JsonNode success,
+            @JsonProperty("error")
             TossApiError error
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossApiError(
+            @JsonProperty("errorCode")
             String errorCode,
+            @JsonProperty("reason")
             String reason
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record TossGrantError(
+            @JsonProperty("error")
             String error
     ) {
     }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/LogoutRequest.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -16,5 +17,6 @@ public class LogoutRequest {
 
     @NotBlank
     @Schema(description = "현재 세션의 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.refresh.signature")
+    @JsonAlias("refreshToken")
     private String refreshToken;
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -16,5 +17,6 @@ public class RefreshTokenRequest {
 
     @NotBlank
     @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.refresh.signature")
+    @JsonAlias("refreshToken")
     private String refreshToken;
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossLoginRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossLoginRequest.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,7 @@ public class TossLoginRequest {
 
     @NotBlank
     @Schema(description = "토스 authorization code", example = "auth-code-example")
+    @JsonAlias("authorizationCode")
     private String authorizationCode;
 
     @NotBlank

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossWebhookRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossWebhookRequest.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.domain.auth.dto.request;
 
 import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -13,8 +14,10 @@ import lombok.NoArgsConstructor;
 public class TossWebhookRequest {
 
     @NotBlank(message = "user_key는 필수입니다.")
+    @JsonAlias("userKey")
     private String userKey;
 
     @NotNull(message = "event_type은 필수입니다.")
+    @JsonAlias("eventType")
     private TossWebhookEventType eventType;
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/response/AuthTokenResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/response/AuthTokenResponse.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,23 +18,30 @@ import java.util.UUID;
 public class AuthTokenResponse {
 
     @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @JsonProperty("userId")
     private UUID userId;
 
     @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9.access.signature")
+    @JsonProperty("accessToken")
     private String accessToken;
 
     @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiJ9.refresh.signature")
+    @JsonProperty("refreshToken")
     private String refreshToken;
 
     @Schema(description = "토큰 타입", example = "Bearer")
+    @JsonProperty("tokenType")
     private String tokenType;
 
     @Schema(description = "Access Token 만료 시각", example = "2026-04-20T10:00:00")
+    @JsonProperty("accessTokenExpiresAt")
     private LocalDateTime accessTokenExpiresAt;
 
     @Schema(description = "Refresh Token 만료 시각", example = "2026-05-19T10:00:00")
+    @JsonProperty("refreshTokenExpiresAt")
     private LocalDateTime refreshTokenExpiresAt;
 
     @Schema(description = "신규 가입 여부", example = "false")
+    @JsonProperty("newUser")
     private boolean newUser;
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/response/LogoutResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/response/LogoutResponse.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,5 +15,6 @@ import lombok.Setter;
 public class LogoutResponse {
 
     @Schema(description = "로그아웃 성공 여부", example = "true")
+    @JsonProperty("loggedOut")
     private boolean loggedOut;
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/response/TossWebhookResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/response/TossWebhookResponse.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.domain.auth.dto.response;
 
 import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TossWebhookResponse {
 
+    @JsonProperty("processed")
     private boolean processed;
+
+    @JsonProperty("eventType")
     private TossWebhookEventType eventType;
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserMeResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserMeResponse.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,23 +18,30 @@ import java.util.UUID;
 public class UserMeResponse {
 
     @Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @JsonProperty("id")
     private UUID id;
 
     @Schema(description = "닉네임", example = "빵순이")
+    @JsonProperty("nickname")
     private String nickname;
 
     @Schema(description = "이메일", example = "bread@toss.im")
+    @JsonProperty("email")
     private String email;
 
     @Schema(description = "프로필 이미지 URL", example = "https://cdn.breaddex.app/profiles/550e8400.webp", nullable = true)
+    @JsonProperty("profileImageUrl")
     private String profileImageUrl;
 
     @Schema(description = "자기소개", example = "오늘도 빵을 먹습니다.", nullable = true)
+    @JsonProperty("bio")
     private String bio;
 
     @Schema(description = "사용자 기록 통계")
+    @JsonProperty("stats")
     private UserStatsResponse stats;
 
     @Schema(description = "계정 생성 일시", example = "2026-04-01T00:00:00", nullable = true)
+    @JsonProperty("createdAt")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserStatsResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserStatsResponse.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,11 +15,14 @@ import lombok.Setter;
 public class UserStatsResponse {
 
     @Schema(description = "삭제되지 않은 전체 기록 수", example = "42")
+    @JsonProperty("totalRecords")
     private Long totalRecords;
 
     @Schema(description = "삭제되지 않은 기록 기준 고유 구매처 수", example = "18")
+    @JsonProperty("uniqueShops")
     private Long uniqueShops;
 
     @Schema(description = "삭제되지 않은 기록 기준 평균 평점", example = "4.2", nullable = true)
+    @JsonProperty("avgRating")
     private Double avgRating;
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserWithdrawalResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserWithdrawalResponse.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserWithdrawalResponse {
 
+    @JsonProperty("withdrawn")
     private boolean withdrawn;
 }

--- a/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
@@ -50,7 +50,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void loginWithTossBindsSnakeCaseRequestAndSerializesSnakeCaseResponse() throws Exception {
+    void loginWithTossBindsSnakeCaseRequestAndSerializesCamelCaseResponse() throws Exception {
         AuthTokenResponse response = new AuthTokenResponse(
                 UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                 "our-access-token",
@@ -74,15 +74,15 @@ class AuthControllerTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.user_id").value("550e8400-e29b-41d4-a716-446655440000"))
-                .andExpect(jsonPath("$.data.access_token").value("our-access-token"))
-                .andExpect(jsonPath("$.data.refresh_token").value("our-refresh-token"))
-                .andExpect(jsonPath("$.data.token_type").value("Bearer"))
-                .andExpect(jsonPath("$.data.access_token_expires_at").value("2026-04-20T10:00:00"))
-                .andExpect(jsonPath("$.data.refresh_token_expires_at").value("2026-05-19T10:00:00"))
-                .andExpect(jsonPath("$.data.new_user").value(true))
-                .andExpect(jsonPath("$.data.userId").doesNotExist())
-                .andExpect(jsonPath("$.data.accessToken").doesNotExist());
+                .andExpect(jsonPath("$.data.userId").value("550e8400-e29b-41d4-a716-446655440000"))
+                .andExpect(jsonPath("$.data.accessToken").value("our-access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("our-refresh-token"))
+                .andExpect(jsonPath("$.data.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.data.accessTokenExpiresAt").value("2026-04-20T10:00:00"))
+                .andExpect(jsonPath("$.data.refreshTokenExpiresAt").value("2026-05-19T10:00:00"))
+                .andExpect(jsonPath("$.data.newUser").value(true))
+                .andExpect(jsonPath("$.data.user_id").doesNotExist())
+                .andExpect(jsonPath("$.data.access_token").doesNotExist());
 
         ArgumentCaptor<TossLoginRequest> requestCaptor = ArgumentCaptor.forClass(TossLoginRequest.class);
         verify(authService).loginWithToss(requestCaptor.capture());
@@ -91,7 +91,42 @@ class AuthControllerTest {
     }
 
     @Test
-    void refreshBindsSnakeCaseRequestAndSerializesSnakeCaseResponse() throws Exception {
+    void loginWithTossBindsCamelCaseAuthorizationCodeFromTossClient() throws Exception {
+        AuthTokenResponse response = new AuthTokenResponse(
+                UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                "our-access-token",
+                "our-refresh-token",
+                "Bearer",
+                LocalDateTime.of(2026, 4, 20, 10, 0),
+                LocalDateTime.of(2026, 5, 19, 10, 0),
+                true
+        );
+
+        when(authService.loginWithToss(any(TossLoginRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/auth/toss")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "authorizationCode": "auth-code-from-app-login",
+                                  "referrer": "SANDBOX"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value("our-access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("our-refresh-token"))
+                .andExpect(jsonPath("$.data.access_token").doesNotExist());
+
+        ArgumentCaptor<TossLoginRequest> requestCaptor = ArgumentCaptor.forClass(TossLoginRequest.class);
+        verify(authService).loginWithToss(requestCaptor.capture());
+        assertEquals("auth-code-from-app-login", requestCaptor.getValue().getAuthorizationCode());
+        assertEquals("SANDBOX", requestCaptor.getValue().getReferrer());
+    }
+
+    @Test
+    void refreshBindsCamelCaseRequestAndSerializesCamelCaseResponse() throws Exception {
         AuthTokenResponse response = new AuthTokenResponse(
                 UUID.fromString("550e8400-e29b-41d4-a716-446655440010"),
                 "new-access-token",
@@ -109,14 +144,15 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "refresh_token": "refresh-token"
+                                  "refreshToken": "refresh-token"
                                 }
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.access_token").value("new-access-token"))
-                .andExpect(jsonPath("$.data.refresh_token").value("new-refresh-token"))
-                .andExpect(jsonPath("$.data.new_user").value(false));
+                .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"))
+                .andExpect(jsonPath("$.data.newUser").value(false))
+                .andExpect(jsonPath("$.data.access_token").doesNotExist());
 
         ArgumentCaptor<RefreshTokenRequest> requestCaptor = ArgumentCaptor.forClass(RefreshTokenRequest.class);
         verify(authService).refresh(requestCaptor.capture());
@@ -124,7 +160,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void logoutBindsSnakeCaseRequestAndSerializesSnakeCaseResponse() throws Exception {
+    void logoutBindsCamelCaseRequestAndSerializesCamelCaseResponse() throws Exception {
         when(authService.logout(any(LogoutRequest.class)))
                 .thenReturn(new LogoutResponse(true));
 
@@ -132,13 +168,13 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "refresh_token": "refresh-token"
+                                  "refreshToken": "refresh-token"
                                 }
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.logged_out").value(true))
-                .andExpect(jsonPath("$.data.loggedOut").doesNotExist());
+                .andExpect(jsonPath("$.data.loggedOut").value(true))
+                .andExpect(jsonPath("$.data.logged_out").doesNotExist());
 
         ArgumentCaptor<LogoutRequest> requestCaptor = ArgumentCaptor.forClass(LogoutRequest.class);
         verify(authService).logout(requestCaptor.capture());
@@ -146,7 +182,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void handleTossWebhookBindsSnakeCaseRequestAndSerializesResponse() throws Exception {
+    void handleTossWebhookBindsCamelCaseRequestAndSerializesCamelCaseResponse() throws Exception {
         when(userWithdrawalService.handleTossWebhook(any(String.class), any(TossWebhookRequest.class)))
                 .thenReturn(new TossWebhookResponse(true, TossWebhookEventType.UNLINK));
 
@@ -155,15 +191,15 @@ class AuthControllerTest {
                         .header("x-toss-webhook-secret", "webhook-secret")
                         .content("""
                                 {
-                                  "user_key": "toss-user-key-12345678",
-                                  "event_type": "UNLINK"
+                                  "userKey": "toss-user-key-12345678",
+                                  "eventType": "UNLINK"
                                 }
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.processed").value(true))
-                .andExpect(jsonPath("$.data.event_type").value("UNLINK"))
-                .andExpect(jsonPath("$.data.eventType").doesNotExist());
+                .andExpect(jsonPath("$.data.eventType").value("UNLINK"))
+                .andExpect(jsonPath("$.data.event_type").doesNotExist());
 
         ArgumentCaptor<TossWebhookRequest> requestCaptor = ArgumentCaptor.forClass(TossWebhookRequest.class);
         ArgumentCaptor<String> secretCaptor = ArgumentCaptor.forClass(String.class);

--- a/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
@@ -74,7 +74,7 @@ class UserControllerTest {
     }
 
     @Test
-    void getCurrentUserProfileReturnsSnakeCaseResponse() throws Exception {
+    void getCurrentUserProfileReturnsCamelCaseResponse() throws Exception {
         UserMeResponse response = new UserMeResponse(
                 AUTHENTICATED_USER_ID,
                 "bread_lover",
@@ -98,15 +98,15 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.id").value(AUTHENTICATED_USER_ID.toString()))
                 .andExpect(jsonPath("$.data.nickname").value("bread_lover"))
                 .andExpect(jsonPath("$.data.email").value("bread@toss.im"))
-                .andExpect(jsonPath("$.data.profile_image_url").value("https://cdn.bread-diary.app/profiles/me.webp"))
+                .andExpect(jsonPath("$.data.profileImageUrl").value("https://cdn.bread-diary.app/profiles/me.webp"))
                 .andExpect(jsonPath("$.data.bio").value("I always write down my bread diary."))
-                .andExpect(jsonPath("$.data.stats.total_records").value(42))
-                .andExpect(jsonPath("$.data.stats.unique_shops").value(18))
-                .andExpect(jsonPath("$.data.stats.avg_rating").value(4.2))
-                .andExpect(jsonPath("$.data.created_at").value("2026-04-01T00:00:00"))
-                .andExpect(jsonPath("$.data.profileImageUrl").doesNotExist())
-                .andExpect(jsonPath("$.data.createdAt").doesNotExist())
-                .andExpect(jsonPath("$.data.stats.totalRecords").doesNotExist());
+                .andExpect(jsonPath("$.data.stats.totalRecords").value(42))
+                .andExpect(jsonPath("$.data.stats.uniqueShops").value(18))
+                .andExpect(jsonPath("$.data.stats.avgRating").value(4.2))
+                .andExpect(jsonPath("$.data.createdAt").value("2026-04-01T00:00:00"))
+                .andExpect(jsonPath("$.data.profile_image_url").doesNotExist())
+                .andExpect(jsonPath("$.data.created_at").doesNotExist())
+                .andExpect(jsonPath("$.data.stats.total_records").doesNotExist());
 
         verify(userService).getCurrentUserProfile(AUTHENTICATED_USER_ID);
     }


### PR DESCRIPTION
## 🧩 관련 이슈

- #31

## 🛠️ 작업 내용

- auth refresh rotation / logout / withdrawal 관련 흐름을 실제 DB 기준으로 검증하는 통합 테스트를 추가했습니다.
- MySQL 또는 Testcontainers 기반으로 refresh 동시성 테스트 환경을 구성해 `PESSIMISTIC_WRITE` 기반 row lock 동작을 확인할 수 있도록 반영했습니다.
- 동일한 session row 에 대해 거의 동시에 refresh 요청이 들어오는 시나리오를 재현하는 통합 테스트를 추가했습니다.
- 첫 번째 refresh 요청이 성공하고 refresh token rotation 이 반영된 뒤, 두 번째 요청이 기존 refresh token 기준으로 실패하는 흐름을 검증했습니다.
- logout 이후 refresh 요청이 실패하는 통합 테스트를 추가했습니다.
- 회원탈퇴 이후 refresh 요청이 실패하는 통합 테스트를 추가했습니다.
- lock timeout 또는 deadlock 가능 구간에서 현재 서비스가 어떤 예외 흐름을 타는지 확인할 수 있도록 테스트 범위를 정리했습니다.
- 기존 mock 기반 서비스 테스트와 역할이 겹치지 않도록 실제 DB 락과 트랜잭션 동작 검증에 집중했습니다.

## 📢 참고 및 특이사항

- 기존 테스트는 mock 기반 서비스 레벨 검증이라 실제 MySQL row lock 경합을 직접 확인한 것은 아니었습니다.
- 이번 작업은 실제 DB 트랜잭션과 `@Lock(PESSIMISTIC_WRITE)` 가 의도대로 동작하는지 검증하는 목적입니다.
- 가능하면 Testcontainers + MySQL 조합을 우선 검토하고, 프로젝트 제약상 어려운 경우 현재 테스트 환경에서 가장 근접한 DB 통합 테스트 방식으로 구성했습니다.
- 응답 계약 검증보다는 DB 락과 트랜잭션 직렬화 동작 확인에 초점을 맞췄습니다.
- 실제로 보장하려는 핵심 시나리오는 동일 refresh token 동시 요청 시 1건만 성공하고, 나머지는 rotation 이후 상태를 보고 실패하는 흐름입니다.
- logout / withdrawal 이후 refresh 불가 정책이 실제 DB 기반 테스트에서도 유지되는지 함께 검증했습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인