### PR TITLE
feat: add auth rate limit MVP

### DIFF
--- a/docs/auth-rate-limit-mvp.md
+++ b/docs/auth-rate-limit-mvp.md
@@ -1,0 +1,102 @@
+# Auth Rate Limit MVP
+
+## 목적
+
+auth 관련 public endpoint에 대해 단일 서버 MVP 수준의 abuse 1차 방어를 추가한다.
+
+이번 범위는 in-memory fixed window 방식이다. Redis, DB 저장, 분산 카운터, sliding window, token bucket은 사용하지 않는다.
+
+## 적용 대상
+
+| Endpoint | Method | 제한 | Window | 기준 |
+| --- | --- | ---: | ---: | --- |
+| `/auth/toss` | `POST` | 10회 | 60초 | IP |
+| `/auth/refresh` | `POST` | 60회 | 60초 | IP |
+| `/auth/webhook/toss-unlink` | `POST` | 60회 | 60초 | IP |
+
+`/auth/logout`, `/events`, bread/breadrecord/upload/s3 endpoint는 이번 MVP rate limit 대상이 아니다.
+
+## 식별 기준
+
+이번 MVP는 `request.getRemoteAddr()`를 그대로 사용한다.
+
+프록시 또는 로드밸런서 뒤에서 실제 client IP가 필요해지면 `RateLimitInterceptor`의 IP 추출 helper를 변경한다. 이번 브랜치에서는 `X-Forwarded-For` 처리를 적용하지 않는다.
+
+## 저장 방식
+
+- `ConcurrentHashMap` 기반 in-memory 저장소를 사용한다.
+- key는 `RateLimitPolicy + identifier` 조합이다.
+- bucket은 `windowStartMillis`, `count`만 가진다.
+- 요청 처리 시 `compute(...)`로 count 증가와 초과 판단을 원자적으로 처리한다.
+- 오래된 bucket은 요청 처리 중 opportunistic cleanup으로 제거한다.
+
+서버 재시작 시 rate limit 상태는 초기화된다. 단일 서버 MVP 기준으로 의도한 동작이다.
+
+## 응답 정책
+
+제한을 초과하면 다음 응답을 반환한다.
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: <seconds>
+```
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "RATE_LIMITED",
+    "message": "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+  }
+}
+```
+
+`Retry-After`는 현재 fixed window가 다시 열릴 때까지 남은 초 단위 값이다.
+
+## 실패 정책
+
+rate limit 초과는 `429 RATE_LIMITED`로 막는다.
+
+rate limiter 내부 계산 오류 또는 예기치 못한 런타임 오류는 fail-open으로 처리한다. 즉, ERROR 로그만 남기고 원 요청은 통과시킨다. rate limit 장애가 로그인/refresh/webhook 기본 흐름을 막지 않기 위한 MVP 정책이다.
+
+## 로그 정책
+
+초과 시 WARN 로그를 남긴다.
+
+- `action=authRateLimit`
+- `result=blocked`
+- `requestId`
+- `endpoint`
+- `identifier`
+- `limit`
+- `windowSeconds`
+- `retryAfterSeconds`
+
+내부 오류 시 ERROR 로그를 남긴다.
+
+- `action=authRateLimit`
+- `result=error`
+- `requestId`
+- `endpoint`
+- `exceptionType`
+
+로그에 남기지 않는 값:
+
+- `Authorization` header
+- access token
+- refresh token
+- Toss authorization code
+- `x-toss-webhook-secret`
+- request body / response body
+- header 전체 dump
+- query string 전체
+
+## 범위 제외
+
+- Redis, DB, Kafka, queue
+- 분산 환경 대응
+- sliding window, token bucket
+- sessionId/userId/token claim 기반 제한
+- `application.yml`, `application-local.yml` 설정 추가
+- Swagger 대규모 수정
+- 운영 관리자 UI

--- a/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.global.common;
 
 import com.bean.breaddiary.global.logging.RequestLogContext;
+import com.bean.breaddiary.global.ratelimit.RateLimitExceededException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class GlobalExceptionHandler {
 
     private static final String DEFAULT_VALIDATION_MESSAGE = "요청 값이 올바르지 않습니다.";
+    private static final String RATE_LIMITED_MESSAGE = "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.";
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ApiErrorResponse> handleResponseStatusException(
@@ -80,6 +82,27 @@ public class GlobalExceptionHandler {
                 request,
                 exception
         );
+    }
+
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ApiErrorResponse> handleRateLimitExceededException(
+            RateLimitExceededException exception,
+            HttpServletRequest request
+    ) {
+        log.warn(
+                "Request failed: code={} method={} path={} requestId={} retryAfterSeconds={} exceptionType={}",
+                "RATE_LIMITED",
+                request.getMethod(),
+                request.getRequestURI(),
+                RequestLogContext.currentRequestIdOrDefault(),
+                exception.getRetryAfterSeconds(),
+                exception.getClass().getSimpleName()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", String.valueOf(exception.getRetryAfterSeconds()))
+                .body(ApiErrorResponse.failure("RATE_LIMITED", RATE_LIMITED_MESSAGE));
     }
 
     @ExceptionHandler({

--- a/src/main/java/com/bean/breaddiary/global/config/WebConfig.java
+++ b/src/main/java/com/bean/breaddiary/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.bean.breaddiary.global.config;
 
 import com.bean.breaddiary.global.interceptor.AuthInterceptor;
 import com.bean.breaddiary.global.logging.RequestLogContext;
+import com.bean.breaddiary.global.ratelimit.RateLimitInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
+    private final RateLimitInterceptor rateLimitInterceptor;
     private final AuthInterceptor authInterceptor;
 
     @Value("${app.cors.allowed-origins:http://localhost:3000,http://localhost:5173,http://localhost:8081,https://bread-diary.app}")
@@ -21,8 +23,13 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/**")
+                .order(0);
+
         registry.addInterceptor(authInterceptor)
-                .addPathPatterns("/**");
+                .addPathPatterns("/**")
+                .order(1);
     }
 
     @Override

--- a/src/main/java/com/bean/breaddiary/global/ratelimit/InMemoryRateLimiter.java
+++ b/src/main/java/com/bean/breaddiary/global/ratelimit/InMemoryRateLimiter.java
@@ -1,0 +1,107 @@
+package com.bean.breaddiary.global.ratelimit;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Component
+public class InMemoryRateLimiter {
+
+    private static final long CLEANUP_INTERVAL_MILLIS = 60_000L;
+
+    private final Map<RateLimitKey, Bucket> buckets = new ConcurrentHashMap<>();
+    private final Clock clock;
+    private volatile long lastCleanupMillis;
+
+    public InMemoryRateLimiter() {
+        this(Clock.systemUTC());
+    }
+
+    InMemoryRateLimiter(Clock clock) {
+        this.clock = clock;
+    }
+
+    public RateLimitResult consume(RateLimitPolicy policy, String identifier) {
+        long nowMillis = clock.millis();
+        cleanupExpiredBuckets(nowMillis);
+
+        RateLimitKey key = new RateLimitKey(policy, identifier);
+        AtomicReference<RateLimitResult> result = new AtomicReference<>();
+
+        buckets.compute(key, (ignored, bucket) -> {
+            if (bucket == null || isExpired(bucket, policy, nowMillis)) {
+                result.set(RateLimitResult.allowedResult());
+                return new Bucket(nowMillis, 1);
+            }
+
+            if (bucket.count() < policy.limit()) {
+                result.set(RateLimitResult.allowedResult());
+                return new Bucket(bucket.windowStartMillis(), bucket.count() + 1);
+            }
+
+            result.set(RateLimitResult.blockedResult(retryAfterSeconds(bucket, policy, nowMillis)));
+            return bucket;
+        });
+
+        return result.get();
+    }
+
+    private void cleanupExpiredBuckets(long nowMillis) {
+        if (nowMillis - lastCleanupMillis < CLEANUP_INTERVAL_MILLIS) {
+            return;
+        }
+
+        lastCleanupMillis = nowMillis;
+        long maxWindowMillis = maxWindowMillis();
+        buckets.entrySet()
+                .removeIf(entry -> nowMillis - entry.getValue().windowStartMillis() > maxWindowMillis * 2);
+    }
+
+    private long maxWindowMillis() {
+        long maxWindowMillis = 0;
+        for (RateLimitPolicy policy : RateLimitPolicy.values()) {
+            maxWindowMillis = Math.max(maxWindowMillis, policy.window().toMillis());
+        }
+        return maxWindowMillis;
+    }
+
+    private boolean isExpired(Bucket bucket, RateLimitPolicy policy, long nowMillis) {
+        return nowMillis - bucket.windowStartMillis() >= policy.window().toMillis();
+    }
+
+    private long retryAfterSeconds(Bucket bucket, RateLimitPolicy policy, long nowMillis) {
+        long elapsedMillis = nowMillis - bucket.windowStartMillis();
+        long remainingMillis = Math.max(0, policy.window().toMillis() - elapsedMillis);
+
+        return Math.max(1, (long) Math.ceil(remainingMillis / 1000.0));
+    }
+
+    public record RateLimitResult(
+            boolean allowed,
+            long retryAfterSeconds
+    ) {
+
+        private static RateLimitResult allowedResult() {
+            return new RateLimitResult(true, 0);
+        }
+
+        private static RateLimitResult blockedResult(long retryAfterSeconds) {
+            return new RateLimitResult(false, retryAfterSeconds);
+        }
+    }
+
+    private record RateLimitKey(
+            RateLimitPolicy policy,
+            String identifier
+    ) {
+    }
+
+    private record Bucket(
+            long windowStartMillis,
+            int count
+    ) {
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/ratelimit/RateLimitExceededException.java
+++ b/src/main/java/com/bean/breaddiary/global/ratelimit/RateLimitExceededException.java
@@ -1,0 +1,21 @@
+package com.bean.breaddiary.global.ratelimit;
+
+public class RateLimitExceededException extends RuntimeException {
+
+    private final RateLimitPolicy policy;
+    private final long retryAfterSeconds;
+
+    public RateLimitExceededException(RateLimitPolicy policy, long retryAfterSeconds) {
+        super("요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
+        this.policy = policy;
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public RateLimitPolicy getPolicy() {
+        return policy;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,64 @@
+package com.bean.breaddiary.global.ratelimit;
+
+import com.bean.breaddiary.global.logging.RequestLogContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private static final String DEFAULT_IDENTIFIER = "-";
+
+    private final InMemoryRateLimiter rateLimiter;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        return RateLimitPolicy.find(request.getMethod(), request.getRequestURI())
+                .map(policy -> checkRateLimit(policy, request))
+                .orElse(true);
+    }
+
+    private boolean checkRateLimit(RateLimitPolicy policy, HttpServletRequest request) {
+        String identifier = resolveIdentifier(request);
+
+        try {
+            InMemoryRateLimiter.RateLimitResult result = rateLimiter.consume(policy, identifier);
+            if (result.allowed()) {
+                return true;
+            }
+
+            log.warn(
+                    "AUTH action=authRateLimit result=blocked requestId={} endpoint={} identifier={} limit={} windowSeconds={} retryAfterSeconds={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    policy.path(),
+                    identifier,
+                    policy.limit(),
+                    policy.windowSeconds(),
+                    result.retryAfterSeconds()
+            );
+            throw new RateLimitExceededException(policy, result.retryAfterSeconds());
+        } catch (RateLimitExceededException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            log.error(
+                    "AUTH action=authRateLimit result=error requestId={} endpoint={} exceptionType={}",
+                    RequestLogContext.currentRequestIdOrDefault(),
+                    policy.path(),
+                    exception.getClass().getSimpleName()
+            );
+            return true;
+        }
+    }
+
+    private String resolveIdentifier(HttpServletRequest request) {
+        String remoteAddr = request.getRemoteAddr();
+        return StringUtils.hasText(remoteAddr) ? remoteAddr : DEFAULT_IDENTIFIER;
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/ratelimit/RateLimitPolicy.java
+++ b/src/main/java/com/bean/breaddiary/global/ratelimit/RateLimitPolicy.java
@@ -1,0 +1,51 @@
+package com.bean.breaddiary.global.ratelimit;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum RateLimitPolicy {
+
+    AUTH_TOSS("POST", "/auth/toss", 10, Duration.ofSeconds(60)),
+    AUTH_REFRESH("POST", "/auth/refresh", 60, Duration.ofSeconds(60)),
+    AUTH_TOSS_WEBHOOK("POST", "/auth/webhook/toss-unlink", 60, Duration.ofSeconds(60));
+
+    private final String method;
+    private final String path;
+    private final int limit;
+    private final Duration window;
+
+    RateLimitPolicy(String method, String path, int limit, Duration window) {
+        this.method = method;
+        this.path = path;
+        this.limit = limit;
+        this.window = window;
+    }
+
+    public static Optional<RateLimitPolicy> find(String method, String path) {
+        return Arrays.stream(values())
+                .filter(policy -> policy.method.equalsIgnoreCase(method))
+                .filter(policy -> policy.path.equals(path))
+                .findFirst();
+    }
+
+    public String method() {
+        return method;
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public int limit() {
+        return limit;
+    }
+
+    public Duration window() {
+        return window;
+    }
+
+    public long windowSeconds() {
+        return window.toSeconds();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
@@ -1,5 +1,7 @@
 package com.bean.breaddiary.global.common;
 
+import com.bean.breaddiary.global.ratelimit.RateLimitExceededException;
+import com.bean.breaddiary.global.ratelimit.RateLimitPolicy;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +18,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -70,6 +73,16 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.error.message").value("이벤트 속성에 허용되지 않는 항목이 포함되어 있습니다."));
     }
 
+    @Test
+    void rateLimitExceededExceptionReturnsRateLimitedCodeAndRetryAfterHeader() throws Exception {
+        mockMvc.perform(get("/rate-limited"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().string("Retry-After", "30"))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("RATE_LIMITED"))
+                .andExpect(jsonPath("$.error.message").value("요청이 너무 많습니다. 잠시 후 다시 시도해주세요."));
+    }
+
     @RestController
     private static class TestController {
 
@@ -89,6 +102,11 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/validation-failure")
         void validationFailure() {
             throw new ValidationFailureException("이벤트 속성에 허용되지 않는 항목이 포함되어 있습니다.");
+        }
+
+        @GetMapping("/rate-limited")
+        void rateLimited() {
+            throw new RateLimitExceededException(RateLimitPolicy.AUTH_TOSS, 30);
         }
     }
 

--- a/src/test/java/com/bean/breaddiary/global/ratelimit/InMemoryRateLimiterTest.java
+++ b/src/test/java/com/bean/breaddiary/global/ratelimit/InMemoryRateLimiterTest.java
@@ -1,0 +1,119 @@
+package com.bean.breaddiary.global.ratelimit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InMemoryRateLimiterTest {
+
+    private MutableClock clock;
+    private InMemoryRateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(Instant.parse("2026-04-22T00:00:00Z"));
+        rateLimiter = new InMemoryRateLimiter(clock);
+    }
+
+    @Test
+    void consumeAllowsRequestsWithinLimit() {
+        for (int i = 0; i < RateLimitPolicy.AUTH_TOSS.limit(); i++) {
+            InMemoryRateLimiter.RateLimitResult result = rateLimiter.consume(
+                    RateLimitPolicy.AUTH_TOSS,
+                    "127.0.0.1"
+            );
+
+            assertTrue(result.allowed());
+        }
+    }
+
+    @Test
+    void consumeBlocksRequestOverLimit() {
+        for (int i = 0; i < RateLimitPolicy.AUTH_TOSS.limit(); i++) {
+            rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1");
+        }
+
+        InMemoryRateLimiter.RateLimitResult result = rateLimiter.consume(
+                RateLimitPolicy.AUTH_TOSS,
+                "127.0.0.1"
+        );
+
+        assertFalse(result.allowed());
+        assertEquals(60, result.retryAfterSeconds());
+    }
+
+    @Test
+    void consumeAllowsAgainAfterWindowExpires() {
+        for (int i = 0; i < RateLimitPolicy.AUTH_TOSS.limit(); i++) {
+            rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1");
+        }
+        assertFalse(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1").allowed());
+
+        clock.advance(Duration.ofSeconds(60));
+
+        assertTrue(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1").allowed());
+    }
+
+    @Test
+    void consumeSeparatesBucketsByEndpoint() {
+        for (int i = 0; i < RateLimitPolicy.AUTH_TOSS.limit(); i++) {
+            rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1");
+        }
+        assertFalse(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1").allowed());
+
+        assertTrue(rateLimiter.consume(RateLimitPolicy.AUTH_REFRESH, "127.0.0.1").allowed());
+    }
+
+    @Test
+    void consumeSeparatesBucketsByIdentifier() {
+        for (int i = 0; i < RateLimitPolicy.AUTH_TOSS.limit(); i++) {
+            rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1");
+        }
+        assertFalse(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1").allowed());
+
+        assertTrue(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.2").allowed());
+    }
+
+    @Test
+    void authRefreshPolicyUsesSixtyRequestsPerSixtySeconds() {
+        assertEquals(60, RateLimitPolicy.AUTH_REFRESH.limit());
+        assertEquals(60, RateLimitPolicy.AUTH_REFRESH.windowSeconds());
+    }
+
+    private static class MutableClock extends Clock {
+
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/ratelimit/RateLimitInterceptorTest.java
+++ b/src/test/java/com/bean/breaddiary/global/ratelimit/RateLimitInterceptorTest.java
@@ -1,0 +1,103 @@
+package com.bean.breaddiary.global.ratelimit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RateLimitInterceptorTest {
+
+    private InMemoryRateLimiter rateLimiter;
+    private RateLimitInterceptor rateLimitInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = mock(InMemoryRateLimiter.class);
+        rateLimitInterceptor = new RateLimitInterceptor(rateLimiter);
+    }
+
+    @Test
+    void preHandleBlocksTossLoginWhenLimitExceeded() {
+        when(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "127.0.0.1"))
+                .thenReturn(new InMemoryRateLimiter.RateLimitResult(false, 30));
+
+        RateLimitExceededException exception = assertThrows(
+                RateLimitExceededException.class,
+                () -> rateLimitInterceptor.preHandle(request("POST", "/auth/toss"), new MockHttpServletResponse(), new Object())
+        );
+
+        assertEquals(RateLimitPolicy.AUTH_TOSS, exception.getPolicy());
+        assertEquals(30, exception.getRetryAfterSeconds());
+    }
+
+    @Test
+    void preHandleBlocksRefreshWhenLimitExceeded() {
+        when(rateLimiter.consume(RateLimitPolicy.AUTH_REFRESH, "127.0.0.1"))
+                .thenReturn(new InMemoryRateLimiter.RateLimitResult(false, 20));
+
+        RateLimitExceededException exception = assertThrows(
+                RateLimitExceededException.class,
+                () -> rateLimitInterceptor.preHandle(request("POST", "/auth/refresh"), new MockHttpServletResponse(), new Object())
+        );
+
+        assertEquals(RateLimitPolicy.AUTH_REFRESH, exception.getPolicy());
+        assertEquals(20, exception.getRetryAfterSeconds());
+    }
+
+    @Test
+    void preHandleBlocksTossWebhookWhenLimitExceeded() {
+        when(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS_WEBHOOK, "127.0.0.1"))
+                .thenReturn(new InMemoryRateLimiter.RateLimitResult(false, 10));
+
+        RateLimitExceededException exception = assertThrows(
+                RateLimitExceededException.class,
+                () -> rateLimitInterceptor.preHandle(request("POST", "/auth/webhook/toss-unlink"), new MockHttpServletResponse(), new Object())
+        );
+
+        assertEquals(RateLimitPolicy.AUTH_TOSS_WEBHOOK, exception.getPolicy());
+        assertEquals(10, exception.getRetryAfterSeconds());
+    }
+
+    @Test
+    void preHandleAllowsTargetEndpointWithinLimitAndUsesRemoteAddrIdentifier() {
+        when(rateLimiter.consume(RateLimitPolicy.AUTH_TOSS, "203.0.113.10"))
+                .thenReturn(new InMemoryRateLimiter.RateLimitResult(true, 0));
+
+        MockHttpServletRequest request = request("POST", "/auth/toss");
+        request.setRemoteAddr("203.0.113.10");
+
+        assertTrue(rateLimitInterceptor.preHandle(request, new MockHttpServletResponse(), new Object()));
+        verify(rateLimiter).consume(RateLimitPolicy.AUTH_TOSS, "203.0.113.10");
+    }
+
+    @Test
+    void preHandleSkipsNonTargetEndpoint() {
+        assertTrue(rateLimitInterceptor.preHandle(request("POST", "/auth/logout"), new MockHttpServletResponse(), new Object()));
+
+        verify(rateLimiter, never()).consume(any(RateLimitPolicy.class), any(String.class));
+    }
+
+    @Test
+    void preHandleFailsOpenWhenLimiterThrowsUnexpectedException() {
+        when(rateLimiter.consume(eq(RateLimitPolicy.AUTH_TOSS), any(String.class)))
+                .thenThrow(new IllegalStateException("internal limiter failure"));
+
+        assertTrue(rateLimitInterceptor.preHandle(request("POST", "/auth/toss"), new MockHttpServletResponse(), new Object()));
+    }
+
+    private MockHttpServletRequest request(String method, String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setRemoteAddr("127.0.0.1");
+        return request;
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #82

## 🛠️ 작업 내용

- auth 관련 주요 endpoint에 대해 MVP 수준의 in-memory fixed window rate limit 을 추가했습니다.
- `global/ratelimit` 패키지를 추가하고 아래 구성 요소를 구현했습니다.
  - `RateLimitPolicy`
  - `InMemoryRateLimiter`
  - `RateLimitInterceptor`
  - `RateLimitExceededException`
- `RateLimitPolicy` 에서 endpoint 별 정책을 분리했습니다.
  - `POST /auth/toss` → `10회 / 60초`
  - `POST /auth/refresh` → `60회 / 60초`
  - `POST /auth/webhook/toss-unlink` → `60회 / 60초`
- `InMemoryRateLimiter` 는 `ConcurrentHashMap` 기반 fixed window 방식으로 구현했습니다.
- 식별자는 MVP 기준으로 `request.getRemoteAddr()` 기반 IP 를 사용하도록 반영했습니다.
- IP 추출은 `RateLimitInterceptor.resolveIdentifier(...)` private helper 로 분리해 이후 proxy 대응 가능성을 남겼습니다.
- `WebConfig` 에서 `RateLimitInterceptor` 를 `AuthInterceptor` 보다 먼저 등록하도록 수정했습니다.
- `GlobalExceptionHandler` 에 `RateLimitExceededException` 전용 handler 를 추가했습니다.
- rate limit 초과 시 `429 Too Many Requests`, `RATE_LIMITED`, `Retry-After` 헤더를 반환하도록 반영했습니다.
- `docs/auth-rate-limit-mvp.md` 문서를 추가해 정책, 응답, fail-open, 로그 금지, 범위 제외를 정리했습니다.
- 관련 테스트를 추가 및 보강했습니다.
  - `InMemoryRateLimiterTest`
  - `RateLimitInterceptorTest`
  - `GlobalExceptionHandlerTest`

## 📢 참고 및 특이사항

- 이번 작업은 이전 event PR 브랜치와 섞이지 않도록 `origin/develop` 기준 새 브랜치 `feat/79-auth-rate-limit` 에서 진행했습니다.
- limiter 내부 오류는 ERROR 로그 후 fail-open 하도록 구현해 본 인증 흐름을 막지 않도록 했습니다.
- 초과 시 WARN 로그를 남기되 민감정보는 로그에 포함하지 않도록 했습니다.
- `application.yml`, `application-local.yml` 변경은 없습니다.
- `bread`, `breadrecord`, `upload`, `s3` 관련 변경은 없습니다.
- 이번 MVP 범위에서는 Redis, DB, Kafka, queue, distributed counter, sliding window, token bucket, proxy/X-Forwarded-For 실제 적용은 제외했습니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#82)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인