### PR TITLE
feat: add totalStickers to user me stats

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/UserStatsProjection.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/dto/projection/UserStatsProjection.java
@@ -4,6 +4,8 @@ public interface UserStatsProjection {
 
     Long getTotalRecords();
 
+    Long getTotalStickers();
+
     Long getUniqueShops();
 
     Double getAvgRating();

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -82,6 +82,7 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
 
     @Query("""
             select count(br) as totalRecords,
+                   count(distinct br.bread.id) as totalStickers,
                    count(distinct case
                        when br.shopName is not null and trim(br.shopName) <> '' then trim(br.shopName)
                        else null

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/mapper/UserMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/mapper/UserMapper.java
@@ -22,12 +22,14 @@ public interface UserMapper {
             return new UserStatsResponse(
                     0L,
                     0L,
+                    0L,
                     0.0
             );
         }
 
         return new UserStatsResponse(
                 resolveCount(projection.getTotalRecords()),
+                resolveCount(projection.getTotalStickers()),
                 resolveCount(projection.getUniqueShops()),
                 roundRating(projection.getAvgRating())
         );

--- a/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserStatsResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/dto/response/UserStatsResponse.java
@@ -18,6 +18,10 @@ public class UserStatsResponse {
     @JsonProperty("totalRecords")
     private Long totalRecords;
 
+    @Schema(description = "삭제되지 않은 기록 기준 고유 빵 스티커 수", example = "15")
+    @JsonProperty("totalStickers")
+    private Long totalStickers;
+
     @Schema(description = "삭제되지 않은 기록 기준 고유 구매처 수", example = "18")
     @JsonProperty("uniqueShops")
     private Long uniqueShops;

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepositoryTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepositoryTest.java
@@ -44,6 +44,7 @@ class BreadRecordRepositoryTest {
 
         assertNotNull(stats);
         assertEquals(6L, stats.getTotalRecords());
+        assertEquals(1L, stats.getTotalStickers());
         assertEquals(2L, stats.getUniqueShops());
         assertEquals(3.3333333333333335, stats.getAvgRating());
     }
@@ -60,14 +61,42 @@ class BreadRecordRepositoryTest {
 
         assertNotNull(stats);
         assertEquals(1L, stats.getTotalRecords());
+        assertEquals(1L, stats.getTotalStickers());
         assertEquals(1L, stats.getUniqueShops());
         assertEquals(5.0, stats.getAvgRating());
     }
 
+    @Test
+    void findUserStatsByUserIdCountsDistinctActiveBreadsAsTotalStickers() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+        Bread firstBread = saveBread(1);
+        Bread secondBread = saveBread(2);
+        Bread thirdBread = saveBread(3);
+        Bread deletedOnlyBread = saveBread(4);
+
+        saveBreadRecord(userId, firstBread, "shop-a", 5, null);
+        saveBreadRecord(userId, firstBread, "shop-a", 4, null);
+        saveBreadRecord(userId, secondBread, "shop-b", 3, null);
+        saveBreadRecord(userId, thirdBread, "shop-c", 2, null);
+        saveBreadRecord(userId, deletedOnlyBread, "shop-d", 1, LocalDateTime.of(2026, 4, 18, 12, 0));
+
+        UserStatsProjection stats = breadRecordRepository.findUserStatsByUserId(userId);
+
+        assertNotNull(stats);
+        assertEquals(4L, stats.getTotalRecords());
+        assertEquals(3L, stats.getTotalStickers());
+        assertEquals(3L, stats.getUniqueShops());
+        assertEquals(3.5, stats.getAvgRating());
+    }
+
     private Bread saveBread() {
+        return saveBread(1);
+    }
+
+    private Bread saveBread(int stickerNumber) {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
         Bread bread = Bread.builder()
-                .stickerNumber(1)
+                .stickerNumber(stickerNumber)
                 .name("bread-" + suffix)
                 .breadType(BreadType.BREAD)
                 .imageUrl("https://cdn.bread-diary.app/breads/test.webp")

--- a/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/controller/UserControllerTest.java
@@ -81,7 +81,7 @@ class UserControllerTest {
                 "bread@toss.im",
                 "https://cdn.bread-diary.app/profiles/me.webp",
                 "I always write down my bread diary.",
-                new UserStatsResponse(42L, 18L, 4.2),
+                new UserStatsResponse(42L, 15L, 18L, 4.2),
                 PROFILE_CREATED_AT
         );
 
@@ -101,12 +101,14 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.profileImageUrl").value("https://cdn.bread-diary.app/profiles/me.webp"))
                 .andExpect(jsonPath("$.data.bio").value("I always write down my bread diary."))
                 .andExpect(jsonPath("$.data.stats.totalRecords").value(42))
+                .andExpect(jsonPath("$.data.stats.totalStickers").value(15))
                 .andExpect(jsonPath("$.data.stats.uniqueShops").value(18))
                 .andExpect(jsonPath("$.data.stats.avgRating").value(4.2))
                 .andExpect(jsonPath("$.data.createdAt").value("2026-04-01T00:00:00"))
                 .andExpect(jsonPath("$.data.profile_image_url").doesNotExist())
                 .andExpect(jsonPath("$.data.created_at").doesNotExist())
-                .andExpect(jsonPath("$.data.stats.total_records").doesNotExist());
+                .andExpect(jsonPath("$.data.stats.total_records").doesNotExist())
+                .andExpect(jsonPath("$.data.stats.total_stickers").doesNotExist());
 
         verify(userService).getCurrentUserProfile(AUTHENTICATED_USER_ID);
     }

--- a/src/test/java/com/bean/breaddiary/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/service/UserServiceTest.java
@@ -51,7 +51,7 @@ class UserServiceTest {
 
         when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
         when(breadRecordRepository.findUserStatsByUserId(userId))
-                .thenReturn(createProjection(42L, 18L, 4.25));
+                .thenReturn(createProjection(42L, 15L, 18L, 4.25));
 
         UserMeResponse actual = userService.getCurrentUserProfile(userId);
 
@@ -60,6 +60,7 @@ class UserServiceTest {
         assertEquals("bread@toss.im", actual.getEmail());
         assertNotNull(actual.getStats());
         assertEquals(42L, actual.getStats().getTotalRecords());
+        assertEquals(15L, actual.getStats().getTotalStickers());
         assertEquals(18L, actual.getStats().getUniqueShops());
         assertEquals(4.3, actual.getStats().getAvgRating());
 
@@ -72,11 +73,12 @@ class UserServiceTest {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
 
         when(breadRecordRepository.findUserStatsByUserId(userId))
-                .thenReturn(createProjection(null, null, null));
+                .thenReturn(createProjection(null, null, null, null));
 
         UserStatsResponse actual = userService.getUserStats(userId);
 
         assertEquals(0L, actual.getTotalRecords());
+        assertEquals(0L, actual.getTotalStickers());
         assertEquals(0L, actual.getUniqueShops());
         assertEquals(0.0, actual.getAvgRating());
     }
@@ -96,11 +98,21 @@ class UserServiceTest {
         assertNotNull(exception.getReason());
     }
 
-    private UserStatsProjection createProjection(Long totalRecords, Long uniqueShops, Double avgRating) {
+    private UserStatsProjection createProjection(
+            Long totalRecords,
+            Long totalStickers,
+            Long uniqueShops,
+            Double avgRating
+    ) {
         return new UserStatsProjection() {
             @Override
             public Long getTotalRecords() {
                 return totalRecords;
+            }
+
+            @Override
+            public Long getTotalStickers() {
+                return totalStickers;
             }
 
             @Override


### PR DESCRIPTION
## 🧩 관련 이슈

- #60

## 🛠️ 작업 내용

- `/users/me` 통계 응답에 `stats.totalStickers` 필드를 추가했습니다.
- 기존 `BreadRecordRepository.findUserStatsByUserId()` 통계 쿼리에 `count(distinct br.bread.id)` 기준의 `totalStickers` 계산을 반영했습니다.
- `UserStatsProjection`에 `getTotalStickers()`를 추가하고, `UserMapper`에서 `UserStatsResponse`로 매핑하도록 수정했습니다.
- `totalStickers`는 활성 `BreadRecord` 기준 고유 `bread.id` 개수로 계산되며, soft delete된 기록은 제외됩니다.
- 같은 bread를 여러 번 기록한 경우에도 스티커는 1개로만 계산되도록 반영했습니다.
- `UserControllerTest`에서 `/users/me` 응답이 `stats.totalStickers` camelCase로 내려가는지 검증했습니다.
- `UserServiceTest`, `BreadRecordRepositoryTest`를 보강해 null 보정, 중복 bread, soft delete 제외 케이스를 검증했습니다.

## 📢 참고 및 특이사항

- 이번 작업은 `/users/me` 통계 조회를 위한 최소 수정 범위만 반영했습니다.
- 기존 `totalRecords`, `uniqueShops`, `avgRating` 계산 방식은 유지했습니다.
- 기존 JPQL aggregate query에 이미 있던 `br.deletedAt is null` 조건을 그대로 사용하므로 soft delete 기록은 자동으로 제외됩니다.
- `totalStickers` 응답은 camelCase 기준이며, snake_case 응답으로 내려가지 않도록 테스트로 함께 검증했습니다.
- 생성 파일은 없고 아래 파일만 수정했습니다.
  - `UserStatsProjection.java`
  - `BreadRecordRepository.java`
  - `UserStatsResponse.java`
  - `UserMapper.java`
  - `BreadRecordRepositoryTest.java`
  - `UserServiceTest.java`
  - `UserControllerTest.java`
- 기존 작업 전부터 있던 `docs/codex-prompts-user/*`, `mvp-backend-readiness-plan.md`, `.gradle-codex/` 변경은 이번 브랜치 범위가 아니라 건드리지 않았습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인