### PR TITLE
feat: add request id observability logging

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
@@ -1,9 +1,11 @@
 package com.bean.breaddiary.domain.auth.client;
 
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -15,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 
+@Slf4j
 @Service
 public class TossAuthClient {
 
@@ -46,6 +49,8 @@ public class TossAuthClient {
             String authorizationCode,
             String referrer
     ) {
+        long startNanos = System.nanoTime();
+
         try {
             TossGenerateTokenResponse response = restClient.post()
                     .uri(GENERATE_TOKEN_PATH)
@@ -58,13 +63,29 @@ public class TossAuthClient {
                 throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "토스 토큰 발급에 실패했습니다.");
             }
 
+            logTossSuccess("tossExchange", startNanos);
             return response.success();
         } catch (RestClientResponseException exception) {
+            logTossFailure(
+                    "tossExchange",
+                    exception.getStatusCode().value(),
+                    extractErrorCode(exception.getResponseBodyAsString()),
+                    startNanos,
+                    exception
+            );
             throw convertException(exception, "토스 토큰 발급에 실패했습니다.");
+        } catch (ResponseStatusException exception) {
+            logTossFailure("tossExchange", exception.getStatusCode().value(), null, startNanos, exception);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedTossFailure("tossExchange", startNanos, exception);
+            throw exception;
         }
     }
 
     public TossLoginMeSuccess getUserInfo(String tossAccessToken) {
+        long startNanos = System.nanoTime();
+
         try {
             TossLoginMeResponse response = restClient.get()
                     .uri(LOGIN_ME_PATH)
@@ -76,16 +97,32 @@ public class TossAuthClient {
                 throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "토스 사용자 정보 조회에 실패했습니다.");
             }
 
+            logTossSuccess("tossLoginMe", startNanos);
             return response.success();
         } catch (RestClientResponseException exception) {
+            logTossFailure(
+                    "tossLoginMe",
+                    exception.getStatusCode().value(),
+                    extractErrorCode(exception.getResponseBodyAsString()),
+                    startNanos,
+                    exception
+            );
             throw convertException(exception, "토스 사용자 정보 조회에 실패했습니다.");
+        } catch (ResponseStatusException exception) {
+            logTossFailure("tossLoginMe", exception.getStatusCode().value(), null, startNanos, exception);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedTossFailure("tossLoginMe", startNanos, exception);
+            throw exception;
         }
     }
 
     public void unlinkByUserKey(String userKey) {
-        requireUnlinkAccessToken();
+        long startNanos = System.nanoTime();
 
         try {
+            requireUnlinkAccessToken();
+
             TossUnlinkResponse response = restClient.post()
                     .uri(REMOVE_BY_USER_KEY_PATH)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -97,12 +134,26 @@ public class TossAuthClient {
             if (response == null || response.success() == null) {
                 throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "토스 연결 끊기에 실패했습니다.");
             }
+            logTossSuccess("tossUnlink", startNanos);
         } catch (RestClientResponseException exception) {
+            logTossFailure(
+                    "tossUnlink",
+                    HttpStatus.BAD_GATEWAY.value(),
+                    extractErrorCode(exception.getResponseBodyAsString()),
+                    startNanos,
+                    exception
+            );
             throw new ResponseStatusException(
                     HttpStatus.BAD_GATEWAY,
                     "토스 연결 끊기에 실패했습니다.",
                     exception
             );
+        } catch (ResponseStatusException exception) {
+            logTossFailure("tossUnlink", exception.getStatusCode().value(), null, startNanos, exception);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedTossFailure("tossUnlink", startNanos, exception);
+            throw exception;
         }
     }
 
@@ -155,6 +206,67 @@ public class TossAuthClient {
                     "TOSS_UNLINK_ACCESS_TOKEN 설정이 필요합니다."
             );
         }
+    }
+
+    private void logTossSuccess(String action, long startNanos) {
+        log.info(
+                "TOSS action={} result=success requestId={} status={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                HttpStatus.OK.value(),
+                durationMs(startNanos)
+        );
+    }
+
+    private void logTossFailure(
+            String action,
+            int status,
+            String errorCode,
+            long startNanos,
+            Exception exception
+    ) {
+        if (status >= HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            log.error(
+                    "TOSS action={} result=fail requestId={} status={} errorCode={} exceptionType={} durationMs={}",
+                    action,
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    status,
+                    valueOrDefault(errorCode),
+                    exception.getClass().getSimpleName(),
+                    durationMs(startNanos)
+            );
+            return;
+        }
+
+        log.warn(
+                "TOSS action={} result=fail requestId={} status={} errorCode={} exceptionType={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                status,
+                valueOrDefault(errorCode),
+                exception.getClass().getSimpleName(),
+                durationMs(startNanos)
+        );
+    }
+
+    private void logUnexpectedTossFailure(String action, long startNanos, RuntimeException exception) {
+        log.error(
+                "TOSS action={} result=fail requestId={} status={} errorCode={} exceptionType={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                "unexpected",
+                "-",
+                exception.getClass().getSimpleName(),
+                durationMs(startNanos)
+        );
+    }
+
+    private long durationMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    private String valueOrDefault(String value) {
+        return StringUtils.hasText(value) ? value : "-";
     }
 
     private record TossGenerateTokenRequest(

--- a/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
@@ -9,7 +9,9 @@ import com.bean.breaddiary.domain.auth.dto.response.LogoutResponse;
 import com.bean.breaddiary.domain.auth.entity.UserSession;
 import com.bean.breaddiary.domain.user.entity.User;
 import com.bean.breaddiary.domain.user.repository.UserRepository;
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
@@ -43,79 +46,174 @@ public class AuthService {
 
     @Transactional
     public AuthTokenResponse loginWithToss(TossLoginRequest request) {
-        LocalDateTime issuedAt = LocalDateTime.now();
+        long startNanos = System.nanoTime();
+        UUID userId = null;
+        UUID sessionId = null;
 
-        TossAuthClient.TossGenerateTokenSuccess tossToken =
-                tossAuthClient.exchangeAuthorizationCode(
-                        request.getAuthorizationCode(),
-                        request.getReferrer()
-                );
-        TossAuthClient.TossLoginMeSuccess tossUserInfo =
-                tossAuthClient.getUserInfo(tossToken.accessToken());
+        try {
+            LocalDateTime issuedAt = LocalDateTime.now();
 
-        ResolvedTossProfile tossProfile = resolveTossProfile(tossUserInfo);
-        UserResolution userResolution = findOrCreateUser(tossProfile);
+            TossAuthClient.TossGenerateTokenSuccess tossToken =
+                    tossAuthClient.exchangeAuthorizationCode(
+                            request.getAuthorizationCode(),
+                            request.getReferrer()
+                    );
+            TossAuthClient.TossLoginMeSuccess tossUserInfo =
+                    tossAuthClient.getUserInfo(tossToken.accessToken());
 
-        UserSession userSession = createPendingSession(userResolution.user(), issuedAt);
+            ResolvedTossProfile tossProfile = resolveTossProfile(tossUserInfo);
+            UserResolution userResolution = findOrCreateUser(tossProfile);
+            userId = userResolution.user().getId();
 
-        return issueTokens(
-                userResolution.user(),
-                userSession,
-                userResolution.newUser(),
-                issuedAt
-        );
+            UserSession userSession = createPendingSession(userResolution.user(), issuedAt);
+            sessionId = userSession.getId();
+
+            AuthTokenResponse response = issueTokens(
+                    userResolution.user(),
+                    userSession,
+                    userResolution.newUser(),
+                    issuedAt
+            );
+
+            log.info(
+                    "AUTH action=login result=success requestId={} userId={} sessionId={} status={} newUser={} durationMs={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(userId),
+                    valueOrDefault(sessionId),
+                    HttpStatus.OK.value(),
+                    userResolution.newUser(),
+                    durationMs(startNanos)
+            );
+
+            return response;
+        } catch (ResponseStatusException exception) {
+            logAuthFailure("login", userId, sessionId, exception, startNanos);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedAuthFailure("login", userId, sessionId, exception, startNanos);
+            throw exception;
+        }
     }
 
     @Transactional
     public AuthTokenResponse refresh(RefreshTokenRequest request) {
-        String refreshToken = requireText(request.getRefreshToken(), "리프레시 토큰이 필요합니다.");
-        JwtTokenProvider.JwtTokenClaims claims = parseRefreshToken(refreshToken);
-        LocalDateTime now = LocalDateTime.now();
+        long startNanos = System.nanoTime();
+        UUID userId = null;
+        UUID sessionId = null;
 
-        UserSession userSession = userSessionService.findSessionForUpdate(claims.sessionId())
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.UNAUTHORIZED,
-                        "유효한 세션이 없습니다."
-                ));
+        try {
+            String refreshToken = requireText(request.getRefreshToken(), "리프레시 토큰이 필요합니다.");
+            JwtTokenProvider.JwtTokenClaims claims = parseRefreshToken(refreshToken);
+            userId = claims.userId();
+            sessionId = claims.sessionId();
+            LocalDateTime now = LocalDateTime.now();
 
-        validateRefreshTokenState(userSession, claims, refreshToken, now, true);
+            UserSession userSession = userSessionService.findSessionForUpdate(claims.sessionId())
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.UNAUTHORIZED,
+                            "유효한 세션이 없습니다."
+                    ));
 
-        User user = getActiveUser(userSession.getUserId());
+            validateRefreshTokenState(userSession, claims, refreshToken, now, true);
 
-        return issueTokens(user, userSession, false, now);
+            User user = getActiveUser(userSession.getUserId());
+
+            AuthTokenResponse response = issueTokens(user, userSession, false, now);
+
+            log.info(
+                    "AUTH action=refresh result=success requestId={} userId={} sessionId={} status={} durationMs={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(user.getId()),
+                    valueOrDefault(userSession.getId()),
+                    HttpStatus.OK.value(),
+                    durationMs(startNanos)
+            );
+
+            return response;
+        } catch (ResponseStatusException exception) {
+            logAuthFailure("refresh", userId, sessionId, exception, startNanos);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedAuthFailure("refresh", userId, sessionId, exception, startNanos);
+            throw exception;
+        }
     }
 
     @Transactional
     public LogoutResponse logout(LogoutRequest request) {
-        String refreshToken = requireText(request.getRefreshToken(), "리프레시 토큰이 필요합니다.");
-        JwtTokenProvider.JwtTokenClaims claims = parseRefreshToken(refreshToken);
-        LocalDateTime now = LocalDateTime.now();
+        long startNanos = System.nanoTime();
+        UUID userId = null;
+        UUID sessionId = null;
 
-        UserSession userSession = userSessionService.findSessionForUpdate(claims.sessionId())
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.UNAUTHORIZED,
-                        "로그아웃할 세션이 없습니다."
-                ));
+        try {
+            String refreshToken = requireText(request.getRefreshToken(), "리프레시 토큰이 필요합니다.");
+            JwtTokenProvider.JwtTokenClaims claims = parseRefreshToken(refreshToken);
+            userId = claims.userId();
+            sessionId = claims.sessionId();
+            LocalDateTime now = LocalDateTime.now();
 
-        validateRefreshTokenState(userSession, claims, refreshToken, now, false);
-        userSessionService.revokeSession(userSession, now);
+            UserSession userSession = userSessionService.findSessionForUpdate(claims.sessionId())
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.UNAUTHORIZED,
+                            "로그아웃할 세션이 없습니다."
+                    ));
 
-        return new LogoutResponse(true);
+            validateRefreshTokenState(userSession, claims, refreshToken, now, false);
+            userSessionService.revokeSession(userSession, now);
+
+            log.info(
+                    "AUTH action=logout result=success requestId={} userId={} sessionId={} status={} durationMs={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(userSession.getUserId()),
+                    valueOrDefault(userSession.getId()),
+                    HttpStatus.OK.value(),
+                    durationMs(startNanos)
+            );
+
+            return new LogoutResponse(true);
+        } catch (ResponseStatusException exception) {
+            logAuthFailure("logout", userId, sessionId, exception, startNanos);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedAuthFailure("logout", userId, sessionId, exception, startNanos);
+            throw exception;
+        }
     }
 
     @Transactional
     public LogoutResponse logoutCurrentSession(UUID sessionId) {
-        LocalDateTime now = LocalDateTime.now();
+        long startNanos = System.nanoTime();
+        UUID userId = null;
 
-        UserSession userSession = userSessionService.findSessionForUpdate(sessionId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.UNAUTHORIZED,
-                        "로그아웃할 세션이 없습니다."
-                ));
+        try {
+            LocalDateTime now = LocalDateTime.now();
 
-        userSessionService.revokeSession(userSession, now);
+            UserSession userSession = userSessionService.findSessionForUpdate(sessionId)
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.UNAUTHORIZED,
+                            "로그아웃할 세션이 없습니다."
+                    ));
 
-        return new LogoutResponse(true);
+            userId = userSession.getUserId();
+            userSessionService.revokeSession(userSession, now);
+
+            log.info(
+                    "AUTH action=logoutCurrentSession result=success requestId={} userId={} sessionId={} status={} durationMs={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(userId),
+                    valueOrDefault(userSession.getId()),
+                    HttpStatus.OK.value(),
+                    durationMs(startNanos)
+            );
+
+            return new LogoutResponse(true);
+        } catch (ResponseStatusException exception) {
+            logAuthFailure("logoutCurrentSession", userId, sessionId, exception, startNanos);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedAuthFailure("logoutCurrentSession", userId, sessionId, exception, startNanos);
+            throw exception;
+        }
     }
 
     private AuthTokenResponse issueTokens(
@@ -342,6 +440,66 @@ public class AuthService {
         } catch (NoSuchAlgorithmException exception) {
             throw new IllegalStateException("SHA-256 알고리즘을 찾을 수 없습니다.", exception);
         }
+    }
+
+    private void logAuthFailure(
+            String action,
+            UUID userId,
+            UUID sessionId,
+            ResponseStatusException exception,
+            long startNanos
+    ) {
+        if (exception.getStatusCode().is5xxServerError()) {
+            log.error(
+                    "AUTH action={} result=fail requestId={} userId={} sessionId={} status={} exceptionType={} durationMs={}",
+                    action,
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(userId),
+                    valueOrDefault(sessionId),
+                    exception.getStatusCode().value(),
+                    exception.getClass().getSimpleName(),
+                    durationMs(startNanos)
+            );
+            return;
+        }
+
+        log.warn(
+                "AUTH action={} result=fail requestId={} userId={} sessionId={} status={} exceptionType={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                valueOrDefault(userId),
+                valueOrDefault(sessionId),
+                exception.getStatusCode().value(),
+                exception.getClass().getSimpleName(),
+                durationMs(startNanos)
+        );
+    }
+
+    private void logUnexpectedAuthFailure(
+            String action,
+            UUID userId,
+            UUID sessionId,
+            RuntimeException exception,
+            long startNanos
+    ) {
+        log.error(
+                "AUTH action={} result=fail requestId={} userId={} sessionId={} status={} exceptionType={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                valueOrDefault(userId),
+                valueOrDefault(sessionId),
+                "unexpected",
+                exception.getClass().getSimpleName(),
+                durationMs(startNanos)
+        );
+    }
+
+    private long durationMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    private String valueOrDefault(Object value) {
+        return value == null ? "-" : value.toString();
     }
 
     private record ResolvedTossProfile(

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
@@ -11,7 +11,9 @@ import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
 import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
 import com.bean.breaddiary.domain.user.entity.User;
 import com.bean.breaddiary.domain.user.repository.UserRepository;
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserWithdrawalService {
@@ -41,14 +44,35 @@ public class UserWithdrawalService {
 
     @Transactional
     public UserWithdrawalResponse withdrawCurrentUser(UUID userId) {
-        User user = userService.getUserById(userId);
+        long startNanos = System.nanoTime();
 
-        if (StringUtils.hasText(user.getTossUserKey())) {
-            tossAuthClient.unlinkByUserKey(user.getTossUserKey());
+        try {
+            User user = userService.getUserById(userId);
+            boolean tossLinked = StringUtils.hasText(user.getTossUserKey());
+
+            if (tossLinked) {
+                tossAuthClient.unlinkByUserKey(user.getTossUserKey());
+            }
+
+            hardDeleteUserData(user);
+
+            log.info(
+                    "USER action=withdrawal result=success requestId={} userId={} status={} tossLinked={} durationMs={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(userId),
+                    HttpStatus.OK.value(),
+                    tossLinked,
+                    durationMs(startNanos)
+            );
+
+            return new UserWithdrawalResponse(true);
+        } catch (ResponseStatusException exception) {
+            logUserFailure("withdrawal", userId, null, exception, startNanos);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedUserFailure("withdrawal", userId, null, exception, startNanos);
+            throw exception;
         }
-
-        hardDeleteUserData(user);
-        return new UserWithdrawalResponse(true);
     }
 
     @Transactional
@@ -56,20 +80,37 @@ public class UserWithdrawalService {
             String requestWebhookSecret,
             TossWebhookRequest request
     ) {
-        validateWebhookSecret(requestWebhookSecret);
+        long startNanos = System.nanoTime();
+        UUID userId = null;
+        TossWebhookEventType eventType = request == null ? null : request.getEventType();
 
-        Optional<User> user = userRepository.findByTossUserKey(normalizeText(request.getUserKey()));
-        if (user.isEmpty()) {
+        try {
+            validateWebhookSecret(requestWebhookSecret);
+
+            Optional<User> user = userRepository.findByTossUserKey(normalizeText(request.getUserKey()));
+            if (user.isEmpty()) {
+                logWebhookSuccess(resolveWebhookAction(eventType), null, eventType, false, startNanos);
+                return new TossWebhookResponse(true, request.getEventType());
+            }
+
+            userId = user.get().getId();
+
+            if (request.getEventType() == TossWebhookEventType.UNLINK) {
+                clearSessionsOnly(userId);
+                logWebhookSuccess("tossUnlinkWebhook", userId, eventType, true, startNanos);
+                return new TossWebhookResponse(true, request.getEventType());
+            }
+
+            hardDeleteUserData(user.get());
+            logWebhookSuccess("tossWithdrawalWebhook", userId, eventType, true, startNanos);
             return new TossWebhookResponse(true, request.getEventType());
+        } catch (ResponseStatusException exception) {
+            logUserFailure(resolveWebhookAction(eventType), userId, eventType, exception, startNanos);
+            throw exception;
+        } catch (RuntimeException exception) {
+            logUnexpectedUserFailure(resolveWebhookAction(eventType), userId, eventType, exception, startNanos);
+            throw exception;
         }
-
-        if (request.getEventType() == TossWebhookEventType.UNLINK) {
-            clearSessionsOnly(user.get().getId());
-            return new TossWebhookResponse(true, request.getEventType());
-        }
-
-        hardDeleteUserData(user.get());
-        return new TossWebhookResponse(true, request.getEventType());
     }
 
     @Transactional
@@ -114,6 +155,92 @@ public class UserWithdrawalService {
                     "토스 웹훅 인증에 실패했습니다."
             );
         }
+    }
+
+    private void logWebhookSuccess(
+            String action,
+            UUID userId,
+            TossWebhookEventType eventType,
+            boolean userFound,
+            long startNanos
+    ) {
+        log.info(
+                "USER action={} result=success requestId={} userId={} status={} eventType={} userFound={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                valueOrDefault(userId),
+                HttpStatus.OK.value(),
+                valueOrDefault(eventType),
+                userFound,
+                durationMs(startNanos)
+        );
+    }
+
+    private void logUserFailure(
+            String action,
+            UUID userId,
+            TossWebhookEventType eventType,
+            ResponseStatusException exception,
+            long startNanos
+    ) {
+        if (exception.getStatusCode().is5xxServerError()) {
+            log.error(
+                    "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                    action,
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    valueOrDefault(userId),
+                    exception.getStatusCode().value(),
+                    valueOrDefault(eventType),
+                    durationMs(startNanos),
+                    exception
+            );
+            return;
+        }
+
+        log.warn(
+                "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                valueOrDefault(userId),
+                exception.getStatusCode().value(),
+                valueOrDefault(eventType),
+                durationMs(startNanos)
+        );
+    }
+
+    private void logUnexpectedUserFailure(
+            String action,
+            UUID userId,
+            TossWebhookEventType eventType,
+            RuntimeException exception,
+            long startNanos
+    ) {
+        log.error(
+                "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                action,
+                RequestLogContext.currentRequestIdOrDefault(),
+                valueOrDefault(userId),
+                "unexpected",
+                valueOrDefault(eventType),
+                durationMs(startNanos),
+                exception
+        );
+    }
+
+    private String resolveWebhookAction(TossWebhookEventType eventType) {
+        if (eventType == TossWebhookEventType.UNLINK) {
+            return "tossUnlinkWebhook";
+        }
+
+        return "tossWithdrawalWebhook";
+    }
+
+    private long durationMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    private String valueOrDefault(Object value) {
+        return value == null ? "-" : value.toString();
     }
 
     private String normalizeText(String value) {

--- a/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.bean.breaddiary.global.common;
 
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -79,11 +80,12 @@ public class GlobalExceptionHandler {
         String message = "요청 형식이 올바르지 않습니다.";
 
         log.warn(
-                "Invalid request: code={} method={} path={} message={}",
+                "Invalid request: code={} method={} path={} requestId={} errorType={}",
                 "INVALID_REQUEST",
                 request.getMethod(),
                 request.getRequestURI(),
-                exception.getMessage()
+                RequestLogContext.currentRequestIdOrDefault(),
+                exception.getClass().getSimpleName()
         );
 
         return ResponseEntity
@@ -97,11 +99,12 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         log.error(
-                "Unexpected server error: code={} method={} path={}",
+                "Unexpected server error: code={} method={} path={} requestId={} exceptionType={}",
                 "INTERNAL_ERROR",
                 request.getMethod(),
                 request.getRequestURI(),
-                exception
+                RequestLogContext.currentRequestIdOrDefault(),
+                exception.getClass().getSimpleName()
         );
 
         return ResponseEntity
@@ -115,11 +118,12 @@ public class GlobalExceptionHandler {
             Exception exception
     ) {
         log.warn(
-                "Validation failed: code={} method={} path={} message={}",
+                "Validation failed: code={} method={} path={} requestId={} errorType={}",
                 "VALIDATION_FAILED",
                 request.getMethod(),
                 request.getRequestURI(),
-                exception.getMessage()
+                RequestLogContext.currentRequestIdOrDefault(),
+                exception.getClass().getSimpleName()
         );
 
         return ResponseEntity
@@ -216,22 +220,25 @@ public class GlobalExceptionHandler {
     ) {
         if (statusCode.is5xxServerError()) {
             log.error(
-                    "Request failed: code={} method={} path={} message={}",
+                    "Request failed: code={} method={} path={} requestId={} message={} exceptionType={}",
                     code,
                     request.getMethod(),
                     request.getRequestURI(),
+                    RequestLogContext.currentRequestIdOrDefault(),
                     message,
-                    exception
+                    exception.getClass().getSimpleName()
             );
             return;
         }
 
         log.warn(
-                "Request failed: code={} method={} path={} message={}",
+                "Request failed: code={} method={} path={} requestId={} message={} exceptionType={}",
                 code,
                 request.getMethod(),
                 request.getRequestURI(),
-                message
+                RequestLogContext.currentRequestIdOrDefault(),
+                message,
+                exception.getClass().getSimpleName()
         );
     }
 }

--- a/src/main/java/com/bean/breaddiary/global/config/WebConfig.java
+++ b/src/main/java/com/bean/breaddiary/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.global.config;
 
 import com.bean.breaddiary.global.interceptor.AuthInterceptor;
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
                         HttpMethod.OPTIONS.name()
                 )
                 .allowedHeaders("*")
-                .exposedHeaders("Location")
+                .exposedHeaders("Location", RequestLogContext.REQUEST_ID_HEADER)
                 .maxAge(3600);
     }
 }

--- a/src/main/java/com/bean/breaddiary/global/filter/AccessLogFilter.java
+++ b/src/main/java/com/bean/breaddiary/global/filter/AccessLogFilter.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.global.filter;
 
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,7 +24,6 @@ import java.util.regex.Pattern;
 public class AccessLogFilter extends OncePerRequestFilter {
 
     private static final String ACCESS_LOG_PREFIX = "ACCESS";
-    private static final String REQUEST_ID_HEADER = "X-Request-Id";
     private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
     private static final String DEFAULT_VALUE = "-";
     private static final int MAX_REQUEST_ID_LENGTH = 80;
@@ -58,6 +58,10 @@ public class AccessLogFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+        String requestId = resolveRequestId(request);
+        request.setAttribute(RequestLogContext.REQUEST_ID_ATTRIBUTE, requestId);
+        response.setHeader(RequestLogContext.REQUEST_ID_HEADER, requestId);
+
         long startNanos = System.nanoTime();
         boolean failed = false;
 
@@ -89,7 +93,7 @@ public class AccessLogFilter extends OncePerRequestFilter {
                 durationMs,
                 resolveAttribute(request, AuthRequestAttributes.USER_ID),
                 resolveAttribute(request, AuthRequestAttributes.SESSION_ID),
-                resolveRequestId(request),
+                resolveAttribute(request, RequestLogContext.REQUEST_ID_ATTRIBUTE),
                 resolveClientIp(request)
         );
     }
@@ -115,7 +119,7 @@ public class AccessLogFilter extends OncePerRequestFilter {
     }
 
     private String resolveRequestId(HttpServletRequest request) {
-        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        String requestId = request.getHeader(RequestLogContext.REQUEST_ID_HEADER);
 
         if (!StringUtils.hasText(requestId)) {
             return UUID.randomUUID().toString();

--- a/src/main/java/com/bean/breaddiary/global/logging/RequestLogContext.java
+++ b/src/main/java/com/bean/breaddiary/global/logging/RequestLogContext.java
@@ -1,0 +1,29 @@
+package com.bean.breaddiary.global.logging;
+
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public final class RequestLogContext {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_ATTRIBUTE = "requestId";
+
+    private static final String DEFAULT_VALUE = "-";
+
+    private RequestLogContext() {
+    }
+
+    public static String currentRequestIdOrDefault() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+
+        if (!(requestAttributes instanceof ServletRequestAttributes servletRequestAttributes)) {
+            return DEFAULT_VALUE;
+        }
+
+        Object requestId = servletRequestAttributes.getRequest()
+                .getAttribute(REQUEST_ID_ATTRIBUTE);
+
+        return requestId == null ? DEFAULT_VALUE : requestId.toString();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/client/TossAuthClientTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/client/TossAuthClientTest.java
@@ -1,0 +1,98 @@
+package com.bean.breaddiary.domain.auth.client;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class TossAuthClientTest {
+
+    private static final String BASE_URL = "https://toss.example";
+    private static final String GENERATE_TOKEN_URL =
+            BASE_URL + "/api-partner/v1/apps-in-toss/user/oauth2/generate-token";
+
+    private TossAuthClient tossAuthClient;
+    private MockRestServiceServer mockServer;
+    private Logger logger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        tossAuthClient = new TossAuthClient(
+                restClientBuilder,
+                new ObjectMapper(),
+                BASE_URL,
+                "unlink-access-token"
+        );
+
+        logger = (Logger) LoggerFactory.getLogger(TossAuthClient.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
+    @Test
+    void exchangeAuthorizationCodeDoesNotLogExternalResponseBodyWhenTossReturnsServerError() {
+        String secretResponseBody = "external-secret-response-body";
+        String responseBody = """
+                {
+                  "error": "TOSS_DOWN",
+                  "reason": "external-secret-response-body"
+                }
+                """;
+
+        mockServer.expect(requestTo(GENERATE_TOKEN_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(responseBody));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> tossAuthClient.exchangeAuthorizationCode("authorization-code", "DEFAULT")
+        );
+
+        assertEquals(HttpStatus.BAD_GATEWAY, exception.getStatusCode());
+        mockServer.verify();
+
+        String logs = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.joining("\n"));
+
+        assertTrue(logs.contains("action=tossExchange"));
+        assertTrue(logs.contains("status=500"));
+        assertTrue(logs.contains("errorCode=TOSS_DOWN"));
+        assertTrue(logs.contains("exceptionType="));
+        assertFalse(logs.contains(secretResponseBody));
+        assertFalse(logs.contains(responseBody));
+        assertTrue(listAppender.list.stream().allMatch(event -> event.getThrowableProxy() == null));
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/filter/AccessLogFilterTest.java
+++ b/src/test/java/com/bean/breaddiary/global/filter/AccessLogFilterTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import com.bean.breaddiary.global.logging.RequestLogContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.AfterEach;
@@ -61,6 +62,38 @@ class AccessLogFilterTest {
         assertTrue(accessLog.matches(".*durationMs=\\d+.*"));
         assertTrue(accessLog.contains("requestId=front-request-1"));
         assertTrue(accessLog.contains("clientIp=203.0.113.10"));
+        assertEquals("front-request-1", response.getHeader(RequestLogContext.REQUEST_ID_HEADER));
+        assertEquals("front-request-1", request.getAttribute(RequestLogContext.REQUEST_ID_ATTRIBUTE));
+    }
+
+    @Test
+    void doFilterSanitizesRequestIdForResponseAttributeAndAccessLog() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        request.addHeader("X-Request-Id", " front request!\r\nid:1 ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        accessLogFilter.doFilter(request, response, passThroughChain());
+
+        String expectedRequestId = "frontrequestid:1";
+        String accessLog = singleLogMessage();
+        assertEquals(expectedRequestId, response.getHeader(RequestLogContext.REQUEST_ID_HEADER));
+        assertEquals(expectedRequestId, request.getAttribute(RequestLogContext.REQUEST_ID_ATTRIBUTE));
+        assertTrue(accessLog.contains("requestId=" + expectedRequestId));
+    }
+
+    @Test
+    void doFilterGeneratesRequestIdWhenHeaderIsMissing() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        accessLogFilter.doFilter(request, response, passThroughChain());
+
+        String responseRequestId = response.getHeader(RequestLogContext.REQUEST_ID_HEADER);
+        UUID.fromString(responseRequestId);
+
+        String accessLog = singleLogMessage();
+        assertEquals(responseRequestId, request.getAttribute(RequestLogContext.REQUEST_ID_ATTRIBUTE));
+        assertTrue(accessLog.contains("requestId=" + responseRequestId));
     }
 
     @Test


### PR DESCRIPTION
## 🧩 관련 이슈

- #68

## 🛠️ 작업 내용

- `X-Request-Id`를 응답 헤더로 내려주도록 추가했습니다.
- AccessLogFilter에서 requestId를 필터 초입에 한 번 확정하고, request attribute / 응답 헤더 / access log에 동일한 값을 사용하도록 정리했습니다.
- 요청 헤더에 `X-Request-Id`가 있으면 sanitize 후 재사용하고, 없으면 UUID를 생성하도록 반영했습니다.
- CORS exposed headers에 `X-Request-Id`를 추가해 프론트에서 읽을 수 있도록 했습니다.
- GlobalExceptionHandler에 requestId를 포함한 예외 로그를 추가해 access log와 예외 로그를 같은 requestId로 추적할 수 있게 했습니다.
- AuthService, TossAuthClient, UserWithdrawalService에 최소 수준의 구조화 로그를 추가해 auth/user 주요 흐름에서 requestId 기반 추적이 가능하도록 했습니다.
- 민감정보 비노출 원칙을 유지하도록 Authorization, access/refresh token, Toss authorization code, webhook secret, request/response body, query string 전체 등이 로그에 직접 남지 않도록 정리했습니다.
- 리뷰에서 지적된 Toss 외부 응답 body 우회 노출 가능성을 줄이기 위해 throwable 전체 로깅을 줄이고, status / errorCode / requestId / action / durationMs / exceptionType 중심으로 로그를 남기도록 조정했습니다.
- Toss 5xx 응답 시 외부 response body 원문이 로그에 남지 않는지 확인하는 테스트를 추가했습니다. :contentReference[oaicite:0]{index=0}

## 📢 참고 및 특이사항

- 이번 작업 범위는 글로벌 로깅 / CORS / 예외 처리와 auth-user 관측성 보강에 한정했습니다.
- bread / breadrecord / s3 / upload 도메인 로직과 auth/token 정책은 변경하지 않았습니다.
- OPTIONS, Swagger, 정적 리소스처럼 AccessLogFilter 제외 대상 요청에는 requestId 헤더를 새로 강제하지 않았습니다.
- access log DB 저장, audit/history 테이블, 외부 로그 수집 인프라, 광범위한 비즈니스 이벤트 로그 설계는 이번 범위에 포함하지 않았습니다.
- 브랜치는 `feat/68-request-id-observability-logging` 에서 작업했고, 원격에 push까지 완료된 상태입니다. :contentReference[oaicite:1]{index=1}

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인