### PR TITLE
fix: stabilize auth logout request contract

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
@@ -103,7 +103,7 @@ public class AuthController {
     })
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<LogoutResponse>> logout(
-            @Valid @RequestBody(required = false) LogoutRequest request,
+            @RequestBody(required = false) LogoutRequest request,
             @Parameter(hidden = true) HttpServletRequest httpServletRequest
     ) {
         if (request != null && StringUtils.hasText(request.getRefreshToken())) {

--- a/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -90,6 +91,27 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .badRequest()
+                .body(ApiErrorResponse.failure("INVALID_REQUEST", message));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiErrorResponse> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException exception,
+            HttpServletRequest request
+    ) {
+        String message = "?붿껌 ?뺤떇???щ컮瑜댁? ?딆뒿?덈떎.";
+
+        log.warn(
+                "Invalid request: code={} method={} path={} requestId={} errorType={}",
+                "INVALID_REQUEST",
+                request.getMethod(),
+                request.getRequestURI(),
+                RequestLogContext.currentRequestIdOrDefault(),
+                exception.getClass().getSimpleName()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                 .body(ApiErrorResponse.failure("INVALID_REQUEST", message));
     }
 

--- a/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
 import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.bean.breaddiary.domain.auth.service.AuthService;
 import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
+import com.bean.breaddiary.global.common.GlobalExceptionHandler;
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -46,6 +48,7 @@ class AuthControllerTest {
         userWithdrawalService = mock(UserWithdrawalService.class);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new AuthController(authService, userWithdrawalService))
+                .setControllerAdvice(new GlobalExceptionHandler())
                 .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
     }
@@ -197,6 +200,40 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data.logged_out").doesNotExist());
 
         verify(authService).logoutCurrentSession(sessionId);
+    }
+
+    @Test
+    void logoutAllowsEmptyJsonObjectAndUsesAuthenticatedSession() throws Exception {
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440021");
+        when(authService.logoutCurrentSession(sessionId))
+                .thenReturn(new LogoutResponse(true));
+
+        mockMvc.perform(post("/auth/logout")
+                        .requestAttr(AuthRequestAttributes.SESSION_ID, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.loggedOut").value(true))
+                .andExpect(jsonPath("$.data.logged_out").doesNotExist());
+
+        verify(authService).logoutCurrentSession(sessionId);
+        verify(authService, never()).logout(any(LogoutRequest.class));
+    }
+
+    @Test
+    void logoutRejectsFormUrlEncodedRequestWithoutCallingService() throws Exception {
+        mockMvc.perform(post("/auth/logout")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content("refreshToken=refresh-token")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnsupportedMediaType())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+
+        verify(authService, never()).logout(any(LogoutRequest.class));
+        verify(authService, never()).logoutCurrentSession(any());
     }
 
     @Test

--- a/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
@@ -51,6 +51,16 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.error.message").value("이름은 필수입니다."));
     }
 
+    @Test
+    void unsupportedMediaTypeReturnsCommonErrorResponse() throws Exception {
+        mockMvc.perform(post("/json-only")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content("name=bread"))
+                .andExpect(status().isUnsupportedMediaType())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+    }
+
     @RestController
     private static class TestController {
 
@@ -61,6 +71,10 @@ class GlobalExceptionHandlerTest {
 
         @PostMapping("/validate")
         void validate(@Valid @RequestBody TestRequest request) {
+        }
+
+        @PostMapping(value = "/json-only", consumes = MediaType.APPLICATION_JSON_VALUE)
+        void jsonOnly(@RequestBody TestRequest request) {
         }
     }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- #이슈번호

## 🛠️ 작업 내용

- `/auth/logout` 요청 계약을 프론트 연동 기준으로 안정화했습니다.
- `AuthController.logout()`의 optional `LogoutRequest`에서 controller 레벨 `@Valid`만 제거해 body 없음과 `{}` JSON body를 모두 허용하도록 정리했습니다.
- Bearer access token + body 없음 호출은 기존처럼 현재 세션 기준 logout으로 동작합니다.
- Bearer access token + `{}` JSON body도 현재 세션 기준 logout으로 `200` 응답되도록 보완했습니다.
- `{ "refreshToken": "..." }` 요청은 기존처럼 refresh token 기반 logout 흐름을 유지합니다.
- `application/x-www-form-urlencoded` 같은 unsupported content type 요청은 `500`이 아니라 `415` + `INVALID_REQUEST` 공통 에러 응답으로 정리했습니다.
- `GlobalExceptionHandler`에 unsupported media type 처리를 추가해 WARN 로그와 공통 에러 응답 구조를 맞췄습니다.
- `LogoutRequest.refreshToken`의 `@NotBlank`는 유지해서 DTO 의미와 기존 refresh token logout validation 의도는 바꾸지 않았습니다.

## 📢 참고 및 특이사항

- 이번 브랜치는 `fix/72-auth-logout-request-contract` 에서 작업했고, logout 요청 계약 보완만 최소 범위로 반영했습니다.
- `bread / breadrecord / s3 / upload` 관련 코드는 수정하지 않았습니다.
- auth/token 정책, refresh rotation, interceptor, requestId/CORS 동작은 변경하지 않았습니다.
- 현재 변경 파일은 아래 4개입니다.
  - `AuthController.java`
  - `GlobalExceptionHandler.java`
  - `AuthControllerTest.java`
  - `GlobalExceptionHandlerTest.java`
- `.gradle-codex/` 는 기존처럼 untracked 캐시 폴더이며 이번 작업 범위에 포함하지 않았습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인