### PR TITLE
fix: unsupported media type 공통 에러 메시지 한글 깨짐 수정

### DIFF
--- a/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java
@@ -134,7 +134,7 @@ public class GlobalExceptionHandler {
             HttpMediaTypeNotSupportedException exception,
             HttpServletRequest request
     ) {
-        String message = "?붿껌 ?뺤떇???щ컮瑜댁? ?딆뒿?덈떎.";
+        String message = "요청 형식이 올바르지 않습니다.";
 
         log.warn(
                 "Invalid request: code={} method={} path={} requestId={} errorType={}",

--- a/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java
@@ -61,7 +61,8 @@ class GlobalExceptionHandlerTest {
                         .content("name=bread"))
                 .andExpect(status().isUnsupportedMediaType())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.message").value("요청 형식이 올바르지 않습니다."));
     }
 
     @Test


### PR DESCRIPTION
## 🧩 관련 이슈

- #94 

## 🛠️ 작업 내용

- `HttpMediaTypeNotSupportedException` 처리 시 내려가던 깨진 한글 메시지를 정상 문구인 `요청 형식이 올바르지 않습니다.`로 수정했습니다.
- `GlobalExceptionHandlerTest`의 `unsupportedMediaTypeReturnsCommonErrorResponse` 테스트에 `error.message` 검증을 추가했습니다.
- `src/main/java`, `src/test/java` 기준으로 동일 유형의 깨진 한글 후보를 재스캔했고 추가 후보는 없음을 확인했습니다.

## 📢 참고 및 특이사항

- 이번 수정 범위는 아래 두 파일로 한정했습니다.
  - `src/main/java/com/bean/breaddiary/global/common/GlobalExceptionHandler.java`
  - `src/test/java/com/bean/breaddiary/global/common/GlobalExceptionHandlerTest.java`
- 원인은 런타임 인코딩 문제가 아니라, unsupported media type 응답용 문자열 리터럴 자체가 이전 커밋 시점부터 깨진 상태로 저장되어 있던 것입니다.
- 기존 테스트는 상태코드와 `error.code`만 검증하고 `error.message`는 검증하지 않아 문제가 남아 있었습니다.
- LF -> CRLF 경고는 워킹카피 라인엔딩 경고이며 diff 품질 문제나 whitespace error는 아닙니다.

## ✅ 체크리스트

- [ ] Merge 대상 브랜치가 **develop** 인지 확인
- [ ] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [ ] 관련 이슈 연결 (`#이슈번호`)
- [ ] 불필요한 코드/주석 제거
- [ ] 기능 정상 작동 확인