### PR TITLE
fix: parse Toss userKey as numeric value

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/client/TossAuthClient.java
@@ -2,7 +2,6 @@ package com.bean.breaddiary.domain.auth.client;
 
 import com.bean.breaddiary.global.logging.RequestLogContext;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -268,90 +267,67 @@ public class TossAuthClient {
     }
 
     private record TossGenerateTokenRequest(
-            @JsonProperty("authorizationCode")
             String authorizationCode,
-            @JsonProperty("referrer")
             String referrer
     ) {
     }
 
     private record TossUnlinkRequest(
-            @JsonProperty("userKey")
             String userKey
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossGenerateTokenResponse(
-            @JsonProperty("resultType")
             String resultType,
-            @JsonProperty("success")
             TossGenerateTokenSuccess success,
-            @JsonProperty("error")
             TossApiError error
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossGenerateTokenSuccess(
-            @JsonProperty("accessToken")
             String accessToken,
-            @JsonProperty("refreshToken")
             String refreshToken,
-            @JsonProperty("tokenType")
             String tokenType,
-            @JsonProperty("expiresIn")
             Long expiresIn,
-            @JsonProperty("scope")
             String scope
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossLoginMeResponse(
-            @JsonProperty("resultType")
             String resultType,
-            @JsonProperty("success")
             TossLoginMeSuccess success,
-            @JsonProperty("error")
             TossApiError error
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossLoginMeSuccess(
-            @JsonProperty("userKey")
-            JsonNode userKey,
-            @JsonProperty("name")
+            Long userKey,
             String name,
-            @JsonProperty("email")
             String email
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossUnlinkResponse(
-            @JsonProperty("resultType")
             String resultType,
-            @JsonProperty("success")
             JsonNode success,
-            @JsonProperty("error")
             TossApiError error
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static record TossApiError(
-            @JsonProperty("errorCode")
             String errorCode,
-            @JsonProperty("reason")
             String reason
     ) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record TossGrantError(
-            @JsonProperty("error")
             String error
     ) {
     }

--- a/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
@@ -269,7 +269,7 @@ public class AuthService {
 
     private ResolvedTossProfile resolveTossProfile(TossAuthClient.TossLoginMeSuccess tossUserInfo) {
         String tossUserKey = requireText(
-                tossUserInfo.userKey() == null ? null : tossUserInfo.userKey().asText(null),
+                tossUserInfo.userKey() == null ? null : String.valueOf(tossUserInfo.userKey()),
                 "토스 사용자 키가 없습니다."
         );
         String decryptedName = tossUserInfoDecryptor.decryptNullable(tossUserInfo.name());

--- a/src/test/java/com/bean/breaddiary/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/AuthServiceTest.java
@@ -86,7 +86,7 @@ class AuthServiceTest {
                 ));
         when(tossAuthClient.getUserInfo("toss-access-token"))
                 .thenReturn(new TossAuthClient.TossLoginMeSuccess(
-                        TextNode.valueOf("toss-user-key-12345678"),
+                        12345678L,
                         "encrypted-name",
                         "encrypted-email"
                 ));
@@ -94,7 +94,7 @@ class AuthServiceTest {
                 .thenReturn("Bread Lover");
         when(tossUserInfoDecryptor.decryptNullable("encrypted-email"))
                 .thenReturn("bread@toss.im");
-        when(userRepository.findByTossUserKey("toss-user-key-12345678"))
+        when(userRepository.findByTossUserKey("12345678"))
                 .thenReturn(Optional.empty());
         when(userRepository.findByEmail("bread@toss.im"))
                 .thenReturn(Optional.empty());
@@ -139,7 +139,7 @@ class AuthServiceTest {
 
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(userCaptor.capture());
-        assertEquals("toss-user-key-12345678", userCaptor.getValue().getTossUserKey());
+        assertEquals("12345678", userCaptor.getValue().getTossUserKey());
         assertEquals("Bread Lover", userCaptor.getValue().getNickname());
         assertEquals("bread@toss.im", userCaptor.getValue().getEmail());
 
@@ -221,14 +221,14 @@ class AuthServiceTest {
         LocalDateTime refreshTokenExpiresAt = LocalDateTime.of(2026, 5, 19, 10, 0);
         User deletedUser = User.builder()
                 .id(userId)
-                .tossUserKey("toss-user-key-87654321")
+                .tossUserKey("87654321")
                 .nickname("old-name")
                 .email("old@toss.im")
                 .deletedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
                 .build();
 
         prepareSuccessfulLogin(
-                "toss-user-key-87654321",
+                "87654321",
                 "Fresh Name",
                 "fresh@toss.im",
                 userId,
@@ -236,7 +236,7 @@ class AuthServiceTest {
                 accessTokenExpiresAt,
                 refreshTokenExpiresAt
         );
-        when(userRepository.findByTossUserKey("toss-user-key-87654321"))
+        when(userRepository.findByTossUserKey("87654321"))
                 .thenReturn(Optional.of(deletedUser));
 
         AuthTokenResponse actual = authService.loginWithToss(
@@ -263,7 +263,7 @@ class AuthServiceTest {
                 .build();
 
         prepareSuccessfulLogin(
-                "toss-user-key-99999999",
+                "99999999",
                 "legacy-user",
                 "legacy@toss.im",
                 userId,
@@ -271,7 +271,7 @@ class AuthServiceTest {
                 accessTokenExpiresAt,
                 refreshTokenExpiresAt
         );
-        when(userRepository.findByTossUserKey("toss-user-key-99999999"))
+        when(userRepository.findByTossUserKey("99999999"))
                 .thenReturn(Optional.empty());
         when(userRepository.findByEmail("legacy@toss.im"))
                 .thenReturn(Optional.of(existingUser));
@@ -281,7 +281,7 @@ class AuthServiceTest {
         );
 
         assertFalse(actual.isNewUser());
-        assertEquals("toss-user-key-99999999", existingUser.getTossUserKey());
+        assertEquals("99999999", existingUser.getTossUserKey());
         assertEquals("legacy@toss.im", existingUser.getEmail());
         verify(userRepository, never()).save(any(User.class));
     }
@@ -303,13 +303,13 @@ class AuthServiceTest {
                 ));
         when(tossAuthClient.getUserInfo("toss-access-token"))
                 .thenReturn(new TossAuthClient.TossLoginMeSuccess(
-                        TextNode.valueOf("toss-user-key-fallback"),
+                        98765432L,
                         "encrypted-name",
                         null
                 ));
         when(tossUserInfoDecryptor.decryptNullable("encrypted-name"))
                 .thenReturn(null);
-        when(userRepository.findByTossUserKey("toss-user-key-fallback"))
+        when(userRepository.findByTossUserKey("98765432"))
                 .thenReturn(Optional.empty());
         when(userRepository.save(any(User.class)))
                 .thenAnswer(invocation -> {
@@ -475,7 +475,7 @@ class AuthServiceTest {
                 ));
         when(tossAuthClient.getUserInfo("toss-access-token"))
                 .thenReturn(new TossAuthClient.TossLoginMeSuccess(
-                        TextNode.valueOf(tossUserKey),
+                        Long.valueOf(tossUserKey),
                         "encrypted-name",
                         "encrypted-email"
                 ));


### PR DESCRIPTION
## 🧩 관련 이슈

- #86 

## 🛠️ 작업 내용
- JsonNode 타입을 Long으로 수정해습니다.
- JsonProperty 에노테이션을 제거했습니다.

## 📢 참고 및 특이사항
- 프론트 분들께 노티 하겠습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인