### PR TITLE
feat: add today bread recommendation api

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -21,6 +21,8 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
 
     List<Bread> findAllByCreatedBy(UUID createdBy);
 
+    List<Bread> findAllByCreatedByIsNullOrderByStickerNumberAsc();
+
     boolean existsByName(String name);
 
     List<Bread> findByNameContainingIgnoreCaseOrderByStickerNumberAsc(String name, Pageable pageable);

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -67,6 +67,10 @@ public class BreadService {
         return breadMapper.mapToAutocompleteResponse(breads, eatCounts);
     }
 
+    public List<Bread> findAllSystemCatalogBreads() {
+        return breadRepository.findAllByCreatedByIsNullOrderByStickerNumberAsc();
+    }
+
     public List<Bread> findCatalogCandidates(String search, BreadType breadType) {
         return breadRepository.findCatalogCandidates(
                 normalizeSearch(search),

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> {
@@ -42,6 +43,31 @@ public interface BreadRecordRepository extends JpaRepository<BreadRecord, UUID> 
     List<BreadRecordCountProjection> countActiveRecordsByBreadIds(
             @Param("userId") UUID userId,
             @Param("breadIds") List<UUID> breadIds
+    );
+
+    @Query("""
+            select br.bread.id as breadId, count(br) as eatCount
+            from BreadRecord br
+            where br.deletedAt is null
+              and br.bread.id in :breadIds
+            group by br.bread.id
+            """)
+    List<BreadRecordCountProjection> countTotalActiveRecordsByBreadIds(
+            @Param("breadIds") List<UUID> breadIds
+    );
+
+    @Query("""
+            select br.bread.id as breadId, count(br) as eatCount
+            from BreadRecord br
+            where br.deletedAt is null
+              and br.bread.createdBy is null
+              and br.eatenDate between :startDate and :endDate
+            group by br.bread.id, br.bread.stickerNumber
+            order by count(br) desc, br.bread.stickerNumber asc
+            """)
+    List<BreadRecordCountProjection> countRecentActiveSystemRecordsByBread(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
     );
 
     @Query("""

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordService.java
@@ -67,6 +67,27 @@ public class BreadRecordService {
                 ));
     }
 
+    public Map<UUID, Long> countTotalActiveRecordsByBreadIds(List<UUID> breadIds) {
+        if (breadIds == null || breadIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return breadRecordRepository.countTotalActiveRecordsByBreadIds(breadIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        BreadRecordCountProjection::getBreadId,
+                        BreadRecordCountProjection::getEatCount
+                ));
+    }
+
+    public List<BreadRecordCountProjection> findRecentActiveSystemBreadCounts(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null || startDate.isAfter(endDate)) {
+            return List.of();
+        }
+
+        return breadRecordRepository.countRecentActiveSystemRecordsByBread(startDate, endDate);
+    }
+
     public Map<UUID, BreadRecordCatalogStats> findCatalogStatsByBreadIds(UUID userId, List<UUID> breadIds) {
         if (userId == null || breadIds == null || breadIds.isEmpty()) {
             return Collections.emptyMap();

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,57 @@
+package com.bean.breaddiary.domain.recommendation.controller;
+
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayResponse;
+import com.bean.breaddiary.domain.recommendation.service.RecommendationComplexService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "오늘의 추천 빵 API", description = "오늘 기록해볼 추천 빵을 조회하는 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/breads")
+public class RecommendationController {
+
+    private final RecommendationComplexService recommendationComplexService;
+
+    @Operation(
+            summary = "오늘의 추천 빵 조회",
+            description = "오늘의 추천 빵 5개를 조회합니다. Authorization 헤더가 있으면 현재 사용자 기준 수집 여부와 이미지 표현을 반영합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "오늘의 추천 빵 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BreadTodayResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Authorization 헤더가 잘못된 경우 인증에 실패합니다. Authorization 헤더가 없으면 비로그인 요청으로 처리됩니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "오늘의 추천 빵 목록을 생성하거나 조회하는 중 서버 오류가 발생했습니다."
+            )
+    })
+    @GetMapping("/today")
+    public ResponseEntity<ApiResponse<BreadTodayResponse>> getTodayRecommendations(
+            @Parameter(hidden = true) HttpServletRequest request
+    ) {
+        UUID userId = AuthRequestAttributes.getOptionalUserId(request);
+        BreadTodayResponse response = recommendationComplexService.getTodayRecommendations(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/dto/mapper/RecommendationMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/dto/mapper/RecommendationMapper.java
@@ -1,0 +1,80 @@
+package com.bean.breaddiary.domain.recommendation.dto.mapper;
+
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayItemResponse;
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayResponse;
+import com.bean.breaddiary.domain.recommendation.entity.DailyRecommendation;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface RecommendationMapper {
+
+    @Mapping(target = "id", source = "recommendation.bread.id")
+    @Mapping(target = "name", source = "recommendation.bread.name")
+    @Mapping(target = "type", source = "recommendation.bread.breadType.code")
+    @Mapping(target = "imageUrl", expression = "java(resolveImageUrl(recommendation.getBread().getImageUrl(), userEatCount))")
+    @Mapping(target = "totalRecordCount", expression = "java(resolveCount(totalRecordCount))")
+    @Mapping(target = "isCollected", expression = "java(isCollected(userEatCount))")
+    BreadTodayItemResponse mapToTodayItem(
+            DailyRecommendation recommendation,
+            Long totalRecordCount,
+            Long userEatCount
+    );
+
+    default BreadTodayResponse mapToTodayResponse(
+            LocalDate date,
+            List<DailyRecommendation> recommendations,
+            Map<UUID, Long> totalRecordCounts,
+            Map<UUID, Long> userEatCounts
+    ) {
+        List<BreadTodayItemResponse> breads = recommendations.stream()
+                .map(recommendation -> {
+                    UUID breadId = recommendation.getBread().getId();
+                    return mapToTodayItem(
+                            recommendation,
+                            totalRecordCounts.get(breadId),
+                            userEatCounts.get(breadId)
+                    );
+                })
+                .toList();
+
+        return new BreadTodayResponse(date, breads);
+    }
+
+    default boolean isCollected(Long eatCount) {
+        return resolveCount(eatCount) > 0;
+    }
+
+    default Long resolveCount(Long count) {
+        return count == null ? 0L : count;
+    }
+
+    default String resolveImageUrl(String imageUrl, Long userEatCount) {
+        if (isCollected(userEatCount)) {
+            return imageUrl;
+        }
+
+        return toPlaceholderUrl(imageUrl);
+    }
+
+    private String toPlaceholderUrl(String imageUrl) {
+        if (imageUrl == null) {
+            return null;
+        }
+
+        int extensionIndex = imageUrl.lastIndexOf('.');
+        if (extensionIndex < 0) {
+            return imageUrl + "_placeholder";
+        }
+
+        return imageUrl.substring(0, extensionIndex)
+                + "_placeholder"
+                + imageUrl.substring(extensionIndex);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/dto/response/BreadTodayItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/dto/response/BreadTodayItemResponse.java
@@ -1,0 +1,35 @@
+package com.bean.breaddiary.domain.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "오늘의 추천 빵 아이템")
+public class BreadTodayItemResponse {
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    private UUID id;
+
+    @Schema(description = "빵 이름", example = "소금빵")
+    private String name;
+
+    @Schema(description = "빵 종류", example = "PASTRY")
+    private String type;
+
+    @Schema(description = "카탈로그 이미지 URL", example = "https://cdn.bread-diary.app/breads/salt-bread.webp")
+    private String imageUrl;
+
+    @Schema(description = "전체 활성 기록 수", example = "128")
+    private Long totalRecordCount;
+
+    @Schema(description = "현재 유저 수집 여부", example = "false")
+    private Boolean isCollected;
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/dto/response/BreadTodayResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/dto/response/BreadTodayResponse.java
@@ -1,0 +1,28 @@
+package com.bean.breaddiary.domain.recommendation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "오늘의 추천 빵 응답")
+public class BreadTodayResponse {
+
+    @Schema(description = "추천 날짜", example = "2026-04-26")
+    private LocalDate date;
+
+    @ArraySchema(
+            schema = @Schema(implementation = BreadTodayItemResponse.class),
+            arraySchema = @Schema(description = "오늘의 추천 빵 목록")
+    )
+    private List<BreadTodayItemResponse> breads;
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/entity/DailyRecommendation.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/entity/DailyRecommendation.java
@@ -1,0 +1,63 @@
+package com.bean.breaddiary.domain.recommendation.entity;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(
+        name = "daily_bread_recommendations",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_daily_bread_recommendations_date_order",
+                        columnNames = {"recommendation_date", "display_order"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_daily_bread_recommendations_date_bread",
+                        columnNames = {"recommendation_date", "bread_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_daily_bread_recommendations_date", columnList = "recommendation_date"),
+                @Index(name = "idx_daily_bread_recommendations_bread", columnList = "bread_id")
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyRecommendation {
+
+    @Id
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "recommendation_date", nullable = false)
+    private LocalDate recommendationDate;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "bread_id", nullable = false)
+    private Bread bread;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/repository/DailyRecommendationRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/repository/DailyRecommendationRepository.java
@@ -1,0 +1,27 @@
+package com.bean.breaddiary.domain.recommendation.repository;
+
+import com.bean.breaddiary.domain.recommendation.entity.DailyRecommendation;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface DailyRecommendationRepository extends JpaRepository<DailyRecommendation, UUID> {
+
+    @EntityGraph(attributePaths = {"bread", "bread.breadType"})
+    List<DailyRecommendation> findAllByRecommendationDateOrderByDisplayOrderAsc(LocalDate recommendationDate);
+
+    @Query("""
+            select distinct recommendation.bread.id
+            from DailyRecommendation recommendation
+            where recommendation.recommendationDate between :startDate and :endDate
+            """)
+    List<UUID> findDistinctBreadIdsByRecommendationDateBetween(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/service/RecommendationComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/service/RecommendationComplexService.java
@@ -1,0 +1,152 @@
+package com.bean.breaddiary.domain.recommendation.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.recommendation.dto.mapper.RecommendationMapper;
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayResponse;
+import com.bean.breaddiary.domain.recommendation.entity.DailyRecommendation;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
+import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationComplexService {
+
+    private static final int RECOMMENDATION_SIZE = 5;
+    private static final int MAX_PER_TYPE = 2;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final RecommendationService recommendationService;
+    private final RecommendationMapper recommendationMapper;
+    private final BreadService breadService;
+    private final BreadRecordService breadRecordService;
+
+    @Transactional
+    public BreadTodayResponse getTodayRecommendations(UUID userId) {
+        LocalDate recommendationDate = LocalDate.now(KST);
+        List<DailyRecommendation> recommendations = recommendationService.findRecommendationsByDate(recommendationDate);
+
+        if (recommendations.isEmpty()) {
+            recommendations = createTodayRecommendations(recommendationDate);
+        }
+
+        List<UUID> breadIds = recommendations.stream()
+                .map(recommendation -> recommendation.getBread().getId())
+                .toList();
+
+        Map<UUID, Long> totalRecordCounts = breadRecordService.countTotalActiveRecordsByBreadIds(breadIds);
+        Map<UUID, Long> userEatCounts = breadRecordService.countActiveRecordsByBreadIds(userId, breadIds);
+
+        return recommendationMapper.mapToTodayResponse(
+                recommendationDate,
+                recommendations,
+                totalRecordCounts,
+                userEatCounts
+        );
+    }
+
+    protected List<DailyRecommendation> createTodayRecommendations(LocalDate recommendationDate) {
+        List<Bread> systemBreads = breadService.findAllSystemCatalogBreads();
+        if (systemBreads.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, Bread> breadById = systemBreads.stream()
+                .collect(Collectors.toMap(Bread::getId, Function.identity()));
+
+        List<UUID> recentlyRecommendedBreadIds = recommendationService.findRecentlyRecommendedBreadIds(
+                recommendationDate.minusDays(3),
+                recommendationDate.minusDays(1)
+        );
+        Set<UUID> excludedBreadIds = new LinkedHashSet<>(recentlyRecommendedBreadIds);
+
+        List<BreadRecordCountProjection> recentCounts = breadRecordService.findRecentActiveSystemBreadCounts(
+                recommendationDate.minusDays(6),
+                recommendationDate
+        );
+
+        List<Bread> popularCandidates = recentCounts.stream()
+                .map(BreadRecordCountProjection::getBreadId)
+                .map(breadById::get)
+                .filter(Objects::nonNull)
+                .toList();
+
+        List<Bread> fallbackCandidates = createDeterministicFallbackCandidates(systemBreads, recommendationDate);
+        List<Bread> selected = selectRecommendations(popularCandidates, fallbackCandidates, excludedBreadIds);
+
+        return recommendationService.saveRecommendations(recommendationDate, selected);
+    }
+
+    private List<Bread> selectRecommendations(
+            List<Bread> popularCandidates,
+            List<Bread> fallbackCandidates,
+            Set<UUID> excludedBreadIds
+    ) {
+        List<Bread> selected = new ArrayList<>();
+
+        addCandidates(selected, popularCandidates, excludedBreadIds, true);
+        addCandidates(selected, fallbackCandidates, excludedBreadIds, true);
+        addCandidates(selected, popularCandidates, Collections.emptySet(), true);
+        addCandidates(selected, fallbackCandidates, Collections.emptySet(), true);
+        addCandidates(selected, fallbackCandidates, Collections.emptySet(), false);
+
+        return selected.stream()
+                .limit(RECOMMENDATION_SIZE)
+                .toList();
+    }
+
+    private void addCandidates(
+            List<Bread> selected,
+            List<Bread> candidates,
+            Set<UUID> excludedBreadIds,
+            boolean enforceTypeLimit
+    ) {
+        for (Bread candidate : candidates) {
+            if (selected.size() >= RECOMMENDATION_SIZE) {
+                return;
+            }
+
+            UUID breadId = candidate.getId();
+            if (excludedBreadIds.contains(breadId)) {
+                continue;
+            }
+
+            if (containsBread(selected, breadId)) {
+                continue;
+            }
+
+            if (enforceTypeLimit && countType(selected, candidate.getBreadType().getCode()) >= MAX_PER_TYPE) {
+                continue;
+            }
+
+            selected.add(candidate);
+        }
+    }
+
+    private List<Bread> createDeterministicFallbackCandidates(List<Bread> breads, LocalDate recommendationDate) {
+        List<Bread> fallbackCandidates = new ArrayList<>(breads);
+        fallbackCandidates.sort(Comparator.comparing(Bread::getStickerNumber).thenComparing(Bread::getId));
+        Collections.shuffle(fallbackCandidates, new Random(recommendationDate.toEpochDay()));
+        return fallbackCandidates;
+    }
+
+    private boolean containsBread(List<Bread> selected, UUID breadId) {
+        return selected.stream().anyMatch(bread -> bread.getId().equals(breadId));
+    }
+
+    private long countType(List<Bread> selected, String breadTypeCode) {
+        return selected.stream()
+                .filter(bread -> bread.getBreadType().getCode().equals(breadTypeCode))
+                .count();
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/service/RecommendationService.java
@@ -1,0 +1,48 @@
+package com.bean.breaddiary.domain.recommendation.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.recommendation.entity.DailyRecommendation;
+import com.bean.breaddiary.domain.recommendation.repository.DailyRecommendationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationService {
+
+    private final DailyRecommendationRepository dailyRecommendationRepository;
+
+    public List<DailyRecommendation> findRecommendationsByDate(LocalDate recommendationDate) {
+        return dailyRecommendationRepository.findAllByRecommendationDateOrderByDisplayOrderAsc(recommendationDate);
+    }
+
+    public List<UUID> findRecentlyRecommendedBreadIds(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null || startDate.isAfter(endDate)) {
+            return List.of();
+        }
+
+        return dailyRecommendationRepository.findDistinctBreadIdsByRecommendationDateBetween(startDate, endDate);
+    }
+
+    @Transactional
+    public List<DailyRecommendation> saveRecommendations(LocalDate recommendationDate, List<Bread> breads) {
+        List<DailyRecommendation> recommendations = IntStream.range(0, breads.size())
+                .mapToObj(index -> DailyRecommendation.builder()
+                        .recommendationDate(recommendationDate)
+                        .bread(breads.get(index))
+                        .displayOrder(index + 1)
+                        .build())
+                .toList();
+
+        return dailyRecommendationRepository.saveAll(recommendations).stream()
+                .sorted((left, right) -> Integer.compare(left.getDisplayOrder(), right.getDisplayOrder()))
+                .toList();
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
@@ -107,6 +107,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         if (HTTP_GET.equalsIgnoreCase(method)
                 && ("/breads".equals(requestUri)
+                || "/breads/today".equals(requestUri)
                 || "/breads/autocomplete".equals(requestUri)
                 || PATH_MATCHER.match("/breads/catalog/*", requestUri))) {
             return true;

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepositoryTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/repository/BreadRecordRepositoryTest.java
@@ -2,6 +2,7 @@ package com.bean.breaddiary.domain.breadrecord.repository;
 
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadtype.entity.BreadType;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.UserStatsProjection;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
 import jakarta.persistence.EntityManager;
@@ -12,11 +13,13 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import static com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest(properties = {
         "spring.jpa.hibernate.ddl-auto=create-drop",
@@ -43,12 +46,12 @@ class BreadRecordRepositoryTest {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
         Bread bread = saveBread();
 
-        saveBreadRecord(userId, bread, "shop-a", 5, null);
-        saveBreadRecord(userId, bread, "   ", 4, null);
-        saveBreadRecord(userId, bread, "", 3, null);
-        saveBreadRecord(userId, bread, null, 2, null);
-        saveBreadRecord(userId, bread, "shop-b", 1, null);
-        saveBreadRecord(userId, bread, "shop-a", 5, null);
+        saveBreadRecord(userId, bread, "shop-a", 5, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, bread, "   ", 4, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, bread, "", 3, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, bread, null, 2, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, bread, "shop-b", 1, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, bread, "shop-a", 5, LocalDate.of(2026, 4, 18), null);
 
         UserStatsProjection stats = breadRecordRepository.findUserStatsByUserId(userId);
 
@@ -64,8 +67,8 @@ class BreadRecordRepositoryTest {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
         Bread bread = saveBread();
 
-        saveBreadRecord(userId, bread, "shop-live", 5, null);
-        saveBreadRecord(userId, bread, "shop-deleted", 1, LocalDateTime.of(2026, 4, 18, 12, 0));
+        saveBreadRecord(userId, bread, "shop-live", 5, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, bread, "shop-deleted", 1, LocalDate.of(2026, 4, 18), LocalDateTime.of(2026, 4, 18, 12, 0));
 
         UserStatsProjection stats = breadRecordRepository.findUserStatsByUserId(userId);
 
@@ -84,11 +87,11 @@ class BreadRecordRepositoryTest {
         Bread thirdBread = saveBread(3);
         Bread deletedOnlyBread = saveBread(4);
 
-        saveBreadRecord(userId, firstBread, "shop-a", 5, null);
-        saveBreadRecord(userId, firstBread, "shop-a", 4, null);
-        saveBreadRecord(userId, secondBread, "shop-b", 3, null);
-        saveBreadRecord(userId, thirdBread, "shop-c", 2, null);
-        saveBreadRecord(userId, deletedOnlyBread, "shop-d", 1, LocalDateTime.of(2026, 4, 18, 12, 0));
+        saveBreadRecord(userId, firstBread, "shop-a", 5, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, firstBread, "shop-a", 4, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, secondBread, "shop-b", 3, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, thirdBread, "shop-c", 2, LocalDate.of(2026, 4, 18), null);
+        saveBreadRecord(userId, deletedOnlyBread, "shop-d", 1, LocalDate.of(2026, 4, 18), LocalDateTime.of(2026, 4, 18, 12, 0));
 
         UserStatsProjection stats = breadRecordRepository.findUserStatsByUserId(userId);
 
@@ -97,6 +100,50 @@ class BreadRecordRepositoryTest {
         assertEquals(3L, stats.getTotalStickers());
         assertEquals(3L, stats.getUniqueShops());
         assertEquals(3.5, stats.getAvgRating());
+    }
+
+    @Test
+    void countRecentActiveSystemRecordsByBreadUsesEatenDateAndIgnoresDeletedAndUserCreatedBread() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440010");
+        Bread countedBread = saveBread(10);
+        Bread oldBread = saveBread(11);
+        Bread deletedBread = saveBread(12);
+        Bread userCreatedBread = saveUserCreatedBread(13);
+
+        saveBreadRecord(userId, countedBread, "shop-a", 5, LocalDate.of(2026, 4, 23), null);
+        saveBreadRecord(userId, countedBread, "shop-b", 4, LocalDate.of(2026, 4, 25), null);
+        saveBreadRecord(userId, oldBread, "shop-c", 3, LocalDate.of(2026, 4, 10), null);
+        saveBreadRecord(userId, deletedBread, "shop-d", 2, LocalDate.of(2026, 4, 24), LocalDateTime.of(2026, 4, 24, 12, 0));
+        saveBreadRecord(userId, userCreatedBread, "shop-e", 1, LocalDate.of(2026, 4, 24), null);
+
+        List<BreadRecordCountProjection> counts = breadRecordRepository.countRecentActiveSystemRecordsByBread(
+                LocalDate.of(2026, 4, 20),
+                LocalDate.of(2026, 4, 26)
+        );
+
+        assertEquals(1, counts.size());
+        assertEquals(countedBread.getId(), counts.get(0).getBreadId());
+        assertEquals(2L, counts.get(0).getEatCount());
+    }
+
+    @Test
+    void countTotalActiveRecordsByBreadIdsIgnoresSoftDeletedRecords() {
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440011");
+        Bread countedBread = saveBread(20);
+        Bread zeroBread = saveBread(21);
+
+        saveBreadRecord(userId, countedBread, "shop-a", 5, LocalDate.of(2026, 4, 20), null);
+        saveBreadRecord(userId, countedBread, "shop-b", 4, LocalDate.of(2026, 4, 21), null);
+        saveBreadRecord(userId, countedBread, "shop-c", 3, LocalDate.of(2026, 4, 22), LocalDateTime.of(2026, 4, 22, 12, 0));
+
+        List<BreadRecordCountProjection> counts = breadRecordRepository.countTotalActiveRecordsByBreadIds(
+                List.of(countedBread.getId(), zeroBread.getId())
+        );
+
+        assertEquals(1, counts.size());
+        assertEquals(countedBread.getId(), counts.get(0).getBreadId());
+        assertEquals(2L, counts.get(0).getEatCount());
+        assertTrue(counts.stream().noneMatch(count -> count.getBreadId().equals(zeroBread.getId())));
     }
 
     private Bread saveBread() {
@@ -116,11 +163,26 @@ class BreadRecordRepositoryTest {
         return bread;
     }
 
+    private Bread saveUserCreatedBread(int stickerNumber) {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Bread bread = Bread.builder()
+                .stickerNumber(stickerNumber)
+                .name("user-bread-" + suffix)
+                .breadType(breadType)
+                .imageUrl("https://cdn.bread-diary.app/breads/test.webp")
+                .createdBy(UUID.fromString("550e8400-e29b-41d4-a716-446655440999"))
+                .build();
+
+        entityManager.persist(bread);
+        return bread;
+    }
+
     private void saveBreadRecord(
             UUID userId,
             Bread bread,
             String shopName,
             int rating,
+            LocalDate eatenDate,
             LocalDateTime deletedAt
     ) {
         BreadRecord breadRecord = BreadRecord.builder()
@@ -128,7 +190,7 @@ class BreadRecordRepositoryTest {
                 .bread(bread)
                 .photoUrl("https://cdn.bread-diary.app/bread-photos/test.webp")
                 .shopName(shopName)
-                .eatenDate(LocalDate.of(2026, 4, 18))
+                .eatenDate(eatenDate)
                 .rating(rating)
                 .review("test")
                 .deletedAt(deletedAt)

--- a/src/test/java/com/bean/breaddiary/domain/recommendation/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/recommendation/controller/RecommendationControllerTest.java
@@ -1,0 +1,94 @@
+package com.bean.breaddiary.domain.recommendation.controller;
+
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayItemResponse;
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayResponse;
+import com.bean.breaddiary.domain.recommendation.service.RecommendationComplexService;
+import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RecommendationControllerTest {
+
+    private RecommendationComplexService recommendationComplexService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        recommendationComplexService = mock(RecommendationComplexService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new RecommendationController(recommendationComplexService))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(camelCaseObjectMapper()))
+                .build();
+    }
+
+    @Test
+    void getTodayRecommendationsReturnsCamelCaseResponse() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        BreadTodayResponse response = new BreadTodayResponse(
+                LocalDate.of(2026, 4, 26),
+                List.of(new BreadTodayItemResponse(
+                        breadId,
+                        "소금빵",
+                        "PASTRY",
+                        "https://cdn.bread-diary.app/breads/salt_placeholder.webp",
+                        128L,
+                        false
+                ))
+        );
+
+        when(recommendationComplexService.getTodayRecommendations(userId)).thenReturn(response);
+
+        mockMvc.perform(get("/breads/today")
+                        .requestAttr(AuthRequestAttributes.USER_ID, userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.date").value("2026-04-26"))
+                .andExpect(jsonPath("$.data.breads[0].id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.breads[0].name").value("소금빵"))
+                .andExpect(jsonPath("$.data.breads[0].type").value("PASTRY"))
+                .andExpect(jsonPath("$.data.breads[0].imageUrl").value("https://cdn.bread-diary.app/breads/salt_placeholder.webp"))
+                .andExpect(jsonPath("$.data.breads[0].totalRecordCount").value(128))
+                .andExpect(jsonPath("$.data.breads[0].isCollected").value(false))
+                .andExpect(jsonPath("$.data.breads[0].image_url").doesNotExist())
+                .andExpect(jsonPath("$.data.breads[0].total_record_count").doesNotExist())
+                .andExpect(jsonPath("$.data.breads[0].is_collected").doesNotExist());
+
+        verify(recommendationComplexService).getTodayRecommendations(userId);
+    }
+
+    @Test
+    void getTodayRecommendationsAllowsAnonymousRequest() throws Exception {
+        when(recommendationComplexService.getTodayRecommendations(null))
+                .thenReturn(new BreadTodayResponse(LocalDate.of(2026, 4, 26), List.of()));
+
+        mockMvc.perform(get("/breads/today"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.breads").isArray());
+
+        verify(recommendationComplexService).getTodayRecommendations(null);
+    }
+
+    private JsonMapper camelCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/recommendation/repository/DailyRecommendationRepositoryTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/recommendation/repository/DailyRecommendationRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.bean.breaddiary.domain.recommendation.repository;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.recommendation.entity.DailyRecommendation;
+import com.bean.breaddiary.domain.breadtype.entity.BreadType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
+class DailyRecommendationRepositoryTest {
+
+    @Autowired
+    private DailyRecommendationRepository dailyRecommendationRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private BreadType breadType;
+
+    @BeforeEach
+    void setUp() {
+        breadType = BreadType.builder()
+                .code("PASTRY")
+                .name("페이스트리")
+                .build();
+        entityManager.persist(breadType);
+    }
+
+    @Test
+    void findAllByRecommendationDateOrderByDisplayOrderAscReturnsOrderedItems() {
+        LocalDate today = LocalDate.of(2026, 4, 26);
+        Bread secondBread = saveBread("두번째", 2);
+        Bread firstBread = saveBread("첫번째", 1);
+
+        saveRecommendation(today, secondBread, 2);
+        saveRecommendation(today, firstBread, 1);
+
+        List<DailyRecommendation> recommendations =
+                dailyRecommendationRepository.findAllByRecommendationDateOrderByDisplayOrderAsc(today);
+
+        assertEquals(2, recommendations.size());
+        assertEquals(firstBread.getId(), recommendations.get(0).getBread().getId());
+        assertEquals(secondBread.getId(), recommendations.get(1).getBread().getId());
+    }
+
+    @Test
+    void findDistinctBreadIdsByRecommendationDateBetweenReturnsRecentBreadIds() {
+        Bread firstBread = saveBread("소금빵", 1);
+        Bread secondBread = saveBread("크루아상", 2);
+        Bread thirdBread = saveBread("베이글", 3);
+
+        saveRecommendation(LocalDate.of(2026, 4, 24), firstBread, 1);
+        saveRecommendation(LocalDate.of(2026, 4, 25), secondBread, 1);
+        saveRecommendation(LocalDate.of(2026, 4, 26), thirdBread, 1);
+
+        List<UUID> breadIds = dailyRecommendationRepository.findDistinctBreadIdsByRecommendationDateBetween(
+                LocalDate.of(2026, 4, 24),
+                LocalDate.of(2026, 4, 25)
+        );
+
+        assertEquals(2, breadIds.size());
+        assertTrue(breadIds.contains(firstBread.getId()));
+        assertTrue(breadIds.contains(secondBread.getId()));
+    }
+
+    private Bread saveBread(String name, int stickerNumber) {
+        Bread bread = Bread.builder()
+                .stickerNumber(stickerNumber)
+                .name(name + "-" + UUID.randomUUID().toString().substring(0, 8))
+                .breadType(breadType)
+                .imageUrl("https://cdn.bread-diary.app/breads/test.webp")
+                .build();
+
+        entityManager.persist(bread);
+        return bread;
+    }
+
+    private void saveRecommendation(LocalDate date, Bread bread, int displayOrder) {
+        entityManager.persist(DailyRecommendation.builder()
+                .recommendationDate(date)
+                .bread(bread)
+                .displayOrder(displayOrder)
+                .build());
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/recommendation/service/RecommendationComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/recommendation/service/RecommendationComplexServiceTest.java
@@ -1,0 +1,177 @@
+package com.bean.breaddiary.domain.recommendation.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.recommendation.dto.mapper.RecommendationMapper;
+import com.bean.breaddiary.domain.recommendation.dto.response.BreadTodayResponse;
+import com.bean.breaddiary.domain.recommendation.entity.DailyRecommendation;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCountProjection;
+import com.bean.breaddiary.domain.breadrecord.service.BreadRecordService;
+import com.bean.breaddiary.domain.breadtype.entity.BreadType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+class RecommendationComplexServiceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private RecommendationService recommendationService;
+    private BreadService breadService;
+    private BreadRecordService breadRecordService;
+    private RecommendationComplexService recommendationComplexService;
+
+    @BeforeEach
+    void setUp() {
+        recommendationService = mock(RecommendationService.class);
+        breadService = mock(BreadService.class);
+        breadRecordService = mock(BreadRecordService.class);
+        RecommendationMapper recommendationMapper = Mappers.getMapper(RecommendationMapper.class);
+
+        recommendationComplexService = new RecommendationComplexService(
+                recommendationService,
+                recommendationMapper,
+                breadService,
+                breadRecordService
+        );
+    }
+
+    @Test
+    void getTodayRecommendationsReturnsStoredRecommendationsWithCollectedState() {
+        LocalDate today = LocalDate.now(KST);
+        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        Bread firstBread = bread("소금빵", "PASTRY", 1);
+        Bread secondBread = bread("베이글", "BREAD", 2);
+        List<DailyRecommendation> recommendations = List.of(
+                recommendation(today, firstBread, 1),
+                recommendation(today, secondBread, 2)
+        );
+
+        when(recommendationService.findRecommendationsByDate(today)).thenReturn(recommendations);
+        when(breadRecordService.countTotalActiveRecordsByBreadIds(List.of(firstBread.getId(), secondBread.getId())))
+                .thenReturn(Map.of(
+                        firstBread.getId(), 128L,
+                        secondBread.getId(), 64L
+                ));
+        when(breadRecordService.countActiveRecordsByBreadIds(userId, List.of(firstBread.getId(), secondBread.getId())))
+                .thenReturn(Map.of(firstBread.getId(), 3L));
+
+        BreadTodayResponse response = recommendationComplexService.getTodayRecommendations(userId);
+
+        assertEquals(today, response.getDate());
+        assertEquals(2, response.getBreads().size());
+        assertEquals("소금빵", response.getBreads().get(0).getName());
+        assertEquals("https://cdn.bread-diary.app/breads/1.webp", response.getBreads().get(0).getImageUrl());
+        assertTrue(response.getBreads().get(0).getIsCollected());
+        assertEquals(128L, response.getBreads().get(0).getTotalRecordCount());
+
+        assertEquals("베이글", response.getBreads().get(1).getName());
+        assertEquals("https://cdn.bread-diary.app/breads/2_placeholder.webp", response.getBreads().get(1).getImageUrl());
+        assertFalse(response.getBreads().get(1).getIsCollected());
+        assertEquals(64L, response.getBreads().get(1).getTotalRecordCount());
+
+        verifyNoInteractions(breadService);
+        verify(recommendationService, never()).saveRecommendations(any(), any());
+    }
+
+    @Test
+    void getTodayRecommendationsCreatesSharedRecommendationsWhenMissing() {
+        LocalDate today = LocalDate.now(KST);
+        Bread salty = bread("소금빵", "PASTRY", 1);
+        Bread croissant = bread("크루아상", "PASTRY", 2);
+        Bread baguette = bread("바게트", "BREAD", 3);
+        Bread bagel = bread("베이글", "BREAD", 4);
+        Bread donut = bread("도넛", "DONUT", 5);
+        Bread cake = bread("카스테라", "CAKE", 6);
+
+        List<Bread> systemBreads = List.of(salty, croissant, baguette, bagel, donut, cake);
+
+        when(recommendationService.findRecommendationsByDate(today)).thenReturn(List.of());
+        when(breadService.findAllSystemCatalogBreads()).thenReturn(systemBreads);
+        when(recommendationService.findRecentlyRecommendedBreadIds(today.minusDays(3), today.minusDays(1)))
+                .thenReturn(List.of(salty.getId()));
+        when(breadRecordService.findRecentActiveSystemBreadCounts(today.minusDays(6), today))
+                .thenReturn(List.of(
+                        countProjection(salty.getId(), 30L),
+                        countProjection(croissant.getId(), 20L),
+                        countProjection(baguette.getId(), 10L)
+                ));
+        when(recommendationService.saveRecommendations(eq(today), any()))
+                .thenAnswer(invocation -> {
+                    List<Bread> selected = invocation.getArgument(1);
+                    return List.of(
+                            recommendation(today, selected.get(0), 1),
+                            recommendation(today, selected.get(1), 2),
+                            recommendation(today, selected.get(2), 3),
+                            recommendation(today, selected.get(3), 4),
+                            recommendation(today, selected.get(4), 5)
+                    );
+                });
+        when(breadRecordService.countTotalActiveRecordsByBreadIds(any()))
+                .thenReturn(Map.of());
+        when(breadRecordService.countActiveRecordsByBreadIds(isNull(), any()))
+                .thenReturn(Map.of());
+
+        BreadTodayResponse response = recommendationComplexService.getTodayRecommendations(null);
+
+        assertEquals(today, response.getDate());
+        assertEquals(5, response.getBreads().size());
+        assertFalse(response.getBreads().stream().anyMatch(item -> item.getId().equals(salty.getId())));
+        assertTrue(response.getBreads().stream().anyMatch(item -> item.getId().equals(croissant.getId())));
+        assertTrue(response.getBreads().stream().anyMatch(item -> item.getId().equals(baguette.getId())));
+        assertEquals(2L, response.getBreads().stream()
+                .filter(item -> "PASTRY".equals(item.getType()))
+                .count());
+        assertTrue(response.getBreads().stream().allMatch(item -> !item.getIsCollected()));
+    }
+
+    private Bread bread(String name, String breadTypeCode, int stickerNumber) {
+        return Bread.builder()
+                .id(UUID.randomUUID())
+                .stickerNumber(stickerNumber)
+                .name(name)
+                .breadType(BreadType.builder()
+                        .id((long) stickerNumber)
+                        .code(breadTypeCode)
+                        .name(breadTypeCode)
+                        .build())
+                .imageUrl("https://cdn.bread-diary.app/breads/" + stickerNumber + ".webp")
+                .build();
+    }
+
+    private DailyRecommendation recommendation(LocalDate date, Bread bread, int order) {
+        return DailyRecommendation.builder()
+                .recommendationDate(date)
+                .bread(bread)
+                .displayOrder(order)
+                .build();
+    }
+
+    private BreadRecordCountProjection countProjection(UUID breadId, Long count) {
+        return new BreadRecordCountProjection() {
+            @Override
+            public UUID getBreadId() {
+                return breadId;
+            }
+
+            @Override
+            public Long getEatCount() {
+                return count;
+            }
+        };
+    }
+}

--- a/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
+++ b/src/test/java/com/bean/breaddiary/global/interceptor/AuthInterceptorTest.java
@@ -86,6 +86,16 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void preHandleAllowsAnonymousRequestForOptionalBreadTodayEndpoint() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/breads/today");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertTrue(authInterceptor.preHandle(request, response, handlerMethod));
+        assertEquals(null, request.getAttribute(AuthRequestAttributes.USER_ID));
+        verifyNoInteractions(userSessionService);
+    }
+
+    @Test
     void preHandleAuthenticatesBearerTokenForOptionalBreadCatalogEndpoint() {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440030");
         UUID sessionId = UUID.fromString("550e8400-e29b-41d4-a716-446655440031");


### PR DESCRIPTION
## 🧩 관련 이슈

- #90 

## 🛠️ 작업 내용

- GET /breads/today 오늘의 추천 빵 API를 추가했습니다.
- 추천 기능은 domain/recommendation 패키지로 분리해 관리하도록 구성했습니다.
- 추천 목록은 날짜 기준 공용 5개로 생성/저장되도록 구현했습니다.
- 추천 후보는 최근 7일 bread_records 집계를 기준으로 선정하고, 최근 3일 추천된 빵은 제외하도록 했습니다.
- 기록 데이터가 부족할 경우 전체 빵 목록에서 날짜 기반 deterministic random으로 보충하도록 했습니다.
- 로그인 유저는 추천 응답에서 isCollected가 계산되고, 미수집 빵은 imageUrl을 placeholder로 내려주도록 처리했습니다.
- /breads/today는 비로그인도 호출 가능하도록 optional auth endpoint로 열었습니다.
- 추천 API controller/service/repository/mapper/entity와 관련 테스트를 함께 추가했습니다.

## 📢 참고 및 특이사항
- 혹시 궁금하신 사항이나 수정이 필요하신 부분 있으시면 언제든지 노티 해주세요!

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인