### PR TITLE
feat: add MVP event collection endpoint

### DIFF
--- a/docs/event-collection-mvp.md
+++ b/docs/event-collection-mvp.md
@@ -1,0 +1,178 @@
+# Event Collection MVP
+
+## 1. 목적
+
+이 문서는 `POST /events` MVP 계약과 구현 범위를 정리한다.
+
+이번 MVP의 서버 역할은 이벤트를 받아 외부 analytics 도구로 best-effort 전달하는 수집 게이트웨이다. 서버는 이벤트 의미나 프론트 재전송 정책을 판단하지 않는다.
+
+## 2. 서버 인증 정책
+
+`POST /events`는 optional auth endpoint다.
+
+| 요청 상태 | 서버 동작 |
+| --- | --- |
+| Authorization header 없음 | 익명 이벤트로 허용 |
+| 유효한 Bearer access token 있음 | `userId`, `sessionId`를 request attribute 기준으로 연결 |
+| invalid/expired/refresh token 있음 | 기존 인증 정책대로 `401 UNAUTHORIZED` |
+
+서버는 invalid token 요청을 익명 이벤트로 자동 downgrade하지 않는다. 익명 fallback은 프론트가 Authorization header를 제거하고 다시 보내는 별도 요청으로 처리한다.
+
+## 3. 프론트 전송 정책
+
+프론트는 이벤트별 전송 정책을 가진다.
+
+| 정책 | 설명 |
+| --- | --- |
+| 익명 허용 | Authorization 없이도 바로 전송 가능 |
+| 인증 우선 | Authorization으로 먼저 전송, `401`이면 refresh 후 1회 재시도 |
+| 드롭 | 인증 실패 시 익명으로 보내지 않고 버림 |
+
+`auth_toss_succeeded`, `logout_clicked`, `bread_record_create_succeeded`는 서버 인증 필수 이벤트가 아니다. 프론트에서 인증 우선 이벤트로 취급한다.
+
+## 4. API 계약
+
+```http
+POST /events
+Content-Type: application/json
+Authorization: Bearer <ACCESS_TOKEN> optional
+```
+
+Request:
+
+```json
+{
+  "eventName": "screen_viewed",
+  "anonymousId": "client-generated-anonymous-id",
+  "occurredAt": "2026-04-22T12:00:00Z",
+  "properties": {
+    "screen": "home"
+  }
+}
+```
+
+Success:
+
+```http
+202 Accepted
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "accepted": true
+  }
+}
+```
+
+## 5. 식별자 규칙
+
+| 상태 | 규칙 |
+| --- | --- |
+| 인증 없음 | `anonymousId` 필수 |
+| 인증 성공 | `anonymousId` 선택 |
+| `userId`도 없고 `anonymousId`도 없음 | `400 VALIDATION_FAILED` |
+| 인증 성공 + `anonymousId` 있음 | 외부 전송 시 `user_id`, `device_id` 함께 사용 가능 |
+| 인증 성공 + `anonymousId` 없음 | 외부 전송 시 `user_id` 사용 |
+| 익명 이벤트 | 외부 전송 시 `device_id=anonymousId` 사용 |
+
+## 6. eventName allowlist
+
+`eventName`은 lower_snake_case이며 아래 값만 허용한다.
+
+- `app_opened`
+- `screen_viewed`
+- `auth_toss_started`
+- `auth_toss_succeeded`
+- `bread_catalog_viewed`
+- `bread_detail_viewed`
+- `bread_record_create_started`
+- `bread_record_create_succeeded`
+- `logout_clicked`
+
+allowlist에 없는 값은 `400 VALIDATION_FAILED`로 거부한다.
+
+## 7. properties 정책
+
+`properties`는 선택값이다. `null`이면 빈 map으로 처리한다.
+
+제한:
+
+- 최대 key 수: 30
+- key 최대 길이: 60
+- string value 최대 길이: 200
+- 허용 value type: string, number, boolean, null
+- 차단 value type: object, array, file/binary 계열
+
+민감 key가 포함되면 `400 VALIDATION_FAILED`로 거부한다.
+
+민감 key:
+
+- `password`
+- `token`
+- `refresh_token`
+- `access_token`
+- `authorization`
+- `cookie`
+- `email`
+- `phone`
+
+민감 key 실패 응답은 구체 key를 노출하지 않는다.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "이벤트 속성에 허용되지 않는 항목이 포함되어 있습니다."
+  }
+}
+```
+
+## 8. occurredAt 정책
+
+- `occurredAt`은 선택값이다.
+- 없으면 서버 수신 시각을 사용한다.
+- 있으면 ISO-8601 offset datetime으로 파싱한다.
+- 파싱 실패는 `400 VALIDATION_FAILED`다.
+
+## 9. Amplitude 전송 정책
+
+- `AMPLITUDE_API_KEY` 환경변수만 사용한다.
+- 이번 MVP에서 `application.yml`은 수정하지 않는다.
+- Amplitude endpoint는 코드 내부 상수로 둔다.
+- API key가 없으면 외부 호출 없이 `202 Accepted`를 반환한다.
+- Amplitude 4xx/5xx/네트워크 실패는 로그만 남기고 `202 Accepted`를 반환한다.
+
+로그에 남기는 값:
+
+- `eventName`
+- `requestId`
+- status
+- exceptionType
+
+로그에 남기지 않는 값:
+
+- properties
+- request body
+- response body 원문
+- API key
+- Authorization header
+- token류
+- email/phone 등 개인정보
+
+## 10. 이번 MVP 범위 밖
+
+- DB event table
+- Redis/Kafka
+- retry queue
+- batch 전송
+- event persistence
+- 관리자 UI
+- 이벤트 조회 API
+- 서버 내부 도메인 이벤트 자동 발행
+- bread/breadrecord 기존 로직 수정
+- Amplitude 외 provider 추상화
+- `application.yml` analytics 설정 추가
+- user agent/IP/device fingerprint 수집

--- a/src/main/java/com/bean/breaddiary/domain/event/client/AmplitudeEventClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/client/AmplitudeEventClient.java
@@ -1,0 +1,145 @@
+package com.bean.breaddiary.domain.event.client;
+
+import com.bean.breaddiary.domain.event.service.EventName;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class AmplitudeEventClient {
+
+    private static final String AMPLITUDE_ENDPOINT = "https://api2.amplitude.com/2/httpapi";
+
+    private final RestClient restClient;
+    private final String apiKey;
+
+    public AmplitudeEventClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${AMPLITUDE_API_KEY:}") String apiKey
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.apiKey = apiKey;
+    }
+
+    public void forward(
+            EventName eventName,
+            Map<String, Object> properties,
+            OffsetDateTime occurredAt,
+            String anonymousId,
+            UUID userId,
+            String requestId
+    ) {
+        long startNanos = System.nanoTime();
+
+        if (!StringUtils.hasText(apiKey)) {
+            log.info(
+                    "EVENT action=eventForward result=skipped requestId={} eventName={} status={} durationMs={}",
+                    requestId,
+                    eventName.value(),
+                    "missingApiKey",
+                    durationMs(startNanos)
+            );
+            return;
+        }
+
+        try {
+            restClient.post()
+                    .uri(AMPLITUDE_ENDPOINT)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new AmplitudeRequest(
+                            apiKey,
+                            List.of(new AmplitudeEvent(
+                                    eventName.value(),
+                                    userId == null ? null : userId.toString(),
+                                    anonymousId,
+                                    occurredAt.toInstant().toEpochMilli(),
+                                    properties
+                            ))
+                    ))
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info(
+                    "EVENT action=eventForward result=success requestId={} eventName={} status={} durationMs={}",
+                    requestId,
+                    eventName.value(),
+                    HttpStatus.OK.value(),
+                    durationMs(startNanos)
+            );
+        } catch (RestClientResponseException exception) {
+            logForwardFailure(eventName, requestId, exception.getStatusCode().value(), exception, startNanos);
+        } catch (RuntimeException exception) {
+            logForwardFailure(eventName, requestId, "unexpected", exception, startNanos);
+        }
+    }
+
+    private void logForwardFailure(
+            EventName eventName,
+            String requestId,
+            Object status,
+            RuntimeException exception,
+            long startNanos
+    ) {
+        int statusCode = status instanceof Integer value ? value : HttpStatus.INTERNAL_SERVER_ERROR.value();
+        if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            log.error(
+                    "EVENT action=eventForward result=fail requestId={} eventName={} status={} exceptionType={} durationMs={}",
+                    requestId,
+                    eventName.value(),
+                    status,
+                    exception.getClass().getSimpleName(),
+                    durationMs(startNanos)
+            );
+            return;
+        }
+
+        log.warn(
+                "EVENT action=eventForward result=fail requestId={} eventName={} status={} exceptionType={} durationMs={}",
+                requestId,
+                eventName.value(),
+                status,
+                exception.getClass().getSimpleName(),
+                durationMs(startNanos)
+        );
+    }
+
+    private long durationMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    private record AmplitudeRequest(
+            @JsonProperty("api_key")
+            String apiKey,
+            @JsonProperty("events")
+            List<AmplitudeEvent> events
+    ) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private record AmplitudeEvent(
+            @JsonProperty("event_type")
+            String eventType,
+            @JsonProperty("user_id")
+            String userId,
+            @JsonProperty("device_id")
+            String deviceId,
+            @JsonProperty("time")
+            long time,
+            @JsonProperty("event_properties")
+            Map<String, Object> eventProperties
+    ) {
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/event/controller/EventController.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/controller/EventController.java
@@ -1,0 +1,39 @@
+package com.bean.breaddiary.domain.event.controller;
+
+import com.bean.breaddiary.domain.event.dto.request.EventCollectRequest;
+import com.bean.breaddiary.domain.event.dto.response.EventCollectResponse;
+import com.bean.breaddiary.domain.event.service.EventCollectionService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventCollectionService eventCollectionService;
+
+    @PostMapping("/events")
+    public ResponseEntity<ApiResponse<EventCollectResponse>> collectEvent(
+            @Valid @RequestBody EventCollectRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        UUID userId = AuthRequestAttributes.getOptionalUserId(httpServletRequest);
+        UUID sessionId = AuthRequestAttributes.getOptionalSessionId(httpServletRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(eventCollectionService.collect(request, userId, sessionId)));
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/event/dto/request/EventCollectRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/dto/request/EventCollectRequest.java
@@ -1,0 +1,30 @@
+package com.bean.breaddiary.domain.event.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventCollectRequest {
+
+    @NotBlank(message = "eventName은 필수입니다.")
+    @JsonProperty("eventName")
+    private String eventName;
+
+    @JsonProperty("properties")
+    private Map<String, Object> properties;
+
+    @JsonProperty("occurredAt")
+    private String occurredAt;
+
+    @JsonProperty("anonymousId")
+    private String anonymousId;
+}

--- a/src/main/java/com/bean/breaddiary/domain/event/dto/response/EventCollectResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/dto/response/EventCollectResponse.java
@@ -1,0 +1,15 @@
+package com.bean.breaddiary.domain.event.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventCollectResponse {
+
+    @JsonProperty("accepted")
+    private boolean accepted;
+}

--- a/src/main/java/com/bean/breaddiary/domain/event/service/EventCollectionService.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/service/EventCollectionService.java
@@ -1,0 +1,88 @@
+package com.bean.breaddiary.domain.event.service;
+
+import com.bean.breaddiary.domain.event.client.AmplitudeEventClient;
+import com.bean.breaddiary.domain.event.dto.request.EventCollectRequest;
+import com.bean.breaddiary.domain.event.dto.response.EventCollectResponse;
+import com.bean.breaddiary.global.common.ValidationFailureException;
+import com.bean.breaddiary.global.logging.RequestLogContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventCollectionService {
+
+    private final EventPropertySanitizer eventPropertySanitizer;
+    private final AmplitudeEventClient amplitudeEventClient;
+
+    public EventCollectResponse collect(
+            EventCollectRequest request,
+            UUID userId,
+            UUID sessionId
+    ) {
+        EventName eventName = EventName.fromValue(request.getEventName());
+        String anonymousId = normalizeAnonymousId(request.getAnonymousId());
+        validateIdentity(userId, anonymousId);
+
+        Map<String, Object> properties = eventPropertySanitizer.sanitize(request.getProperties());
+        OffsetDateTime occurredAt = resolveOccurredAt(request.getOccurredAt());
+        String requestId = RequestLogContext.currentRequestIdOrDefault();
+
+        try {
+            amplitudeEventClient.forward(
+                    eventName,
+                    properties,
+                    occurredAt,
+                    anonymousId,
+                    userId,
+                    requestId
+            );
+        } catch (RuntimeException exception) {
+            log.error(
+                    "EVENT action=collect result=forwardFailure requestId={} eventName={} userId={} sessionId={} exceptionType={}",
+                    requestId,
+                    eventName.value(),
+                    valueOrDefault(userId),
+                    valueOrDefault(sessionId),
+                    exception.getClass().getSimpleName()
+            );
+        }
+
+        return new EventCollectResponse(true);
+    }
+
+    private void validateIdentity(UUID userId, String anonymousId) {
+        if (userId == null && !StringUtils.hasText(anonymousId)) {
+            throw new ValidationFailureException("anonymousId가 필요합니다.");
+        }
+    }
+
+    private String normalizeAnonymousId(String anonymousId) {
+        return StringUtils.hasText(anonymousId) ? anonymousId.trim() : null;
+    }
+
+    private OffsetDateTime resolveOccurredAt(String occurredAt) {
+        if (!StringUtils.hasText(occurredAt)) {
+            return OffsetDateTime.now(ZoneOffset.UTC);
+        }
+
+        try {
+            return OffsetDateTime.parse(occurredAt.trim());
+        } catch (DateTimeParseException exception) {
+            throw new ValidationFailureException("occurredAt 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private String valueOrDefault(Object value) {
+        return value == null ? "-" : value.toString();
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/event/service/EventName.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/service/EventName.java
@@ -1,0 +1,49 @@
+package com.bean.breaddiary.domain.event.service;
+
+import com.bean.breaddiary.global.common.ValidationFailureException;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+public enum EventName {
+
+    APP_OPENED("app_opened"),
+    SCREEN_VIEWED("screen_viewed"),
+    AUTH_TOSS_STARTED("auth_toss_started"),
+    AUTH_TOSS_SUCCEEDED("auth_toss_succeeded"),
+    BREAD_CATALOG_VIEWED("bread_catalog_viewed"),
+    BREAD_DETAIL_VIEWED("bread_detail_viewed"),
+    BREAD_RECORD_CREATE_STARTED("bread_record_create_started"),
+    BREAD_RECORD_CREATE_SUCCEEDED("bread_record_create_succeeded"),
+    LOGOUT_CLICKED("logout_clicked");
+
+    private static final Pattern LOWER_SNAKE_CASE = Pattern.compile("^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$");
+    private static final String INVALID_EVENT_NAME_MESSAGE = "허용되지 않는 이벤트 이름입니다.";
+
+    private final String value;
+
+    EventName(String value) {
+        this.value = value;
+    }
+
+    public static EventName fromValue(String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new ValidationFailureException("eventName은 필수입니다.");
+        }
+
+        String normalized = value.trim();
+        if (!LOWER_SNAKE_CASE.matcher(normalized).matches()) {
+            throw new ValidationFailureException(INVALID_EVENT_NAME_MESSAGE);
+        }
+
+        return Arrays.stream(values())
+                .filter(eventName -> eventName.value.equals(normalized))
+                .findFirst()
+                .orElseThrow(() -> new ValidationFailureException(INVALID_EVENT_NAME_MESSAGE));
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/event/service/EventPropertySanitizer.java
+++ b/src/main/java/com/bean/breaddiary/domain/event/service/EventPropertySanitizer.java
@@ -1,0 +1,83 @@
+package com.bean.breaddiary.domain.event.service;
+
+import com.bean.breaddiary.global.common.ValidationFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Component
+public class EventPropertySanitizer {
+
+    public static final String SENSITIVE_PROPERTY_MESSAGE = "이벤트 속성에 허용되지 않는 항목이 포함되어 있습니다.";
+
+    private static final int MAX_PROPERTY_COUNT = 30;
+    private static final int MAX_KEY_LENGTH = 60;
+    private static final int MAX_STRING_VALUE_LENGTH = 200;
+    private static final Pattern KEY_PATTERN = Pattern.compile("^[a-z][A-Za-z0-9_]*$");
+    private static final Set<String> SENSITIVE_KEY_PARTS = Set.of(
+            "password",
+            "token",
+            "refresh_token",
+            "access_token",
+            "authorization",
+            "cookie",
+            "email",
+            "phone"
+    );
+
+    public Map<String, Object> sanitize(Map<String, Object> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return Map.of();
+        }
+
+        if (properties.size() > MAX_PROPERTY_COUNT) {
+            throw new ValidationFailureException("이벤트 속성 개수가 허용 범위를 초과했습니다.");
+        }
+
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        properties.forEach((key, value) -> {
+            validateKey(key);
+            sanitized.put(key, sanitizeValue(value));
+        });
+
+        return Collections.unmodifiableMap(sanitized);
+    }
+
+    private void validateKey(String key) {
+        if (!StringUtils.hasText(key)
+                || key.length() > MAX_KEY_LENGTH
+                || !KEY_PATTERN.matcher(key).matches()) {
+            throw new ValidationFailureException("이벤트 속성 이름이 올바르지 않습니다.");
+        }
+
+        String normalizedKey = key.toLowerCase(Locale.ROOT);
+        boolean sensitive = SENSITIVE_KEY_PARTS.stream()
+                .anyMatch(normalizedKey::contains);
+
+        if (sensitive) {
+            throw new ValidationFailureException(SENSITIVE_PROPERTY_MESSAGE);
+        }
+    }
+
+    private Object sanitizeValue(Object value) {
+        if (value == null || value instanceof Boolean || value instanceof Number) {
+            return value;
+        }
+
+        if (value instanceof String stringValue) {
+            if (stringValue.length() > MAX_STRING_VALUE_LENGTH) {
+                throw new ValidationFailureException("이벤트 속성 값이 허용 길이를 초과했습니다.");
+            }
+
+            return stringValue;
+        }
+
+        throw new ValidationFailureException("이벤트 속성 값 형식이 올바르지 않습니다.");
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
@@ -70,6 +70,18 @@ public class GlobalExceptionHandler {
         return validationFailure(message, request, exception);
     }
 
+    @ExceptionHandler(ValidationFailureException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationFailureException(
+            ValidationFailureException exception,
+            HttpServletRequest request
+    ) {
+        return validationFailure(
+                resolveMessage(exception.getMessage(), DEFAULT_VALIDATION_MESSAGE),
+                request,
+                exception
+        );
+    }
+
     @ExceptionHandler({
             HttpMessageNotReadableException.class,
             MissingRequestHeaderException.class

--- a/src/main/java/com/bean/breaddiary/global/common/ValidationFailureException.java
+++ b/src/main/java/com/bean/breaddiary/global/common/ValidationFailureException.java
@@ -1,0 +1,8 @@
+package com.bean.breaddiary.global.common;
+
+public class ValidationFailureException extends RuntimeException {
+
+    public ValidationFailureException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
@@ -112,7 +112,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        return false;
+        return HTTP_POST.equalsIgnoreCase(method) && "/events".equals(requestUri);
     }
 
     private boolean hasAuthorizationHeader(HttpServletRequest request) {

--- a/src/test/java/com/bean/breaddiary/domain/event/client/AmplitudeEventClientTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/event/client/AmplitudeEventClientTest.java
@@ -1,0 +1,185 @@
+package com.bean.breaddiary.domain.event.client;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.bean.breaddiary.domain.event.service.EventName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+class AmplitudeEventClientTest {
+
+    private static final String AMPLITUDE_URL = "https://api2.amplitude.com/2/httpapi";
+
+    private MockRestServiceServer mockServer;
+    private Logger logger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        logger = (Logger) LoggerFactory.getLogger(AmplitudeEventClient.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
+    @Test
+    void forwardDoesNotCallAmplitudeWhenApiKeyIsMissing() {
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        AmplitudeEventClient amplitudeEventClient = new AmplitudeEventClient(restClientBuilder, "");
+
+        amplitudeEventClient.forward(
+                EventName.SCREEN_VIEWED,
+                Map.of("screen", "home"),
+                OffsetDateTime.parse("2026-04-22T12:00:00Z"),
+                "anon-123",
+                null,
+                "request-id"
+        );
+
+        mockServer.verify();
+        assertTrue(formattedLogs().contains("status=missingApiKey"));
+    }
+
+    @Test
+    void forwardSendsAuthenticatedEventWithUserIdAndDeviceId() {
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        AmplitudeEventClient amplitudeEventClient = new AmplitudeEventClient(restClientBuilder, "api-key");
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440100");
+
+        mockServer.expect(requestTo(AMPLITUDE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().json("""
+                        {
+                          "api_key": "api-key",
+                          "events": [
+                            {
+                              "event_type": "screen_viewed",
+                              "user_id": "550e8400-e29b-41d4-a716-446655440100",
+                              "device_id": "anon-123",
+                              "time": 1776859200000,
+                              "event_properties": {
+                                "screen": "home"
+                              }
+                            }
+                          ]
+                        }
+                        """))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{}"));
+
+        amplitudeEventClient.forward(
+                EventName.SCREEN_VIEWED,
+                Map.of("screen", "home"),
+                OffsetDateTime.parse("2026-04-22T12:00:00Z"),
+                "anon-123",
+                userId,
+                "request-id"
+        );
+
+        mockServer.verify();
+    }
+
+    @Test
+    void forwardSendsAnonymousEventWithDeviceId() {
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        AmplitudeEventClient amplitudeEventClient = new AmplitudeEventClient(restClientBuilder, "api-key");
+
+        mockServer.expect(requestTo(AMPLITUDE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().json("""
+                        {
+                          "api_key": "api-key",
+                          "events": [
+                            {
+                              "event_type": "app_opened",
+                              "device_id": "anon-123",
+                              "time": 1776859200000,
+                              "event_properties": {}
+                            }
+                          ]
+                        }
+                        """))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{}"));
+
+        amplitudeEventClient.forward(
+                EventName.APP_OPENED,
+                Map.of(),
+                OffsetDateTime.parse("2026-04-22T12:00:00Z"),
+                "anon-123",
+                null,
+                "request-id"
+        );
+
+        mockServer.verify();
+    }
+
+    @Test
+    void forwardDoesNotLogExternalResponseBodyWhenAmplitudeFails() {
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        AmplitudeEventClient amplitudeEventClient = new AmplitudeEventClient(restClientBuilder, "api-key");
+        String responseBody = "external-secret-response-body";
+
+        mockServer.expect(requestTo(AMPLITUDE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .body(responseBody));
+
+        amplitudeEventClient.forward(
+                EventName.SCREEN_VIEWED,
+                Map.of("screen", "home"),
+                OffsetDateTime.parse("2026-04-22T12:00:00Z"),
+                "anon-123",
+                null,
+                "request-id"
+        );
+
+        mockServer.verify();
+        String logs = formattedLogs();
+        assertTrue(logs.contains("action=eventForward"));
+        assertTrue(logs.contains("eventName=screen_viewed"));
+        assertTrue(logs.contains("status=500"));
+        assertTrue(logs.contains("exceptionType="));
+        assertFalse(logs.contains(responseBody));
+        assertTrue(listAppender.list.stream().allMatch(event -> event.getThrowableProxy() == null));
+    }
+
+    private String formattedLogs() {
+        return listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/event/controller/EventControllerTest.java
@@ -1,0 +1,132 @@
+package com.bean.breaddiary.domain.event.controller;
+
+import com.bean.breaddiary.domain.event.dto.request.EventCollectRequest;
+import com.bean.breaddiary.domain.event.dto.response.EventCollectResponse;
+import com.bean.breaddiary.domain.event.service.EventCollectionService;
+import com.bean.breaddiary.global.common.GlobalExceptionHandler;
+import com.bean.breaddiary.global.common.ValidationFailureException;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class EventControllerTest {
+
+    private EventCollectionService eventCollectionService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        eventCollectionService = mock(EventCollectionService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new EventController(eventCollectionService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
+                .build();
+    }
+
+    @Test
+    void collectEventReturnsAcceptedForAnonymousRequest() throws Exception {
+        when(eventCollectionService.collect(any(EventCollectRequest.class), isNull(), isNull()))
+                .thenReturn(new EventCollectResponse(true));
+
+        mockMvc.perform(post("/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventName": "screen_viewed",
+                                  "anonymousId": "anon-123",
+                                  "properties": {
+                                    "screen": "home"
+                                  }
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accepted").value(true));
+    }
+
+    @Test
+    void collectEventPassesAuthenticatedAttributesToService() throws Exception {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
+
+        when(eventCollectionService.collect(any(EventCollectRequest.class), any(UUID.class), any(UUID.class)))
+                .thenReturn(new EventCollectResponse(true));
+
+        mockMvc.perform(post("/events")
+                        .requestAttr(AuthRequestAttributes.USER_ID, userId)
+                        .requestAttr(AuthRequestAttributes.SESSION_ID, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventName": "logout_clicked"
+                                }
+                                """))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accepted").value(true));
+
+        ArgumentCaptor<EventCollectRequest> requestCaptor = ArgumentCaptor.forClass(EventCollectRequest.class);
+        verify(eventCollectionService).collect(requestCaptor.capture(), eq(userId), eq(sessionId));
+        assertEquals("logout_clicked", requestCaptor.getValue().getEventName());
+    }
+
+    @Test
+    void collectEventReturnsValidationFailedWhenServiceRejectsRequest() throws Exception {
+        when(eventCollectionService.collect(any(EventCollectRequest.class), isNull(), isNull()))
+                .thenThrow(new ValidationFailureException("anonymousId가 필요합니다."));
+
+        mockMvc.perform(post("/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventName": "screen_viewed"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.error.message").value("anonymousId가 필요합니다."));
+    }
+
+    @Test
+    void collectEventReturnsValidationFailedForBlankEventName() throws Exception {
+        mockMvc.perform(post("/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "eventName": "",
+                                  "anonymousId": "anon-123"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"));
+    }
+
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/event/service/EventCollectionServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/event/service/EventCollectionServiceTest.java
@@ -1,0 +1,148 @@
+package com.bean.breaddiary.domain.event.service;
+
+import com.bean.breaddiary.domain.event.client.AmplitudeEventClient;
+import com.bean.breaddiary.domain.event.dto.request.EventCollectRequest;
+import com.bean.breaddiary.domain.event.dto.response.EventCollectResponse;
+import com.bean.breaddiary.global.common.ValidationFailureException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class EventCollectionServiceTest {
+
+    private AmplitudeEventClient amplitudeEventClient;
+    private EventCollectionService eventCollectionService;
+
+    @BeforeEach
+    void setUp() {
+        amplitudeEventClient = mock(AmplitudeEventClient.class);
+        eventCollectionService = new EventCollectionService(
+                new EventPropertySanitizer(),
+                amplitudeEventClient
+        );
+    }
+
+    @Test
+    void collectRejectsAnonymousEventWithoutAnonymousId() {
+        EventCollectRequest request = new EventCollectRequest(
+                "screen_viewed",
+                Map.of("screen", "home"),
+                null,
+                null
+        );
+
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventCollectionService.collect(request, null, null)
+        );
+    }
+
+    @Test
+    void collectAllowsAuthenticatedEventWithoutAnonymousId() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440010");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440011");
+        EventCollectRequest request = new EventCollectRequest(
+                "logout_clicked",
+                null,
+                null,
+                null
+        );
+
+        eventCollectionService.collect(request, userId, sessionId);
+
+        verify(amplitudeEventClient).forward(
+                eq(EventName.LOGOUT_CLICKED),
+                eq(Map.of()),
+                any(OffsetDateTime.class),
+                eq(null),
+                eq(userId),
+                any(String.class)
+        );
+    }
+
+    @Test
+    void collectParsesOccurredAtAndSanitizesProperties() {
+        EventCollectRequest request = new EventCollectRequest(
+                "screen_viewed",
+                Map.of("screen", "home"),
+                "2026-04-22T12:00:00Z",
+                "anon-123"
+        );
+
+        eventCollectionService.collect(request, null, null);
+
+        ArgumentCaptor<OffsetDateTime> occurredAtCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(amplitudeEventClient).forward(
+                eq(EventName.SCREEN_VIEWED),
+                eq(Map.of("screen", "home")),
+                occurredAtCaptor.capture(),
+                eq("anon-123"),
+                eq(null),
+                any(String.class)
+        );
+        assertEquals(OffsetDateTime.parse("2026-04-22T12:00:00Z"), occurredAtCaptor.getValue());
+    }
+
+    @Test
+    void collectRejectsInvalidOccurredAt() {
+        EventCollectRequest request = new EventCollectRequest(
+                "screen_viewed",
+                null,
+                "invalid-date-time",
+                "anon-123"
+        );
+
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventCollectionService.collect(request, null, null)
+        );
+    }
+
+    @Test
+    void collectDoesNotPropagateAmplitudeFailure() {
+        EventCollectRequest request = new EventCollectRequest(
+                "screen_viewed",
+                Map.of("screen", "home"),
+                null,
+                "anon-123"
+        );
+
+        doThrow(new RuntimeException("external-secret-response-body"))
+                .when(amplitudeEventClient)
+                .forward(any(EventName.class), anyMap(), any(OffsetDateTime.class), any(), any(), any(String.class));
+
+        EventCollectResponse response = assertDoesNotThrow(() -> eventCollectionService.collect(request, null, null));
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void collectRejectsUnknownEventName() {
+        EventCollectRequest request = new EventCollectRequest(
+                "unknown_event",
+                null,
+                null,
+                "anon-123"
+        );
+
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventCollectionService.collect(request, null, null)
+        );
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/event/service/EventPropertySanitizerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/event/service/EventPropertySanitizerTest.java
@@ -1,0 +1,97 @@
+package com.bean.breaddiary.domain.event.service;
+
+import com.bean.breaddiary.global.common.ValidationFailureException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EventPropertySanitizerTest {
+
+    private EventPropertySanitizer eventPropertySanitizer;
+
+    @BeforeEach
+    void setUp() {
+        eventPropertySanitizer = new EventPropertySanitizer();
+    }
+
+    @Test
+    void sanitizeReturnsEmptyMapForNullProperties() {
+        assertEquals(Map.of(), eventPropertySanitizer.sanitize(null));
+    }
+
+    @Test
+    void sanitizeAllowsPrimitiveValuesAndNull() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("screen", "home");
+        properties.put("count", 1);
+        properties.put("enabled", true);
+        properties.put("emptyValue", null);
+
+        Map<String, Object> sanitized = eventPropertySanitizer.sanitize(properties);
+
+        assertEquals("home", sanitized.get("screen"));
+        assertEquals(1, sanitized.get("count"));
+        assertEquals(true, sanitized.get("enabled"));
+        assertEquals(null, sanitized.get("emptyValue"));
+    }
+
+    @Test
+    void sanitizeRejectsTooManyProperties() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        IntStream.rangeClosed(1, 31)
+                .forEach(index -> properties.put("key" + index, index));
+
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventPropertySanitizer.sanitize(properties)
+        );
+    }
+
+    @Test
+    void sanitizeRejectsTooLongKey() {
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventPropertySanitizer.sanitize(Map.of("a".repeat(61), "value"))
+        );
+    }
+
+    @Test
+    void sanitizeRejectsTooLongStringValue() {
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventPropertySanitizer.sanitize(Map.of("screen", "a".repeat(201)))
+        );
+    }
+
+    @Test
+    void sanitizeRejectsObjectAndArrayValues() {
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventPropertySanitizer.sanitize(Map.of("nested", Map.of("key", "value")))
+        );
+
+        assertThrows(
+                ValidationFailureException.class,
+                () -> eventPropertySanitizer.sanitize(Map.of("items", List.of("a", "b")))
+        );
+    }
+
+    @Test
+    void sanitizeRejectsSensitiveKeysWithoutExposingKeyInMessage() {
+        ValidationFailureException exception = assertThrows(
+                ValidationFailureException.class,
+                () -> eventPropertySanitizer.sanitize(Map.of("accessToken", "secret"))
+        );
+
+        assertEquals(EventPropertySanitizer.SENSITIVE_PROPERTY_MESSAGE, exception.getMessage());
+        assertFalse(exception.getMessage().contains("accessToken"));
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
@@ -61,6 +61,15 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
     }
 
+    @Test
+    void validationFailureExceptionReturnsValidationFailedCode() throws Exception {
+        mockMvc.perform(get("/validation-failure"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_FAILED"))
+                .andExpect(jsonPath("$.error.message").value("이벤트 속성에 허용되지 않는 항목이 포함되어 있습니다."));
+    }
+
     @RestController
     private static class TestController {
 
@@ -75,6 +84,11 @@ class GlobalExceptionHandlerTest {
 
         @PostMapping(value = "/json-only", consumes = MediaType.APPLICATION_JSON_VALUE)
         void jsonOnly(@RequestBody TestRequest request) {
+        }
+
+        @GetMapping("/validation-failure")
+        void validationFailure() {
+            throw new ValidationFailureException("이벤트 속성에 허용되지 않는 항목이 포함되어 있습니다.");
         }
     }
 

--- a/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
+++ b/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
@@ -130,6 +130,83 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void preHandleAllowsAnonymousRequestForOptionalEventsEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/events");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        assertEquals(null, request.getAttribute(AuthRequestAttributes.USER_ID));
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
+    void preHandleAuthenticatesBearerTokenForOptionalEventsEndpoint() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440040");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440041");
+        LocalDateTime now = LocalDateTime.now();
+        String accessToken = jwtTokenProvider.createAccessToken(
+                userId,
+                sessionId,
+                now,
+                now.plusDays(1)
+        );
+        UserSession userSession = UserSession.builder()
+                .id(sessionId)
+                .userId(userId)
+                .refreshTokenHash("hashed-refresh-token")
+                .currentJti("current-jti")
+                .refreshExpiresAt(now.plusDays(30))
+                .build();
+
+        when(userSessionService.findActiveSession(eq(sessionId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(userSession));
+
+        MockHttpServletRequest request = authorizedRequest("POST", "/events", accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        assertEquals(userId, request.getAttribute(AuthRequestAttributes.USER_ID));
+        assertEquals(sessionId, request.getAttribute(AuthRequestAttributes.SESSION_ID));
+    }
+
+    @Test
+    void preHandleRejectsInvalidBearerTokenForOptionalEventsEndpoint() {
+        MockHttpServletRequest request = authorizedRequest("POST", "/events", "invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> authInterceptor.preHandle(request, response, handlerMethod)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
+    void preHandleRejectsRefreshTokenForOptionalEventsEndpoint() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440042");
+        UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440043");
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                userId,
+                sessionId,
+                "refresh-jti",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(30)
+        );
+
+        MockHttpServletRequest request = authorizedRequest("POST", "/events", refreshToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> authInterceptor.preHandle(request, response, handlerMethod)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
+
+    @Test
     void preHandleRejectsMissingBearerTokenForProtectedEndpoint() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/breads/550e8400-e29b-41d4-a716-446655440000");
         MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## 🧩 관련 이슈

- #78 

## 🛠️ 작업 내용

- MVP 수준의 이벤트 수집 기능을 추가했습니다.
- `POST /events` 엔드포인트를 구현하고, 익명 사용자와 로그인 사용자를 모두 처리할 수 있도록 optional auth 방식으로 반영했습니다.
- 이벤트 수집 요청/응답 DTO를 추가하고 camelCase 규칙을 유지하도록 구성했습니다.
- `ApiResponse` 기반으로 `202 Accepted` 응답을 반환하도록 구현했습니다.
- 이벤트 수집 서비스에서 이벤트 스키마 검증, 메타데이터 조립, 민감정보 필터링을 처리하도록 반영했습니다.
- 외부 분석 도구 전송용 client를 추가하고, best-effort 방식으로 외부 전송을 수행하도록 구현했습니다.
- 외부 전송 실패가 로그인, 기록 저장 등 기존 핵심 기능 흐름을 막지 않도록 예외를 전파하지 않고 로그만 남기도록 처리했습니다.
- `AuthInterceptor`에 `POST /events` optional auth 정책을 반영했습니다.
- 이벤트 수집 관련 최소 설정값을 추가했습니다.
- 이벤트 수집 API와 실패 정책, 환경값을 정리하는 문서를 추가 또는 갱신했습니다.
- controller / service / external client / interceptor 테스트를 추가해 핵심 정책을 검증했습니다.

## 📢 참고 및 특이사항

- 이번 구현은 MVP 범위에 맞춰 단순한 구조로 구성했습니다.
- Redis / Kafka / DB event table / retry queue / batch 전송 / 관리자 UI 같은 무거운 구조는 도입하지 않았습니다.
- 백엔드는 이벤트를 받아 외부 분석 도구로 전달하는 역할만 수행하고, 이벤트 전송 실패가 본 기능을 막지 않도록 했습니다.
- 인증은 optional auth 기준으로 처리했습니다.
  - Authorization header 없음: 익명 이벤트 허용
  - 유효한 Bearer token 있음: userId 연계
  - 잘못된 Bearer token 있음: 기존 정책대로 `401`
- `eventName`은 allowlist 기반으로 관리하고, `properties`는 flat object만 허용하도록 제한했습니다.
- request body, token, secret, 민감정보는 로그에 남기지 않도록 처리했습니다.
- bread / breadrecord 핵심 기능 로직에는 직접 이벤트 호출을 삽입하지 않았습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#78`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인