### PR TITLE
feat: add request access logging with sensitive data masking

### DIFF
--- a/src/main/java/com/bean/breaddiary/global/filter/AccessLogFilter.java
+++ b/src/main/java/com/bean/breaddiary/global/filter/AccessLogFilter.java
@@ -1,0 +1,164 @@
+package com.bean.breaddiary.global.filter;
+
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class AccessLogFilter extends OncePerRequestFilter {
+
+    private static final String ACCESS_LOG_PREFIX = "ACCESS";
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+    private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final String DEFAULT_VALUE = "-";
+    private static final int MAX_REQUEST_ID_LENGTH = 80;
+    private static final int MAX_CLIENT_IP_LENGTH = 80;
+    private static final int INTERNAL_SERVER_ERROR_STATUS = 500;
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+    private static final Pattern UNSAFE_REQUEST_ID_CHARACTERS = Pattern.compile("[^A-Za-z0-9._:-]");
+    private static final Pattern CONTROL_CHARACTERS = Pattern.compile("[\\r\\n\\t]");
+    private static final Pattern STATIC_RESOURCE_PATTERN = Pattern.compile(
+            ".+\\.(css|js|map|png|jpg|jpeg|gif|svg|ico|webp|woff|woff2|ttf)$",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String method = request.getMethod();
+        String path = request.getRequestURI();
+
+        return "OPTIONS".equalsIgnoreCase(method)
+                || "/error".equals(path)
+                || "/swagger-ui.html".equals(path)
+                || PATH_MATCHER.match("/swagger-ui/**", path)
+                || PATH_MATCHER.match("/v3/api-docs/**", path)
+                || PATH_MATCHER.match("/webjars/**", path)
+                || "/favicon.ico".equals(path)
+                || STATIC_RESOURCE_PATTERN.matcher(path).matches();
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        long startNanos = System.nanoTime();
+        boolean failed = false;
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ServletException | IOException | RuntimeException exception) {
+            failed = true;
+            throw exception;
+        } finally {
+            writeAccessLog(request, response, startNanos, failed);
+        }
+    }
+
+    private void writeAccessLog(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            long startNanos,
+            boolean failed
+    ) {
+        long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
+        int status = resolveStatus(response, failed);
+
+        log.info(
+                "{} method={} path={} status={} durationMs={} userId={} sessionId={} requestId={} clientIp={}",
+                ACCESS_LOG_PREFIX,
+                request.getMethod(),
+                request.getRequestURI(),
+                status,
+                durationMs,
+                resolveAttribute(request, AuthRequestAttributes.USER_ID),
+                resolveAttribute(request, AuthRequestAttributes.SESSION_ID),
+                resolveRequestId(request),
+                resolveClientIp(request)
+        );
+    }
+
+    private int resolveStatus(HttpServletResponse response, boolean failed) {
+        int status = response.getStatus();
+
+        if (failed && status < INTERNAL_SERVER_ERROR_STATUS) {
+            return INTERNAL_SERVER_ERROR_STATUS;
+        }
+
+        return status;
+    }
+
+    private String resolveAttribute(HttpServletRequest request, String attributeName) {
+        Object value = request.getAttribute(attributeName);
+
+        if (value == null) {
+            return DEFAULT_VALUE;
+        }
+
+        return sanitize(value.toString(), MAX_REQUEST_ID_LENGTH);
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+
+        if (!StringUtils.hasText(requestId)) {
+            return UUID.randomUUID().toString();
+        }
+
+        String sanitized = UNSAFE_REQUEST_ID_CHARACTERS.matcher(requestId.trim()).replaceAll("");
+
+        if (!StringUtils.hasText(sanitized)) {
+            return UUID.randomUUID().toString();
+        }
+
+        return truncate(sanitized, MAX_REQUEST_ID_LENGTH);
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
+
+        if (StringUtils.hasText(forwardedFor)) {
+            return sanitize(forwardedFor.split(",", 2)[0], MAX_CLIENT_IP_LENGTH);
+        }
+
+        return sanitize(request.getRemoteAddr(), MAX_CLIENT_IP_LENGTH);
+    }
+
+    private String sanitize(String value, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return DEFAULT_VALUE;
+        }
+
+        String sanitized = CONTROL_CHARACTERS.matcher(value.trim()).replaceAll("");
+
+        if (!StringUtils.hasText(sanitized)) {
+            return DEFAULT_VALUE;
+        }
+
+        return truncate(sanitized, maxLength);
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+
+        return value.substring(0, maxLength);
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/filter/AccessLogFilterTest.java
+++ b/src/test/java/com/bean/breaddiary/global/filter/AccessLogFilterTest.java
@@ -1,0 +1,154 @@
+package com.bean.breaddiary.global.filter;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AccessLogFilterTest {
+
+    private AccessLogFilter accessLogFilter;
+    private Logger logger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        accessLogFilter = new AccessLogFilter();
+        logger = (Logger) LoggerFactory.getLogger(AccessLogFilter.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
+    @Test
+    void doFilterWritesMethodPathStatusDurationRequestIdAndClientIp() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        request.addHeader("X-Request-Id", "front-request-1");
+        request.addHeader("X-Forwarded-For", "203.0.113.10, 10.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = (servletRequest, servletResponse) -> response.setStatus(200);
+
+        accessLogFilter.doFilter(request, response, filterChain);
+
+        String accessLog = singleLogMessage();
+        assertTrue(accessLog.startsWith("ACCESS "));
+        assertTrue(accessLog.contains("method=GET"));
+        assertTrue(accessLog.contains("path=/users/me"));
+        assertTrue(accessLog.contains("status=200"));
+        assertTrue(accessLog.matches(".*durationMs=\\d+.*"));
+        assertTrue(accessLog.contains("requestId=front-request-1"));
+        assertTrue(accessLog.contains("clientIp=203.0.113.10"));
+    }
+
+    @Test
+    void doFilterWritesAuthenticatedUserAttributesWhenAvailable() throws Exception {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/logout");
+        request.setAttribute(AuthRequestAttributes.USER_ID, userId);
+        request.setAttribute(AuthRequestAttributes.SESSION_ID, sessionId);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        accessLogFilter.doFilter(request, response, passThroughChain());
+
+        String accessLog = singleLogMessage();
+        assertTrue(accessLog.contains("userId=" + userId));
+        assertTrue(accessLog.contains("sessionId=" + sessionId));
+    }
+
+    @Test
+    void doFilterUsesSafeDefaultsWhenAuthenticatedAttributesAreMissing() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/bread-types");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        accessLogFilter.doFilter(request, response, passThroughChain());
+
+        String accessLog = singleLogMessage();
+        assertTrue(accessLog.contains("userId=-"));
+        assertTrue(accessLog.contains("sessionId=-"));
+    }
+
+    @Test
+    void doFilterDoesNotLogSensitiveHeadersOrQueryString() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/toss");
+        request.setQueryString("authorizationCode=secret-code&refreshToken=secret-refresh&uploadUrl=https://s3.example.com/file?X-Amz-Signature=secret-signature");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer secret-access-token");
+        request.addHeader("x-toss-webhook-secret", "secret-webhook");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        accessLogFilter.doFilter(request, response, passThroughChain());
+
+        String accessLog = singleLogMessage();
+        assertTrue(accessLog.contains("path=/auth/toss"));
+        assertFalse(accessLog.contains("secret-access-token"));
+        assertFalse(accessLog.contains("secret-webhook"));
+        assertFalse(accessLog.contains("secret-code"));
+        assertFalse(accessLog.contains("secret-refresh"));
+        assertFalse(accessLog.contains("X-Amz-Signature"));
+        assertFalse(accessLog.contains("s3.example.com"));
+    }
+
+    @Test
+    void doFilterWritesAccessLogAndRethrowsWhenChainThrowsException() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = (servletRequest, servletResponse) -> {
+            throw new ServletException("boom");
+        };
+
+        assertThrows(ServletException.class, () -> accessLogFilter.doFilter(request, response, filterChain));
+
+        String accessLog = singleLogMessage();
+        assertTrue(accessLog.contains("method=GET"));
+        assertTrue(accessLog.contains("path=/users/me"));
+        assertTrue(accessLog.contains("status=500"));
+    }
+
+    @Test
+    void doFilterSkipsExcludedPaths() throws Exception {
+        AtomicInteger chainCount = new AtomicInteger();
+        FilterChain countingChain = (servletRequest, servletResponse) -> chainCount.incrementAndGet();
+
+        accessLogFilter.doFilter(new MockHttpServletRequest("OPTIONS", "/users/me"), new MockHttpServletResponse(), countingChain);
+        accessLogFilter.doFilter(new MockHttpServletRequest("GET", "/swagger-ui/index.html"), new MockHttpServletResponse(), countingChain);
+        accessLogFilter.doFilter(new MockHttpServletRequest("GET", "/v3/api-docs"), new MockHttpServletResponse(), countingChain);
+        accessLogFilter.doFilter(new MockHttpServletRequest("GET", "/favicon.ico"), new MockHttpServletResponse(), countingChain);
+        accessLogFilter.doFilter(new MockHttpServletRequest("GET", "/assets/app.js"), new MockHttpServletResponse(), countingChain);
+
+        assertEquals(5, chainCount.get());
+        assertTrue(listAppender.list.isEmpty());
+    }
+
+    private FilterChain passThroughChain() {
+        return (servletRequest, servletResponse) -> {
+        };
+    }
+
+    private String singleLogMessage() {
+        assertEquals(1, listAppender.list.size());
+        return listAppender.list.get(0).getFormattedMessage();
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #62 

## 🛠️ 작업 내용

- 요청/응답 access logging 을 추가해 주요 API 호출 흐름을 추적할 수 있도록 반영했습니다.
- 요청 메서드, URI, 응답 상태, 처리 시간 등 운영에 필요한 핵심 access log 정보를 남기도록 정리했습니다.
- 민감정보가 로그에 직접 남지 않도록 마스킹 처리 로직을 추가했습니다.
- access token, refresh token, authorization code, secret, cookie 등 보안 민감도가 높은 값은 원문이 노출되지 않도록 처리했습니다.
- 로그 노이즈를 줄이기 위해 health / swagger / static 요청은 access logging 대상에서 제외하도록 정책을 반영했습니다.
- 정상 응답과 예외 응답 모두에서 일관된 형태로 로그가 남도록 정리했습니다.
- logging 동작과 민감정보 마스킹 정책을 검증하는 테스트 또는 최소 단위 테스트를 추가했습니다.

## 📢 참고 및 특이사항

- 이번 작업은 기능 변경이 아니라 운영 추적성과 디버깅 편의성을 높이기 위한 로깅 작업입니다.
- 민감정보는 절대 로그에 원문 그대로 남기지 않는 것을 우선 원칙으로 두었습니다.
- 기존 controller / service / interceptor / filter 구조를 최대한 유지하면서 최소 수정 방식으로 반영했습니다.
- 전면적인 로깅 체계 개편이나 외부 로그 수집 시스템 연동까지는 이번 범위에 포함하지 않았습니다.
- 과도한 중복 로그가 생기지 않도록 access logging 위치를 최소 범위로 제한했습니다.
- health / swagger / static 요청 제외 여부는 실제 운영 로그에서 불필요한 노이즈를 줄이기 위한 기준으로 결정했습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인