### PR TITLE
feat: add Toss mTLS RestClient

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -33,14 +34,11 @@ public class TossAuthClient {
     private final String unlinkAccessToken;
 
     public TossAuthClient(
-            RestClient.Builder restClientBuilder,
+            @Qualifier("tossRestClient") RestClient restClient,
             ObjectMapper objectMapper,
-            @Value("${app.auth.toss.base-url:https://apps-in-toss-api.toss.im}") String baseUrl,
             @Value("${TOSS_UNLINK_ACCESS_TOKEN:${app.auth.toss.unlink-access-token:}}") String unlinkAccessToken
     ) {
-        this.restClient = restClientBuilder
-                .baseUrl(baseUrl)
-                .build();
+        this.restClient = restClient;
         this.objectMapper = objectMapper;
         this.unlinkAccessToken = unlinkAccessToken;
     }

--- a/src/main/java/com/bean/breaddiary/domain/auth/config/TossRestClientConfig.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/config/TossRestClientConfig.java
@@ -1,0 +1,100 @@
+package com.bean.breaddiary.domain.auth.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+
+@Configuration
+public class TossRestClientConfig {
+
+    private static final String PKCS12_KEY_STORE_TYPE = "PKCS12";
+
+    @Bean
+    @Qualifier("tossRestClient")
+    public RestClient tossRestClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${app.auth.toss.base-url:https://apps-in-toss-api.toss.im}") String baseUrl,
+            @Value("${app.auth.toss.mtls.key-store-path:}") String keyStorePath,
+            @Value("${app.auth.toss.mtls.key-store-password:}") String keyStorePassword
+    ) {
+        RestClient.Builder tossRestClientBuilder = restClientBuilder.baseUrl(baseUrl);
+        if (!isMtlsConfigured(keyStorePath, keyStorePassword)) {
+            return tossRestClientBuilder.build();
+        }
+
+        SSLContext sslContext = createMtlsSslContext(keyStorePath, keyStorePassword);
+        HttpClient httpClient = HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .build();
+
+        return tossRestClientBuilder
+                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .build();
+    }
+
+    private boolean isMtlsConfigured(String keyStorePath, String keyStorePassword) {
+        boolean hasPath = StringUtils.hasText(keyStorePath);
+        boolean hasPassword = StringUtils.hasText(keyStorePassword);
+        if (hasPath != hasPassword) {
+            throw new IllegalStateException(
+                    "토스 mTLS 설정은 key-store-path와 key-store-password를 함께 지정해야 합니다."
+            );
+        }
+
+        return hasPath;
+    }
+
+    private SSLContext createMtlsSslContext(String keyStorePath, String keyStorePassword) {
+        try {
+            char[] password = keyStorePassword.toCharArray();
+            KeyStore keyStore = loadKeyStore(keyStorePath, password);
+
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(
+                    KeyManagerFactory.getDefaultAlgorithm()
+            );
+            keyManagerFactory.init(keyStore, password);
+
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm()
+            );
+            trustManagerFactory.init((KeyStore) null);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(
+                    keyManagerFactory.getKeyManagers(),
+                    trustManagerFactory.getTrustManagers(),
+                    new SecureRandom()
+            );
+
+            return sslContext;
+        } catch (GeneralSecurityException | IOException exception) {
+            throw new IllegalStateException("토스 mTLS SSL 설정을 초기화할 수 없습니다.", exception);
+        }
+    }
+
+    private KeyStore loadKeyStore(String keyStorePath, char[] password)
+            throws GeneralSecurityException, IOException {
+        KeyStore keyStore = KeyStore.getInstance(PKCS12_KEY_STORE_TYPE);
+        try (InputStream inputStream = Files.newInputStream(Path.of(keyStorePath))) {
+            keyStore.load(inputStream, password);
+        }
+
+        return keyStore;
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/auth/client/TossAuthClientTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/client/TossAuthClientTest.java
@@ -41,9 +41,8 @@ class TossAuthClientTest {
         RestClient.Builder restClientBuilder = RestClient.builder();
         mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
         tossAuthClient = new TossAuthClient(
-                restClientBuilder,
+                restClientBuilder.baseUrl(BASE_URL).build(),
                 new ObjectMapper(),
-                BASE_URL,
                 "unlink-access-token"
         );
 

--- a/src/test/java/com/bean/breaddiary/domain/auth/config/TossRestClientConfigTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/config/TossRestClientConfigTest.java
@@ -1,0 +1,62 @@
+package com.bean.breaddiary.domain.auth.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TossRestClientConfigTest {
+
+    private final TossRestClientConfig tossRestClientConfig = new TossRestClientConfig();
+
+    @Test
+    void tossRestClientBuildsWithoutMtlsWhenKeyStoreIsMissing() {
+        assertDoesNotThrow(() -> tossRestClientConfig.tossRestClient(
+                RestClient.builder(),
+                "https://toss.example",
+                "",
+                ""
+        ));
+    }
+
+    @Test
+    void tossRestClientRejectsPartialMtlsConfiguration() {
+        assertThrows(IllegalStateException.class, () -> tossRestClientConfig.tossRestClient(
+                RestClient.builder(),
+                "https://toss.example",
+                "/tmp/toss-client.p12",
+                ""
+        ));
+    }
+
+    @Test
+    void tossRestClientBuildsWithPkcs12KeyStore() throws Exception {
+        String password = "changeit";
+        Path keyStorePath = createEmptyPkcs12KeyStore(password);
+
+        assertDoesNotThrow(() -> tossRestClientConfig.tossRestClient(
+                RestClient.builder(),
+                "https://toss.example",
+                keyStorePath.toString(),
+                password
+        ));
+    }
+
+    private Path createEmptyPkcs12KeyStore(String password) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, password.toCharArray());
+
+        Path keyStorePath = Files.createTempFile("toss-client-test-", ".p12");
+        try (OutputStream outputStream = Files.newOutputStream(keyStorePath)) {
+            keyStore.store(outputStream, password.toCharArray());
+        }
+
+        return keyStorePath;
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #84 

## 🛠️ 작업 내용
- PO님께 받은 mTLS 파일을 서버로 옮겼습니다.
- properties설정 변경했습니다.
- Toss 전용 RestClient를 사용하도록 변경했습니다.

## 📢 참고 및 특이사항
- 로그인 확인 다시 해봐야 할 것 같읍니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인