### PR TITLE
docs: add toss e2e readiness checklist

### DIFF
--- a/docs/auth-manual-verification.md
+++ b/docs/auth-manual-verification.md
@@ -6,7 +6,22 @@
 
 범위는 `auth`, `user`, `token`, 인증 인터셉터, access log 확인까지다. `bread`, `breadrecord`, `s3`, `upload` 도메인 로직은 수정하지 않았고, 공개/선택 인증 endpoint 확인을 위해 호출만 했다.
 
-## 2. develop 반영 상태
+## 2. 최신 상태 메모
+
+이 문서는 `test/66-auth-manual-verification` 브랜치에서 수행한 당시 수동 검증 기록이다. 이후 `fix/72-auth-logout-request-contract`에서 `/auth/logout` 계약이 보완되었다.
+
+현재 최신 계약은 다음과 같다.
+
+| 요청 형태 | 최신 상태 |
+| --- | --- |
+| Bearer access token + body 없음 | 허용 |
+| Bearer access token + `{}` | 허용 |
+| `{ "refreshToken": "..." }` | 허용 |
+| `application/x-www-form-urlencoded` | 사용하지 않음, `415 INVALID_REQUEST` |
+
+실제 Toss E2E 준비 체크리스트는 `docs/toss-e2e-checklist.md`를 기준으로 본다.
+
+## 3. develop 반영 상태
 
 작업 시작 시 아래 순서로 최신 상태를 확인했다.
 
@@ -132,7 +147,7 @@ http://localhost:8080/v3/api-docs
 | `POST /auth/refresh` 정상 refresh token | `200` | access/refresh 모두 재발급 |
 | `POST /auth/refresh` 이전 refresh token 재사용 | `409` | `이미 회전된 리프레시 토큰입니다.` |
 | `POST /auth/logout` 토큰 없음 | `401` | 보호 API로 차단 |
-| `POST /auth/logout` `{}` body + 정상 access token | `400` | `LogoutRequest.refreshToken` validation 발생 |
+| `POST /auth/logout` `{}` body + 정상 access token | `400` | 당시 결과. 최신 구현에서는 `200`, `loggedOut=true` |
 | `POST /auth/logout` body 없음 + `Content-Type: application/json` + 정상 access token | `200` | `loggedOut=true` |
 | 로그아웃 후 `POST /auth/refresh` | `401` | 세션 없음으로 실패 |
 | `POST /auth/toss` blank body 값 | `400` | validation 실패 |
@@ -201,7 +216,7 @@ Invoke-WebRequest `
 
 ### logout
 
-중요: 현재 구현은 access token 기반 로그아웃을 할 때 `{}` body가 아니라 body를 보내지 않는 방식이어야 한다.
+최신 구현에서는 access token 기반 로그아웃을 할 때 body 없음과 `{}` body를 모두 허용한다. `Content-Type`은 `application/json`을 사용한다.
 
 ```powershell
 curl.exe -i -X POST "http://localhost:8080/auth/logout" `
@@ -251,7 +266,7 @@ Invoke-WebRequest `
 | 바로 가능 | 인증 실패 응답 | 토큰 없음/잘못된 토큰 공통 에러 확인 가능 |
 | 조건부 가능 | `/users/me` 성공 | 로컬 DB에 user/session과 유효 access token 필요 |
 | 조건부 가능 | `/auth/refresh` 성공/rotation | 로컬 DB에 user/session과 유효 refresh token/hash/currentJti 필요 |
-| 조건부 가능 | `/auth/logout` 성공 | 유효 access token 필요, body 없이 호출 필요 |
+| 조건부 가능 | `/auth/logout` 성공 | 유효 access token 필요, body 없음 또는 `{}` 허용 |
 | 조건부 가능 | webhook 성공 | `TOSS_WEBHOOK_SECRET` 설정 필요 |
 | 조건부 가능 | `DELETE /users/me` | tossUserKey가 없으면 로컬 단독 가능, tossUserKey가 있으면 Toss unlink 외부 API 필요 |
 | 현재 불가 | `/auth/toss` 실로그인 성공 | 실제 Toss authorizationCode/referrer와 Toss 설정 필요 |
@@ -282,8 +297,8 @@ HTTP 수동 호출은 `curl.exe`와 `Invoke-WebRequest`를 함께 사용했다. 
 
 ## 13. 남은 TODO
 
-- `/auth/logout`은 `{}` body를 보내면 validation 실패가 난다. 프론트에는 body 없이 호출하도록 공유해야 한다.
-- `Invoke-WebRequest`처럼 body 없이 호출하면서 `Content-Type`이 `application/x-www-form-urlencoded`로 잡히면 현재 500이 난다. 실제 클라이언트가 이런 요청을 보낼 가능성이 있으면 auth 브랜치에서 예외 처리 또는 controller signature 보완을 검토한다.
+- 해결됨: 최신 구현에서 `/auth/logout`은 body 없음, `{}`, `{ "refreshToken": "..." }`를 허용한다.
+- 해결됨: `application/x-www-form-urlencoded` 같은 unsupported content type은 `415 INVALID_REQUEST`로 응답한다. 프론트는 `application/json`을 사용한다.
 - `/dev/auth/token`은 `AuthInterceptor` whitelist에는 있지만 controller 구현은 확인되지 않았다. 수동 검증 편의가 필요하면 별도 결정이 필요하다.
 - Toss 실로그인은 프론트/Toss 콘솔/authorizationCode/referrer 준비 후 별도 E2E로 확인한다.
 - Toss userKey가 있는 앱 탈퇴는 실제 `TOSS_UNLINK_ACCESS_TOKEN`과 Toss API 성공이 있어야 완전 검증 가능하다.

--- a/docs/local-env-and-e2e-guide.md
+++ b/docs/local-env-and-e2e-guide.md
@@ -168,7 +168,7 @@ Bearer access token이 필요하다.
 | --- | --- | --- |
 | `GET` | `/users/me` | 현재 사용자 프로필/통계 |
 | `DELETE` | `/users/me` | 회원탈퇴 |
-| `POST` | `/auth/logout` | empty body면 현재 access token의 session 종료 |
+| `POST` | `/auth/logout` | body 없음/`{}`이면 현재 access token의 session 종료, refreshToken body도 허용 |
 | `GET` | `/breads/{recordId}` | 기록 상세 |
 | `POST` | `/breads` | 기록 생성. multipart/S3 필요 |
 | `POST` | `/breads/new` | 신규 빵 + 기록 생성. multipart/S3 필요 |
@@ -248,7 +248,15 @@ curl.exe -i -X POST "http://localhost:8080/auth/refresh" `
 
 #### `POST /auth/logout`
 
-현재 정책은 empty body + Bearer access token으로 현재 session을 종료하는 방식이다. refresh token body도 호환 경로로 남아 있다.
+최신 정책은 Bearer access token으로 현재 session을 종료하는 방식이다. body 없음과 `{}` body를 모두 허용하며, refresh token body도 호환 경로로 남아 있다.
+
+| 요청 형태 | 상태 |
+| --- | --- |
+| Bearer access token + body 없음 | 허용 |
+| Bearer access token + `{}` | 허용 |
+| `{ "refreshToken": "..." }` | 허용 |
+| `application/x-www-form-urlencoded` | 사용하지 않음 |
+| unsupported content type | `415 INVALID_REQUEST` |
 
 ```powershell
 curl.exe -i -X POST "http://localhost:8080/auth/logout" `
@@ -347,17 +355,17 @@ curl.exe -i "http://localhost:8080/users/me" `
 | `GET /breads/catalog/{breadId}` | 구현됨 | 일부 controller 테스트 존재 | 조건부 가능 | 실제 `breadId` | 선택 인증 |
 | `POST /auth/toss` | 구현됨 | `AuthControllerTest`, `AuthServiceTest` | 조건부 가능 | 실제 Toss code/referrer | 실연동 미완료 |
 | `POST /auth/refresh` | 구현됨 | 단위/동시성/MySQL 통합 테스트 | 조건부 가능 | 유효한 refresh token 필요 | Toss 로그인 성공 후 완전 확인 |
-| `POST /auth/logout` | 구현됨 | controller/service 테스트 | 조건부 가능 | 유효한 access token/session 필요 | empty body 지원 |
+| `POST /auth/logout` | 구현됨 | controller/service 테스트 | 조건부 가능 | 유효한 access token/session 필요 | empty body, `{}`, refreshToken body 지원 |
 | `POST /auth/webhook/toss-unlink` | 구현됨 | controller/service 테스트 | 조건부 가능 | webhook secret, user 데이터 | eventType 분기 |
 | `GET /users/me` | 구현됨 | `UserControllerTest` | 조건부 가능 | 유효한 access token/session 필요 | JWT 기준 |
-| Access logging | 구현됨 | `AccessLogFilterTest` | 가능 | 서버 기동 | requestId는 로그에만 남음 |
+| Access logging | 구현됨 | `AccessLogFilterTest` | 가능 | 서버 기동 | requestId는 access log와 `X-Request-Id` 응답 헤더에 남음 |
 
 ## 10. 알려진 제한 사항 / TODO
 
 - Dev token 발급용 실제 controller는 코드상 확인되지 않았다. 수동 auth/user 검증을 쉽게 하려면 별도 dev token 전략이나 seed 전략이 필요할 수 있다.
 - Toss 실로그인 성공 검증은 프론트에서 실제 `authorizationCode`와 `referrer`를 받아와야 가능하다.
 - S3가 필요한 multipart 기록 생성 API는 로컬 S3 mock 또는 테스트용 AWS 설정 없이는 완전한 수동 검증이 어렵다.
-- `requestId`는 access log에만 남고 응답 헤더로 내려가지 않는다. 프론트/백엔드 공동 디버깅을 위해 응답 헤더 노출 여부는 별도 결정이 필요하다.
+- `requestId`는 access log와 `X-Request-Id` 응답 헤더에 함께 남는다. 프론트에서 읽어야 하면 CORS exposed header 설정을 확인한다.
 - `application.yml`의 민감값 형태 설정은 env/secret 기반으로 분리하는 것이 안전하다.
 - `/v1` prefix는 현재 controller 코드 기준으로 붙어 있지 않다. Gateway/Nginx에서 처리할지, Spring에서 처리할지는 별도 결정이 필요하다.
 

--- a/docs/toss-e2e-checklist.md
+++ b/docs/toss-e2e-checklist.md
@@ -1,0 +1,324 @@
+# Toss E2E 준비 체크리스트
+
+## 1. 문서 목적
+
+이 문서는 실제 Toss 로그인 E2E를 실행하기 전에 백엔드, 프론트, Toss console, 배포 환경에서 준비해야 할 값과 검증 순서를 정리한다.
+
+이번 문서는 실로그인 성공 결과 기록이 아니다. 현재 백엔드에는 Toss 로그인 흐름이 구현되어 있지만, 실제 성공 검증은 프론트 redirect/referrer, Toss developer console 설정, 배포 URL, 외부 secret/env가 준비된 뒤에만 가능하다.
+
+상태 표기는 다음 기준을 사용한다.
+
+| 상태 | 의미 |
+| --- | --- |
+| 이미 준비됨 | 현재 코드와 테스트에서 확인 가능한 범위 |
+| 조건부 가능 | 로컬 DB, user/session/token, env 값을 직접 준비하면 확인 가능한 범위 |
+| 실환경 필요 | 프론트, Toss console, 배포 URL, Toss 외부 API 응답이 필요해서 백엔드 단독으로 확인할 수 없는 범위 |
+| 미확인 | 아직 실제 값으로 검증하지 않은 범위 |
+
+## 2. 현재 백엔드에서 이미 준비된 것
+
+| 항목 | 상태 | 메모 |
+| --- | --- | --- |
+| `POST /auth/toss` | 이미 준비됨, 실제 성공은 실환경 필요 | `authorizationCode`, `referrer`를 받아 Toss token API와 login-me API를 호출한 뒤 앱 access/refresh token을 발급하는 흐름이 있다. |
+| `GET /users/me` | 이미 준비됨, 성공 호출은 조건부 가능 | Bearer access token 인증 후 현재 사용자 정보와 stats를 반환한다. |
+| `POST /auth/refresh` | 이미 준비됨, 성공 호출은 조건부 가능 | refresh token을 검증하고 access/refresh token을 모두 재발급한다. refresh token rotation과 재사용 방지가 적용되어 있다. |
+| `POST /auth/logout` | 이미 준비됨, 성공 호출은 조건부 가능 | Bearer access token 기반 현재 세션 로그아웃과 refreshToken body 기반 로그아웃을 모두 지원한다. |
+| `POST /auth/webhook/toss-unlink` | 이미 준비됨, 성공 호출은 조건부 가능 | `x-toss-webhook-secret` 검증 후 `UNLINK`, `WITHDRAWAL_TERMS`, `WITHDRAWAL_TOSS` 이벤트를 처리한다. |
+| `DELETE /users/me` | 이미 준비됨, 성공 호출은 조건부 가능 | 현재 사용자 탈퇴를 처리한다. Toss userKey가 있으면 Toss unlink 외부 호출이 필요하다. |
+| AuthInterceptor | 이미 준비됨 | Bearer access token을 검증하고 `authenticatedUserId`, `authenticatedSessionId` request attribute를 저장한다. refresh token은 일반 API 인증에 허용하지 않는다. |
+| requestId/access log | 이미 준비됨 | `X-Request-Id` 요청 헤더가 있으면 sanitize 후 재사용하고, 없으면 UUID를 생성한다. 응답 헤더와 access log의 requestId가 같다. |
+| CORS | 이미 준비됨 | `CORS_ALLOWED_ORIGINS` 또는 `app.cors.allowed-origins`로 origin을 설정한다. `Location`, `X-Request-Id`가 exposed header에 포함되어 있다. |
+| 민감정보 비노출 원칙 | 이미 준비됨 | access log는 query string, Authorization header, body, webhook secret, token 값을 남기지 않는 방향으로 테스트되어 있다. |
+
+## 3. 실제 Toss E2E 전에 필요한 값
+
+실제 값은 문서, PR 본문, 로그에 남기지 않는다. 아래 항목은 모두 환경 변수, 배포 secret, Toss console, 프론트 설정에서 관리한다.
+
+| 값 | 필요 위치 | 설명 |
+| --- | --- | --- |
+| backend base URL | 프론트, Toss E2E 실행자 | 프론트가 호출할 백엔드 주소다. 예: 로컬 `http://localhost:8080`, 배포 `<BACKEND_BASE_URL>`. |
+| frontend redirect URL | 프론트, Toss console | Toss 로그인 완료 후 authorization code를 받을 프론트 redirect 주소다. |
+| `authorizationCode` | 프론트 -> 백엔드 | 프론트가 Toss 로그인 후 획득해 `POST /auth/toss`에 전달한다. 일회성 값으로 보고 재사용하지 않는다. |
+| `referrer` | 프론트 -> 백엔드 | 프론트가 Toss 로그인 결과와 함께 전달한다. 백엔드는 Toss generate-token 요청에 사용한다. |
+| Toss developer console redirect 설정 | Toss console | 프론트 redirect URL과 실제 로그인 진입 환경이 Toss console 설정과 일치해야 한다. |
+| `TOSS_DECRYPTION_KEY` | 백엔드 env/secret | Toss 사용자 정보 복호화에 필요하다. |
+| `TOSS_AAD` | 백엔드 env/secret | Toss 사용자 정보 복호화 AAD 값이다. |
+| `TOSS_WEBHOOK_SECRET` | 백엔드 env/secret, webhook 호출자 | `POST /auth/webhook/toss-unlink`의 `x-toss-webhook-secret` 검증에 필요하다. |
+| `TOSS_UNLINK_ACCESS_TOKEN` | 백엔드 env/secret | Toss userKey가 있는 사용자의 탈퇴/unlink 외부 호출에 필요하다. |
+| `JWT_SECRET` | 백엔드 env/secret | 앱 access/refresh token 서명과 검증에 필요하다. |
+| DB 연결 정보 | 백엔드 env/profile | user, session, refresh token rotation 상태 저장에 필요하다. 로컬은 `local` profile과 MySQL 준비가 필요하다. |
+| `CORS_ALLOWED_ORIGINS` | 백엔드 env/config | 실제 프론트 origin을 포함해야 한다. 프론트에서 `X-Request-Id`를 읽어야 하면 exposed header 설정도 확인한다. |
+
+## 4. 로컬 실행 전 점검
+
+로컬에서 백엔드를 띄워 실패 응답, 인증 실패, refresh/logout 조건부 흐름을 확인하려면 다음 값이 필요하다.
+
+```powershell
+$env:SPRING_PROFILES_ACTIVE = "local"
+$env:JWT_SECRET = "<JWT_SECRET>"
+$env:CORS_ALLOWED_ORIGINS = "http://localhost:3000,http://localhost:5173"
+$env:TOSS_WEBHOOK_SECRET = "<TOSS_WEBHOOK_SECRET>"
+$env:TOSS_UNLINK_ACCESS_TOKEN = "<TOSS_UNLINK_ACCESS_TOKEN>"
+$env:TOSS_DECRYPTION_KEY = "<TOSS_DECRYPTION_KEY>"
+$env:TOSS_AAD = "<TOSS_AAD>"
+```
+
+```powershell
+.\gradlew.bat bootRun
+```
+
+Swagger/OpenAPI 확인 경로:
+
+```text
+http://localhost:8080/swagger-ui.html
+http://localhost:8080/swagger-ui/index.html
+http://localhost:8080/v3/api-docs
+```
+
+## 5. 실제 Toss 로그인 E2E 검증 순서
+
+아래 순서는 프론트, Toss console, 백엔드 배포/env가 모두 준비된 뒤 실행한다.
+
+1. 프론트에서 Toss 로그인 진입
+   - 프론트가 실제 Toss 로그인 플로우를 시작한다.
+   - redirect URL이 Toss console 설정과 일치하는지 먼저 확인한다.
+
+2. 프론트에서 `authorizationCode`, `referrer` 획득
+   - 획득한 값은 즉시 백엔드로 전달한다.
+   - 같은 `authorizationCode`를 재사용하지 않는다.
+
+3. `POST /auth/toss` 호출
+
+```http
+POST <BACKEND_BASE_URL>/auth/toss
+Content-Type: application/json
+X-Request-Id: <OPTIONAL_REQUEST_ID>
+```
+
+```json
+{
+  "authorizationCode": "<TOSS_AUTHORIZATION_CODE>",
+  "referrer": "<TOSS_REFERRER>"
+}
+```
+
+기대 결과:
+
+```json
+{
+  "success": true,
+  "data": {
+    "userId": "<USER_ID>",
+    "accessToken": "<ACCESS_TOKEN>",
+    "refreshToken": "<REFRESH_TOKEN>",
+    "tokenType": "Bearer",
+    "accessTokenExpiresAt": "<DATE_TIME>",
+    "refreshTokenExpiresAt": "<DATE_TIME>",
+    "newUser": true
+  }
+}
+```
+
+4. 응답 헤더 확인
+   - `X-Request-Id`가 내려오는지 확인한다.
+   - 프론트 브라우저에서 해당 헤더를 읽을 수 없으면 CORS exposed header 설정을 확인한다.
+
+5. `GET /users/me` 확인
+
+```http
+GET <BACKEND_BASE_URL>/users/me
+Authorization: Bearer <ACCESS_TOKEN>
+```
+
+확인 항목:
+
+- `success=true`
+- `data.id`
+- `data.nickname`
+- `data.email`
+- `data.stats.totalRecords`
+- `data.stats.totalStickers`
+- `data.stats.uniqueShops`
+- `data.stats.avgRating`
+
+6. `POST /auth/refresh` 확인
+
+```http
+POST <BACKEND_BASE_URL>/auth/refresh
+Content-Type: application/json
+```
+
+```json
+{
+  "refreshToken": "<REFRESH_TOKEN>"
+}
+```
+
+확인 항목:
+
+- 새 `accessToken` 발급
+- 새 `refreshToken` 발급
+- `newUser=false`
+
+7. 이전 refresh token 재사용 실패 확인
+   - 6단계에서 사용한 이전 refresh token으로 다시 `/auth/refresh`를 호출한다.
+   - 기대 결과는 `409 CONFLICT` 계열이다.
+
+8. `POST /auth/logout` 확인
+
+권장 호출:
+
+```http
+POST <BACKEND_BASE_URL>/auth/logout
+Authorization: Bearer <ACCESS_TOKEN>
+Content-Type: application/json
+```
+
+body 없음 또는 `{}`를 사용할 수 있다.
+
+```json
+{}
+```
+
+기대 결과:
+
+```json
+{
+  "success": true,
+  "data": {
+    "loggedOut": true
+  }
+}
+```
+
+9. logout 이후 refresh 실패 확인
+   - logout으로 세션이 종료된 뒤 해당 세션의 refresh token으로 `/auth/refresh`를 호출한다.
+   - 기대 결과는 `401 UNAUTHORIZED` 계열이다.
+
+10. `DELETE /users/me` 확인
+    - 새 로그인 또는 아직 유효한 access token이 필요하다.
+    - Toss userKey가 있는 사용자는 `TOSS_UNLINK_ACCESS_TOKEN`과 Toss 외부 API 접근이 필요하다.
+
+```http
+DELETE <BACKEND_BASE_URL>/users/me
+Authorization: Bearer <ACCESS_TOKEN>
+```
+
+11. 필요 시 webhook/unlink 확인
+
+```http
+POST <BACKEND_BASE_URL>/auth/webhook/toss-unlink
+Content-Type: application/json
+x-toss-webhook-secret: <TOSS_WEBHOOK_SECRET>
+```
+
+```json
+{
+  "userKey": "<TOSS_USER_KEY>",
+  "eventType": "UNLINK"
+}
+```
+
+`eventType`은 현재 `UNLINK`, `WITHDRAWAL_TERMS`, `WITHDRAWAL_TOSS`를 사용한다.
+
+## 6. logout 최신 계약
+
+`POST /auth/logout`은 보호 API이므로 Bearer access token이 필요하다.
+
+| 요청 형태 | 상태 | 설명 |
+| --- | --- | --- |
+| Bearer access token + body 없음 | 허용 | 현재 인증된 access token의 sessionId로 로그아웃한다. |
+| Bearer access token + `{}` | 허용 | body 없음과 동일하게 현재 인증 세션을 로그아웃한다. |
+| `{ "refreshToken": "..." }` | 허용 | refresh token을 검증한 뒤 해당 세션을 로그아웃한다. 호환 경로로 유지한다. |
+| `application/x-www-form-urlencoded` | 사용하지 않음 | JSON API 계약이 아니므로 프론트에서 사용하지 않는다. |
+| unsupported content type | `415 INVALID_REQUEST` | 공통 에러 응답으로 내려간다. |
+
+프론트 권장 호출은 다음 중 하나다.
+
+```http
+POST /auth/logout
+Authorization: Bearer <ACCESS_TOKEN>
+Content-Type: application/json
+```
+
+또는
+
+```json
+{}
+```
+
+## 7. 현재 가능한 것과 아직 불가능한 것
+
+### 로컬만으로 가능한 검증
+
+- 서버 bootRun과 Swagger 접근 확인
+- `GET /bread-types` 같은 public API 200 확인
+- token 없음/잘못된 token의 `401` 확인
+- `/auth/toss` 요청 body validation 실패 확인
+- `/auth/webhook/toss-unlink`의 missing header `400`, wrong secret `401` 확인
+- access log의 `requestId`, `method`, `path`, `status`, `durationMs` 형태 확인
+- `X-Request-Id` 응답 헤더 확인
+
+### DB에 테스트용 user/session/token을 준비하면 가능한 검증
+
+- `GET /users/me` 성공
+- `POST /auth/refresh` 성공과 refresh token rotation
+- 이전 refresh token 재사용 `409`
+- `POST /auth/logout` 성공
+- logout 이후 refresh `401`
+- Toss userKey가 없는 로컬 사용자 `DELETE /users/me` 성공
+- webhook secret이 맞고 unknown userKey인 경우 `processed=true` 응답
+
+### 프론트 + Toss console + 배포 URL이 있어야 가능한 검증
+
+- 실제 Toss 로그인 성공
+- 실제 Toss `authorizationCode`와 `referrer`로 `/auth/toss` 성공
+- Toss login-me 응답 복호화 성공
+- 프론트 브라우저에서 CORS, `X-Request-Id`, auth/user camelCase 응답 확인
+- 실제 로그인 token pair로 `/users/me -> /auth/refresh -> /auth/logout` 전체 플로우 확인
+
+### 현재 외부값 부족으로 아직 못 한 검증
+
+- 실제 Toss authorization code 기반 로그인 성공
+- 실제 Toss console redirect 설정 일치 여부
+- 실제 Toss 암호화 사용자 정보 복호화
+- Toss userKey가 있는 사용자의 실제 unlink API 성공
+- 실배포 origin에서의 CORS 동작
+
+## 8. 실패 시 체크 포인트
+
+| 증상/status | 확인할 것 |
+| --- | --- |
+| `400 BAD_REQUEST` | JSON body 형식, `authorizationCode`, `referrer`, webhook body, 필수 값 누락을 확인한다. |
+| `401 UNAUTHORIZED` | Bearer access token, refresh token, token type, 만료 여부, webhook secret, `JWT_SECRET`, Toss invalid grant 여부를 확인한다. |
+| `409 CONFLICT` | refresh token이 이미 rotation된 이전 값인지 확인한다. 재사용 실패는 기대 동작이다. |
+| `415 INVALID_REQUEST` | `Content-Type`이 `application/json`인지 확인한다. `application/x-www-form-urlencoded`는 사용하지 않는다. |
+| `404 NOT_FOUND` 또는 프론트 redirect 실패 | frontend redirect URL, Toss console redirect 설정, 프론트 라우팅, backend base URL을 확인한다. |
+| CORS 에러 | `CORS_ALLOWED_ORIGINS`에 실제 프론트 origin이 포함되어 있는지 확인한다. 프론트에서 `X-Request-Id`를 읽어야 하면 exposed header도 확인한다. |
+| Toss 연동 실패 | Toss console redirect 설정, `authorizationCode` 재사용/만료, `referrer`, `TOSS_DECRYPTION_KEY`, `TOSS_AAD`, `TOSS_UNLINK_ACCESS_TOKEN`, Toss API 접근 가능 여부를 확인한다. |
+| `500 INTERNAL_ERROR` | `JWT_SECRET`, DB 연결, 필수 env 누락, 서버 로그의 `requestId`를 확인한다. |
+| `502 TOSS_SERVER_ERROR` | Toss 외부 API 장애 또는 비정상 응답 가능성을 확인한다. 서버 로그의 `TOSS action`, `status`, `errorCode`, `requestId`를 확인한다. |
+
+## 9. 로그와 민감정보 주의
+
+다음 값은 문서, PR, 로그, 이슈 댓글에 남기지 않는다.
+
+- Authorization header
+- access token
+- refresh token
+- Toss authorization code
+- `x-toss-webhook-secret`
+- `TOSS_*` secret 값
+- request body / response body 원문
+- presigned URL full query
+- production credential
+
+문제 추적 시에는 `X-Request-Id`와 서버 access log의 `requestId`를 기준으로 맞춰 본다.
+
+## 10. 다음 작업자 메모
+
+- 이 문서는 체크리스트이며, 실제 Toss 성공 검증 결과가 아니다.
+- 실제 E2E 브랜치는 프론트에서 `authorizationCode`와 `referrer`를 전달할 수 있고 Toss console redirect/env가 준비된 뒤 시작한다.
+- auth/user 응답은 현재 프론트 연동 기준 camelCase를 사용한다.
+- bread, breadrecord, s3, upload 도메인 로직은 이 문서 작업 범위가 아니다.
+- 운영 secret 외부화와 실제 secret rotation은 별도 운영/보안 브랜치에서 다룬다.


### PR DESCRIPTION
## 🧩 관련 이슈

- #이슈번호

## 🛠️ 작업 내용

- Toss 실로그인 E2E 전에 필요한 준비사항과 검증 순서를 정리한 `docs/toss-e2e-checklist.md` 를 추가했습니다.
- 현재 백엔드에서 이미 준비된 auth/user 흐름과, 로컬에서 가능한 검증 / 실환경이 필요한 검증을 구분해 문서화했습니다.
- Toss E2E 실행 전에 필요한 외부 조건을 정리했습니다.
  - backend base URL
  - frontend redirect URL
  - frontend authorizationCode / referrer
  - Toss console redirect 설정
  - `TOSS_DECRYPTION_KEY`
  - `TOSS_AAD`
  - `TOSS_WEBHOOK_SECRET`
  - `TOSS_UNLINK_ACCESS_TOKEN`
  - `CORS_ALLOWED_ORIGINS`
- `/auth/logout` 최신 계약을 문서 기준으로 정리했습니다.
  - body 없음 허용
  - `{}` 허용
  - `{ "refreshToken": "..." }` 허용
  - `application/x-www-form-urlencoded` 는 사용하지 않음
  - unsupported content type 은 `415 INVALID_REQUEST`
- 기존 문서와의 충돌을 줄이기 위해 아래 문서도 함께 최신 계약 기준으로 보완했습니다.
  - `docs/auth-manual-verification.md`
  - `docs/local-env-and-e2e-guide.md`
- `auth-manual-verification.md` 는 과거 수동 검증 기록 문서임을 명시하고, 최신 계약은 새 체크리스트 기준으로 보도록 정리했습니다. :contentReference[oaicite:0]{index=0}

## 📢 참고 및 특이사항

- 이번 브랜치는 `docs/74-toss-e2e-readiness` 입니다.
- 코드 변경은 없고 문서만 수정했습니다.
- auth 정책, interceptor 동작, access log 구조, Toss API 호출 방식, 테스트 코드는 변경하지 않았습니다.
- 실제 Toss 로그인 성공 결과를 만든 것이 아니라, “나중에 바로 실행 가능한 준비 체크리스트”를 문서화한 작업입니다.
- 문서에는 확인된 사실만 적고, 실환경이 필요한 항목은 별도로 구분했습니다.
- 민감정보나 실제 secret 값, token 값, authorizationCode, webhook secret, presigned URL full query 등은 문서에 넣지 않았습니다. :contentReference[oaicite:1]{index=1}

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인