### PR TITLE
chore: refine recommendation api swagger error response

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/bean/breaddiary/domain/recommendation/controller/RecommendationController.java
@@ -37,10 +37,6 @@ public class RecommendationController {
                     content = @Content(schema = @Schema(implementation = BreadTodayResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401",
-                    description = "Authorization 헤더가 잘못된 경우 인증에 실패합니다. Authorization 헤더가 없으면 비로그인 요청으로 처리됩니다."
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "500",
                     description = "오늘의 추천 빵 목록을 생성하거나 조회하는 중 서버 오류가 발생했습니다."
             )
@@ -49,9 +45,6 @@ public class RecommendationController {
     public ResponseEntity<ApiResponse<BreadTodayResponse>> getTodayRecommendations(
             @Parameter(hidden = true) HttpServletRequest request
     ) {
-        UUID userId = AuthRequestAttributes.getOptionalUserId(request);
-        BreadTodayResponse response = recommendationComplexService.getTodayRecommendations(userId);
-
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(recommendationComplexService.getTodayRecommendations(AuthRequestAttributes.getOptionalUserId(request))));
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #92 

## 🛠️ 작업 내용
- swagger 500 에러 예시를 수정했습니다.

## 📢 참고 및 특이사항
- Response DTO 글로벌 Exception 설정 문제로 현재 해당 문제가 해결되진 않았습니다.
- 현재 이슈 내용과 불일치하지만 401 에러가 스웨거에 필요가 앖다 판단해 해당 부분 제거 작업에 대해서 PR을 진행하려 합니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인