### PR TITLE
feat: add resized photo thumbnails and placeholder images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 	implementation 'org.mapstruct:mapstruct:1.6.3'
+	implementation 'org.imgscalr:imgscalr-lib:4.2'
+	implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 	implementation platform('software.amazon.awssdk:bom:2.27.21')
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'software.amazon.awssdk:url-connection-client'

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -65,7 +65,7 @@ public interface BreadMapper {
     @Mapping(target = "stickerNumber", source = "bread.stickerNumber")
     @Mapping(target = "name", source = "bread.name")
     @Mapping(target = "breadType", source = "bread.breadType.code")
-    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    @Mapping(target = "imageUrl", expression = "java(resolveCatalogImageUrl(bread.getImageUrl(), stats))")
     @Mapping(target = "isCollected", expression = "java(isCollected(stats))")
     @Mapping(target = "eatCount", expression = "java(resolveEatCount(stats))")
     @Mapping(target = "avgRating", expression = "java(resolveAvgRating(stats))")
@@ -97,6 +97,29 @@ public interface BreadMapper {
 
     default Boolean isCollected(BreadRecordCatalogStats stats) {
         return stats != null && resolveEatCount(stats) > 0;
+    }
+
+    default String resolveCatalogImageUrl(String imageUrl, BreadRecordCatalogStats stats) {
+        if (isCollected(stats)) {
+            return imageUrl;
+        }
+
+        return toPlaceholderUrl(imageUrl);
+    }
+
+    private String toPlaceholderUrl(String imageUrl) {
+        if (imageUrl == null) {
+            return null;
+        }
+
+        int extensionIndex = imageUrl.lastIndexOf('.');
+        if (extensionIndex < 0) {
+            return imageUrl + "_placeholder";
+        }
+
+        return imageUrl.substring(0, extensionIndex)
+                + "_placeholder"
+                + imageUrl.substring(extensionIndex);
     }
 
     default Long resolveEatCount(BreadRecordCatalogStats stats) {

--- a/src/main/java/com/bean/breaddiary/global/image/ImageResizeService.java
+++ b/src/main/java/com/bean/breaddiary/global/image/ImageResizeService.java
@@ -1,0 +1,143 @@
+package com.bean.breaddiary.global.image;
+
+import org.imgscalr.Scalr;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.imageio.ImageIO;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+@Service
+public class ImageResizeService {
+
+    private static final int ORIGINAL_MAX_SIZE = 1200;
+    private static final int THUMBNAIL_MAX_SIZE = 400;
+    private static final String WEBP_FORMAT = "webp";
+    private static final String WEBP_CONTENT_TYPE = "image/webp";
+    private static final String WEBP_EXTENSION = ".webp";
+    private static final float WEBP_QUALITY = 0.8F;
+
+    public ProcessedBreadPhoto processBreadPhoto(MultipartFile photo) {
+        BufferedImage sourceImage = readImage(photo);
+        BufferedImage originalImage = resizeToMaxLongSide(sourceImage, ORIGINAL_MAX_SIZE);
+        BufferedImage thumbnailImage = resizeToMaxLongSide(sourceImage, THUMBNAIL_MAX_SIZE);
+
+        return new ProcessedBreadPhoto(
+                toResizedImage(originalImage),
+                toResizedImage(thumbnailImage)
+        );
+    }
+
+    private BufferedImage readImage(MultipartFile photo) {
+        try {
+            BufferedImage image = ImageIO.read(photo.getInputStream());
+            if (image == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "올바른 이미지 파일을 업로드해주세요.");
+            }
+
+            return image;
+        } catch (IOException exception) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 파일을 읽을 수 없습니다.", exception);
+        }
+    }
+
+    private BufferedImage resizeToMaxLongSide(BufferedImage image, int maxSize) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        if (width <= maxSize && height <= maxSize) {
+            return image;
+        }
+
+        return Scalr.resize(
+                image,
+                Scalr.Method.QUALITY,
+                Scalr.Mode.AUTOMATIC,
+                maxSize
+        );
+    }
+
+    private ResizedImage toResizedImage(BufferedImage image) {
+        BufferedImage webpCompatibleImage = toWebpCompatibleImage(image);
+
+        ImageWriter writer = getWebpWriter();
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             ImageOutputStream imageOutputStream = ImageIO.createImageOutputStream(outputStream)) {
+            if (imageOutputStream == null) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환에 실패했습니다.");
+            }
+
+            writer.setOutput(imageOutputStream);
+            writer.write(null, new IIOImage(webpCompatibleImage, null, null), createWebpWriteParam(writer));
+            imageOutputStream.flush();
+
+            return new ResizedImage(
+                    outputStream.toByteArray(),
+                    WEBP_CONTENT_TYPE,
+                    WEBP_EXTENSION
+            );
+        } catch (IOException exception) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환에 실패했습니다.", exception);
+        } finally {
+            writer.dispose();
+        }
+    }
+
+    private ImageWriter getWebpWriter() {
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName(WEBP_FORMAT);
+        if (!writers.hasNext()) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "WebP 이미지 변환 설정이 필요합니다."
+            );
+        }
+
+        return writers.next();
+    }
+
+    private ImageWriteParam createWebpWriteParam(ImageWriter writer) {
+        ImageWriteParam writeParam = writer.getDefaultWriteParam();
+        if (writeParam.canWriteCompressed()) {
+            writeParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            String[] compressionTypes = writeParam.getCompressionTypes();
+            if (compressionTypes != null && compressionTypes.length > 0) {
+                writeParam.setCompressionType(compressionTypes[0]);
+            }
+            writeParam.setCompressionQuality(WEBP_QUALITY);
+        }
+
+        return writeParam;
+    }
+
+    private BufferedImage toWebpCompatibleImage(BufferedImage image) {
+        BufferedImage convertedImage = new BufferedImage(
+                image.getWidth(),
+                image.getHeight(),
+                BufferedImage.TYPE_INT_RGB
+        );
+        Graphics2D graphics = convertedImage.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+            graphics.drawImage(image, 0, 0, null);
+        } finally {
+            graphics.dispose();
+        }
+
+        return convertedImage;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/image/ProcessedBreadPhoto.java
+++ b/src/main/java/com/bean/breaddiary/global/image/ProcessedBreadPhoto.java
@@ -1,0 +1,12 @@
+package com.bean.breaddiary.global.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProcessedBreadPhoto {
+
+    private ResizedImage original;
+    private ResizedImage thumbnail;
+}

--- a/src/main/java/com/bean/breaddiary/global/image/ResizedImage.java
+++ b/src/main/java/com/bean/breaddiary/global/image/ResizedImage.java
@@ -1,0 +1,13 @@
+package com.bean.breaddiary.global.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResizedImage {
+
+    private byte[] bytes;
+    private String contentType;
+    private String extension;
+}

--- a/src/main/java/com/bean/breaddiary/global/s3/S3UploadService.java
+++ b/src/main/java/com/bean/breaddiary/global/s3/S3UploadService.java
@@ -1,5 +1,8 @@
 package com.bean.breaddiary.global.s3;
 
+import com.bean.breaddiary.global.image.ProcessedBreadPhoto;
+import com.bean.breaddiary.global.image.ResizedImage;
+import com.bean.breaddiary.global.image.ImageResizeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -12,7 +15,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-import java.io.IOException;
 import java.util.Set;
 import java.util.UUID;
 
@@ -20,6 +22,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class S3UploadService {
 
+    private static final long MAX_PHOTO_SIZE_BYTES = 10L * 1024L * 1024L;
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
             "image/jpeg",
             "image/png",
@@ -27,6 +30,7 @@ public class S3UploadService {
     );
 
     private final S3Client s3Client;
+    private final ImageResizeService imageResizeService;
 
     @Value("${app.aws.s3.region}")
     private String region;
@@ -37,33 +41,26 @@ public class S3UploadService {
     @Value("${app.aws.s3.public-base-url:}")
     private String publicBaseUrl;
 
-    @Value("${app.aws.s3.bread-photo-prefix:bread}")
+    @Value("${app.aws.s3.bread-photo-prefix:bread-photos}")
     private String breadPhotoPrefix;
 
     public String uploadBreadPhoto(UUID userId, MultipartFile photo) {
         validateS3Properties();
         validatePhoto(photo);
 
-        String key = createBreadPhotoKey(userId, photo);
-        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(key)
-                .contentType(photo.getContentType())
-                .contentLength(photo.getSize())
-                .build();
+        ProcessedBreadPhoto processedBreadPhoto = imageResizeService.processBreadPhoto(photo);
+        String imageId = UUID.randomUUID().toString();
+        String originalKey = createBreadPhotoKey(userId, imageId, processedBreadPhoto.getOriginal());
+        String thumbnailKey = createThumbnailKey(originalKey);
 
         try {
-            s3Client.putObject(
-                    putObjectRequest,
-                    RequestBody.fromInputStream(photo.getInputStream(), photo.getSize())
-            );
-        } catch (IOException exception) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 파일을 읽을 수 없습니다.", exception);
+            putObject(originalKey, processedBreadPhoto.getOriginal());
+            putObject(thumbnailKey, processedBreadPhoto.getThumbnail());
         } catch (S3Exception exception) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.", exception);
         }
 
-        return createPublicUrl(key);
+        return createPublicUrl(originalKey);
     }
 
     private void validateS3Properties() {
@@ -80,27 +77,47 @@ public class S3UploadService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "사진은 필수입니다.");
         }
 
+        if (photo.getSize() > MAX_PHOTO_SIZE_BYTES) {
+            throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE, "사진 크기는 10MB 이하여야 합니다.");
+        }
+
         if (!ALLOWED_CONTENT_TYPES.contains(photo.getContentType())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "사진은 JPEG, PNG, WebP 형식만 업로드할 수 있습니다.");
         }
     }
 
-    private String createBreadPhotoKey(UUID userId, MultipartFile photo) {
-        return "%s/%s/%s%s".formatted(
-                normalizePrefix(breadPhotoPrefix),
-                userId,
-                UUID.randomUUID(),
-                resolveExtension(photo.getContentType())
+    private void putObject(String key, ResizedImage image) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentLength((long) image.getBytes().length)
+                .build();
+
+        s3Client.putObject(
+                putObjectRequest,
+                RequestBody.fromBytes(image.getBytes())
         );
     }
 
-    private String resolveExtension(String contentType) {
-        return switch (contentType) {
-            case "image/jpeg" -> ".jpg";
-            case "image/png" -> ".png";
-            case "image/webp" -> ".webp";
-            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다.");
-        };
+    private String createBreadPhotoKey(UUID userId, String imageId, ResizedImage image) {
+        return "%s/%s/%s%s".formatted(
+                normalizePrefix(breadPhotoPrefix),
+                userId,
+                imageId,
+                image.getExtension()
+        );
+    }
+
+    private String createThumbnailKey(String originalKey) {
+        int extensionIndex = originalKey.lastIndexOf('.');
+        if (extensionIndex < 0) {
+            return originalKey + "_thumb";
+        }
+
+        return originalKey.substring(0, extensionIndex)
+                + "_thumb"
+                + originalKey.substring(extensionIndex);
     }
 
     private String createPublicUrl(String key) {
@@ -117,7 +134,7 @@ public class S3UploadService {
 
     private String normalizePrefix(String prefix) {
         if (!StringUtils.hasText(prefix)) {
-            return "bread";
+            return "bread-photos";
         }
         return removeTrailingSlash(prefix);
     }

--- a/src/test/java/com/bean/breaddiary/global/image/ImageResizeServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/global/image/ImageResizeServiceTest.java
@@ -1,0 +1,125 @@
+package com.bean.breaddiary.global.image;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImageResizeServiceTest {
+
+    private final ImageResizeService imageResizeService = new ImageResizeService();
+
+    @Test
+    void processBreadPhotoCreatesWebpOriginalAndThumbnail() throws IOException {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "bread.jpg",
+                "image/jpeg",
+                imageBytes("jpg", 1600, 900)
+        );
+
+        ProcessedBreadPhoto processedBreadPhoto = imageResizeService.processBreadPhoto(photo);
+
+        assertWebp(processedBreadPhoto.getOriginal());
+        assertWebp(processedBreadPhoto.getThumbnail());
+        assertMaxLongSide(processedBreadPhoto.getOriginal(), 1200);
+        assertMaxLongSide(processedBreadPhoto.getThumbnail(), 400);
+    }
+
+    @Test
+    void processBreadPhotoAcceptsPngImage() throws IOException {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "bread.png",
+                "image/png",
+                imageBytes("png", 900, 1600)
+        );
+
+        ProcessedBreadPhoto processedBreadPhoto = imageResizeService.processBreadPhoto(photo);
+
+        assertWebp(processedBreadPhoto.getOriginal());
+        assertWebp(processedBreadPhoto.getThumbnail());
+        assertMaxLongSide(processedBreadPhoto.getOriginal(), 1200);
+        assertMaxLongSide(processedBreadPhoto.getThumbnail(), 400);
+    }
+
+    @Test
+    void processBreadPhotoAcceptsWebpImage() throws IOException {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "bread.webp",
+                "image/webp",
+                imageBytes("webp", 800, 600)
+        );
+
+        ProcessedBreadPhoto processedBreadPhoto = imageResizeService.processBreadPhoto(photo);
+
+        assertWebp(processedBreadPhoto.getOriginal());
+        assertWebp(processedBreadPhoto.getThumbnail());
+        assertMaxLongSide(processedBreadPhoto.getOriginal(), 1200);
+        assertMaxLongSide(processedBreadPhoto.getThumbnail(), 400);
+    }
+
+    @Test
+    void processBreadPhotoRejectsInvalidImageBytes() {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "invalid.jpg",
+                "image/jpeg",
+                "not-image".getBytes()
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> imageResizeService.processBreadPhoto(photo)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    private void assertWebp(ResizedImage image) {
+        assertEquals("image/webp", image.getContentType());
+        assertEquals(".webp", image.getExtension());
+        assertTrue(image.getBytes().length > 0);
+    }
+
+    private void assertMaxLongSide(ResizedImage image, int maxSize) throws IOException {
+        BufferedImage bufferedImage = ImageIO.read(new ByteArrayInputStream(image.getBytes()));
+
+        assertNotNull(bufferedImage);
+        assertTrue(bufferedImage.getWidth() <= maxSize);
+        assertTrue(bufferedImage.getHeight() <= maxSize);
+    }
+
+    private byte[] imageBytes(String format, int width, int height) throws IOException {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setColor(Color.ORANGE);
+            graphics.fillRect(0, 0, width, height);
+            graphics.setColor(Color.DARK_GRAY);
+            graphics.fillOval(width / 4, height / 4, width / 2, height / 2);
+        } finally {
+            graphics.dispose();
+        }
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            boolean written = ImageIO.write(image, format, outputStream);
+            assertTrue(written);
+            return outputStream.toByteArray();
+        }
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/s3/S3UploadServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/global/s3/S3UploadServiceTest.java
@@ -1,0 +1,114 @@
+package com.bean.breaddiary.global.s3;
+
+import com.bean.breaddiary.global.image.ImageResizeService;
+import com.bean.breaddiary.global.image.ProcessedBreadPhoto;
+import com.bean.breaddiary.global.image.ResizedImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class S3UploadServiceTest {
+
+    private static final UUID USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+    private S3Client s3Client;
+    private ImageResizeService imageResizeService;
+    private S3UploadService s3UploadService;
+
+    @BeforeEach
+    void setUp() {
+        s3Client = mock(S3Client.class);
+        imageResizeService = mock(ImageResizeService.class);
+        s3UploadService = new S3UploadService(s3Client, imageResizeService);
+
+        ReflectionTestUtils.setField(s3UploadService, "region", "ap-northeast-2");
+        ReflectionTestUtils.setField(s3UploadService, "bucket", "breaddiary-bucket");
+        ReflectionTestUtils.setField(s3UploadService, "publicBaseUrl", "https://cdn.example.com");
+        ReflectionTestUtils.setField(s3UploadService, "breadPhotoPrefix", "bread-photos");
+    }
+
+    @Test
+    void uploadBreadPhotoUploadsOriginalAndThumbnailAndReturnsOriginalCloudFrontUrl() {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "bread.jpg",
+                "image/jpeg",
+                "photo".getBytes()
+        );
+        when(imageResizeService.processBreadPhoto(photo)).thenReturn(new ProcessedBreadPhoto(
+                new ResizedImage("original".getBytes(), "image/webp", ".webp"),
+                new ResizedImage("thumbnail".getBytes(), "image/webp", ".webp")
+        ));
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        String photoUrl = s3UploadService.uploadBreadPhoto(USER_ID, photo);
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client, org.mockito.Mockito.times(2)).putObject(requestCaptor.capture(), any(RequestBody.class));
+        List<PutObjectRequest> requests = requestCaptor.getAllValues();
+        String originalKey = requests.get(0).key();
+        String thumbnailKey = requests.get(1).key();
+
+        assertTrue(originalKey.matches("bread-photos/%s/[0-9a-f\\-]{36}\\.webp".formatted(USER_ID)));
+        assertEquals(originalKey.replace(".webp", "_thumb.webp"), thumbnailKey);
+        assertEquals("image/webp", requests.get(0).contentType());
+        assertEquals("image/webp", requests.get(1).contentType());
+        assertEquals(8L, requests.get(0).contentLength());
+        assertEquals(9L, requests.get(1).contentLength());
+        assertEquals("https://cdn.example.com/" + originalKey, photoUrl);
+    }
+
+    @Test
+    void uploadBreadPhotoRejectsUnsupportedContentType() {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "bread.gif",
+                "image/gif",
+                "photo".getBytes()
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> s3UploadService.uploadBreadPhoto(USER_ID, photo)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    void uploadBreadPhotoRejectsOver10MbPhoto() {
+        MockMultipartFile photo = new MockMultipartFile(
+                "photo",
+                "large.jpg",
+                "image/jpeg",
+                new byte[10 * 1024 * 1024 + 1]
+        );
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> s3UploadService.uploadBreadPhoto(USER_ID, photo)
+        );
+
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, exception.getStatusCode());
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #79 

## 🛠️ 작업 내용
- s3 버킷을 `public`에서 `private`로 수정하였습니다.
  - CloudFront에서 서빙하도록 `application.properties` 설정을 수정했습니다.
- 이미지 업로드 시 리사이즈 하여 원본과 리사이즈 이미지를 s3에 저장하도록 수정했습니다.
  - 리사이즈는 `_thumbnail`을 subfix로 붙이면 `GET`할 수 있습니다.
- 빵 도감 미 수집 사진은 PO님 요청주셨던 `_placeholder`를 subfix 하도록 mapper를 수정했습니다.

## 📢 참고 및 특이사항
- 자아아알 됩니당

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인