### PR TITLE
feat: enable infinite scroll for bread autocomplete

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/controller/BreadController.java
@@ -118,10 +118,14 @@ public class BreadController {
     public ResponseEntity<ApiResponse<BreadAutocompleteResponse>> autocompleteBreads(
             @Parameter(description = "검색어. 미입력 시 인기순 빵 목록을 반환합니다.", example = "크루")
             @RequestParam(value = "q", required = false) String query,
+            @Parameter(description = "페이지네이션 커서. 검색어가 있으면 마지막 sticker_number, 없으면 {record_count}_{sticker_number} 형식", example = "6")
+            @RequestParam(value = "cursor", required = false) String cursor,
+            @Parameter(description = "페이지당 개수. 기본 20, 최대 50", example = "20")
+            @RequestParam(value = "limit", required = false) Integer limit,
             @Parameter(hidden = true) HttpServletRequest request
     ) {
         UUID userId = AuthRequestAttributes.getOptionalUserId(request);
-        BreadAutocompleteResponse response = breadComplexService.autocompleteBreads(query, userId);
+        BreadAutocompleteResponse response = breadComplexService.autocompleteBreads(query, cursor, limit, userId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -46,7 +46,12 @@ public interface BreadMapper {
     @Mapping(target = "eatCount", expression = "java(resolveEatCount(eatCount))")
     BreadAutocompleteItemResponse mapToAutocompleteItem(Bread bread, Long eatCount);
 
-    default BreadAutocompleteResponse mapToAutocompleteResponse(List<Bread> breads, Map<UUID, Long> eatCounts) {
+    default BreadAutocompleteResponse mapToAutocompleteResponse(
+            List<Bread> breads,
+            Map<UUID, Long> eatCounts,
+            String nextCursor,
+            boolean hasMore
+    ) {
         List<BreadAutocompleteItemResponse> items = breads.stream()
                 .map(bread -> mapToAutocompleteItem(
                         bread,
@@ -54,7 +59,7 @@ public interface BreadMapper {
                 ))
                 .toList();
 
-        return new BreadAutocompleteResponse(items);
+        return new BreadAutocompleteResponse(items, nextCursor, hasMore);
     }
 
     default Long resolveEatCount(Long eatCount) {

--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/response/BreadAutocompleteResponse.java
@@ -21,4 +21,10 @@ public class BreadAutocompleteResponse {
             arraySchema = @Schema(description = "자동완성 빵 목록")
     )
     private List<BreadAutocompleteItemResponse> items;
+
+    @Schema(description = "다음 페이지 커서. 다음 페이지가 없으면 null", example = "6", nullable = true)
+    private String nextCursor;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private Boolean hasMore;
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -30,6 +30,19 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
     @Query("""
             select b
             from Bread b
+            where lower(b.name) like lower(concat('%', :name, '%'))
+              and (:cursorStickerNumber is null or b.stickerNumber > :cursorStickerNumber)
+            order by b.stickerNumber asc
+            """)
+    List<Bread> findAutocompleteByNameContainingAfterStickerNumber(
+            @Param("name") String name,
+            @Param("cursorStickerNumber") Integer cursorStickerNumber,
+            Pageable pageable
+    );
+
+    @Query("""
+            select b
+            from Bread b
             left join BreadRecord br
                 on br.bread = b
                 and br.deletedAt is null
@@ -37,6 +50,32 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
             order by count(br) desc, b.stickerNumber asc
             """)
     List<Bread> findPopularOrderByRecordCountDesc(Pageable pageable);
+
+    @Query("""
+            select b
+            from Bread b
+            left join BreadRecord br
+                on br.bread = b
+                and br.deletedAt is null
+            group by b
+            having (:recordCountCursor is null
+                    or count(br) < :recordCountCursor
+                    or (count(br) = :recordCountCursor and b.stickerNumber > :stickerNumberCursor))
+            order by count(br) desc, b.stickerNumber asc
+            """)
+    List<Bread> findPopularAutocompleteAfterCursor(
+            @Param("recordCountCursor") Long recordCountCursor,
+            @Param("stickerNumberCursor") Integer stickerNumberCursor,
+            Pageable pageable
+    );
+
+    @Query("""
+            select count(br)
+            from BreadRecord br
+            where br.bread.id = :breadId
+              and br.deletedAt is null
+            """)
+    Long countActiveRecordsByBreadId(@Param("breadId") UUID breadId);
 
     @Query("""
             select b

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -42,12 +42,13 @@ public class BreadComplexService {
     private final BreadTypeService breadTypeService;
     private final BreadRecordService breadRecordService;
 
-    public BreadAutocompleteResponse autocompleteBreads(String query, UUID userId) {
-        List<Bread> breads = breadService.searchAutocompleteBreads(query);
+    public BreadAutocompleteResponse autocompleteBreads(String query, String cursor, Integer limit, UUID userId) {
+        BreadService.AutocompleteSlice autocompleteSlice = breadService.searchAutocompleteBreads(query, cursor, limit);
+        List<Bread> breads = autocompleteSlice.getItems();
 
         Map<UUID, Long> eatCounts = resolveEatCounts(userId, breads);
 
-        return breadService.createAutocompleteResponse(breads, eatCounts);
+        return breadService.createAutocompleteResponse(autocompleteSlice, eatCounts);
     }
 
     public BreadCatalogListResponse getBreadCatalog(

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -19,6 +19,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -28,7 +31,8 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class BreadService {
 
-    private static final int AUTOCOMPLETE_LIMIT = 20;
+    private static final int DEFAULT_AUTOCOMPLETE_LIMIT = 20;
+    private static final int MAX_AUTOCOMPLETE_LIMIT = 50;
     private static final String DEFAULT_USER_BREAD_IMAGE_URL =
             "https://cdn.bread-diary.app/catalog/default_user_bread.webp";
 
@@ -47,24 +51,34 @@ public class BreadService {
         return breadRepository.existsByName(name);
     }
 
-    public List<Bread> searchAutocompleteBreads(String query) {
-        Pageable limit = PageRequest.of(0, AUTOCOMPLETE_LIMIT);
+    public AutocompleteSlice searchAutocompleteBreads(String query, String cursor, Integer limit) {
+        int normalizedLimit = normalizeAutocompleteLimit(limit);
+        Pageable pageable = PageRequest.of(0, normalizedLimit + 1);
 
         if (query == null || query.isBlank()) {
-            return breadRepository.findPopularOrderByRecordCountDesc(limit);
+            return searchPopularAutocompleteBreads(cursor, normalizedLimit, pageable);
         }
 
-        return breadRepository.findByNameContainingIgnoreCaseOrderByStickerNumberAsc(
+        Integer cursorStickerNumber = parseStickerNumberCursor(cursor);
+        List<Bread> breads = breadRepository.findAutocompleteByNameContainingAfterStickerNumber(
                 query.trim(),
-                limit
+                cursorStickerNumber,
+                pageable
         );
+
+        return createStickerNumberAutocompleteSlice(breads, normalizedLimit);
     }
 
     public BreadAutocompleteResponse createAutocompleteResponse(
-            List<Bread> breads,
+            AutocompleteSlice autocompleteSlice,
             Map<UUID, Long> eatCounts
     ) {
-        return breadMapper.mapToAutocompleteResponse(breads, eatCounts);
+        return breadMapper.mapToAutocompleteResponse(
+                autocompleteSlice.getItems(),
+                eatCounts,
+                autocompleteSlice.getNextCursor(),
+                autocompleteSlice.getHasMore()
+        );
     }
 
     public List<Bread> findAllSystemCatalogBreads() {
@@ -149,5 +163,98 @@ public class BreadService {
         }
 
         return search.trim();
+    }
+
+    private AutocompleteSlice searchPopularAutocompleteBreads(
+            String cursor,
+            int normalizedLimit,
+            Pageable pageable
+    ) {
+        PopularAutocompleteCursor popularCursor = parsePopularAutocompleteCursor(cursor);
+        List<Bread> breads = breadRepository.findPopularAutocompleteAfterCursor(
+                popularCursor.getRecordCount(),
+                popularCursor.getStickerNumber(),
+                pageable
+        );
+
+        if (breads.size() <= normalizedLimit) {
+            return new AutocompleteSlice(breads, null, false);
+        }
+
+        List<Bread> pageItems = breads.subList(0, normalizedLimit);
+        Bread lastBread = pageItems.get(pageItems.size() - 1);
+        Long recordCount = breadRepository.countActiveRecordsByBreadId(lastBread.getId());
+        String nextCursor = recordCount + "_" + lastBread.getStickerNumber();
+
+        return new AutocompleteSlice(pageItems, nextCursor, true);
+    }
+
+    private AutocompleteSlice createStickerNumberAutocompleteSlice(List<Bread> breads, int normalizedLimit) {
+        if (breads.size() <= normalizedLimit) {
+            return new AutocompleteSlice(breads, null, false);
+        }
+
+        List<Bread> pageItems = breads.subList(0, normalizedLimit);
+        String nextCursor = String.valueOf(pageItems.get(pageItems.size() - 1).getStickerNumber());
+
+        return new AutocompleteSlice(pageItems, nextCursor, true);
+    }
+
+    private int normalizeAutocompleteLimit(Integer limit) {
+        if (limit == null || limit < 1) {
+            return DEFAULT_AUTOCOMPLETE_LIMIT;
+        }
+
+        return Math.min(limit, MAX_AUTOCOMPLETE_LIMIT);
+    }
+
+    private Integer parseStickerNumberCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Integer.parseInt(cursor.trim());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private PopularAutocompleteCursor parsePopularAutocompleteCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return PopularAutocompleteCursor.empty();
+        }
+
+        int separatorIndex = cursor.indexOf('_');
+        if (separatorIndex < 0 || separatorIndex == cursor.length() - 1) {
+            return PopularAutocompleteCursor.empty();
+        }
+
+        try {
+            long recordCount = Long.parseLong(cursor.substring(0, separatorIndex).trim());
+            int stickerNumber = Integer.parseInt(cursor.substring(separatorIndex + 1).trim());
+            return new PopularAutocompleteCursor(recordCount, stickerNumber);
+        } catch (NumberFormatException ignored) {
+            return PopularAutocompleteCursor.empty();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class AutocompleteSlice {
+        private List<Bread> items;
+        private String nextCursor;
+        private Boolean hasMore;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class PopularAutocompleteCursor {
+        private Long recordCount;
+        private Integer stickerNumber;
+
+        private static PopularAutocompleteCursor empty() {
+            return new PopularAutocompleteCursor(null, null);
+        }
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerAutocompleteTest.java
@@ -41,21 +41,25 @@ class BreadControllerAutocompleteTest {
     void autocompleteBreadsReturnsSpecResponseWithSnakeCaseFields() throws Exception {
         UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
-        BreadAutocompleteResponse response = new BreadAutocompleteResponse(List.of(
-                new BreadAutocompleteItemResponse(
+        BreadAutocompleteResponse response = new BreadAutocompleteResponse(
+                List.of(new BreadAutocompleteItemResponse(
                         breadId,
                         "크루아상",
                         "PASTRY",
                         6,
                         "https://cdn.bread-diary.app/breads/croissant.webp",
                         5L
-                )
-        ));
+                )),
+                "6",
+                true
+        );
 
-        when(breadComplexService.autocompleteBreads("크루", userId)).thenReturn(response);
+        when(breadComplexService.autocompleteBreads("크루", "3", 10, userId)).thenReturn(response);
 
         mockMvc.perform(get("/breads/autocomplete")
                         .param("q", "크루")
+                        .param("cursor", "3")
+                        .param("limit", "10")
                         .requestAttr(AuthRequestAttributes.USER_ID, userId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -65,23 +69,26 @@ class BreadControllerAutocompleteTest {
                 .andExpect(jsonPath("$.data.items[0].sticker_number").value(6))
                 .andExpect(jsonPath("$.data.items[0].image_url").value("https://cdn.bread-diary.app/breads/croissant.webp"))
                 .andExpect(jsonPath("$.data.items[0].eat_count").value(5))
+                .andExpect(jsonPath("$.data.next_cursor").value("6"))
+                .andExpect(jsonPath("$.data.has_more").value(true))
                 .andExpect(jsonPath("$.data.items[0].breadId").doesNotExist())
                 .andExpect(jsonPath("$.data.items[0].breadType").doesNotExist());
 
-        verify(breadComplexService).autocompleteBreads("크루", userId);
+        verify(breadComplexService).autocompleteBreads("크루", "3", 10, userId);
     }
 
     @Test
     void autocompleteBreadsAllowsAnonymousRequest() throws Exception {
-        when(breadComplexService.autocompleteBreads(null, null))
-                .thenReturn(new BreadAutocompleteResponse(List.of()));
+        when(breadComplexService.autocompleteBreads(null, null, null, null))
+                .thenReturn(new BreadAutocompleteResponse(List.of(), null, false));
 
         mockMvc.perform(get("/breads/autocomplete"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.items").isArray());
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.has_more").value(false));
 
-        verify(breadComplexService).autocompleteBreads(null, null);
+        verify(breadComplexService).autocompleteBreads(null, null, null, null);
     }
 
     private JsonMapper snakeCaseObjectMapper() {

--- a/src/test/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapperTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapperTest.java
@@ -1,6 +1,7 @@
 package com.bean.breaddiary.domain.bread.dto.mapper;
 
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadtype.entity.BreadType;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture.*;
@@ -118,5 +120,28 @@ class BreadMapperTest {
 
         assertEquals("https://cdn.bread-diary.app/breads/croissant_placeholder.webp", response.getImageUrl());
         assertEquals(0L, response.getEatCount());
+    }
+
+    @Test
+    void mapToAutocompleteResponseIncludesPaginationMetadata() {
+        UUID breadId = UUID.fromString("b78af3bc-d52b-4aa9-9996-182003d018ba");
+        Bread bread = Bread.builder()
+                .id(breadId)
+                .stickerNumber(6)
+                .name("크루아상")
+                .breadType(PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/breads/croissant.webp")
+                .build();
+
+        BreadAutocompleteResponse response = breadMapper.mapToAutocompleteResponse(
+                java.util.List.of(bread),
+                Map.of(breadId, 5L),
+                "6",
+                true
+        );
+
+        assertEquals(1, response.getItems().size());
+        assertEquals("6", response.getNextCursor());
+        assertEquals(true, response.getHasMore());
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
@@ -52,35 +52,37 @@ class BreadComplexServiceTest {
                 .breadType(PASTRY)
                 .imageUrl("https://cdn.bread-diary.app/breads/croissant.webp")
                 .build();
-        BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of());
+        BreadService.AutocompleteSlice autocompleteSlice = new BreadService.AutocompleteSlice(List.of(bread), "6", true);
+        BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of(), "6", true);
 
-        when(breadService.searchAutocompleteBreads("크루")).thenReturn(List.of(bread));
+        when(breadService.searchAutocompleteBreads("크루", "3", 10)).thenReturn(autocompleteSlice);
         when(breadRecordService.countActiveRecordsByBreadIds(userId, List.of(breadId)))
                 .thenReturn(Map.of(breadId, 5L));
-        when(breadService.createAutocompleteResponse(List.of(bread), Map.of(breadId, 5L)))
+        when(breadService.createAutocompleteResponse(autocompleteSlice, Map.of(breadId, 5L)))
                 .thenReturn(expected);
 
-        BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads("크루", userId);
+        BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads("크루", "3", 10, userId);
 
         assertSame(expected, actual);
-        verify(breadService).searchAutocompleteBreads("크루");
+        verify(breadService).searchAutocompleteBreads("크루", "3", 10);
         verify(breadRecordService).countActiveRecordsByBreadIds(userId, List.of(breadId));
-        verify(breadService).createAutocompleteResponse(List.of(bread), Map.of(breadId, 5L));
+        verify(breadService).createAutocompleteResponse(autocompleteSlice, Map.of(breadId, 5L));
     }
 
     @Test
     void autocompleteBreadsSkipsEatCountLookupForAnonymousUser() {
-        BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of());
+        BreadService.AutocompleteSlice autocompleteSlice = new BreadService.AutocompleteSlice(List.of(), null, false);
+        BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of(), null, false);
 
-        when(breadService.searchAutocompleteBreads(null)).thenReturn(List.of());
-        when(breadService.createAutocompleteResponse(List.of(), Map.of())).thenReturn(expected);
+        when(breadService.searchAutocompleteBreads(null, null, null)).thenReturn(autocompleteSlice);
+        when(breadService.createAutocompleteResponse(autocompleteSlice, Map.of())).thenReturn(expected);
 
-        BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads(null, null);
+        BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads(null, null, null, null);
 
         assertSame(expected, actual);
-        verify(breadService).searchAutocompleteBreads(null);
+        verify(breadService).searchAutocompleteBreads(null, null, null);
         verifyNoInteractions(breadRecordService);
-        verify(breadService).createAutocompleteResponse(List.of(), Map.of());
+        verify(breadService).createAutocompleteResponse(autocompleteSlice, Map.of());
     }
 
     @Test

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadServiceTest.java
@@ -1,0 +1,127 @@
+package com.bean.breaddiary.domain.bread.service;
+
+import com.bean.breaddiary.domain.bread.dto.mapper.BreadMapper;
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.repository.BreadRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture.BAGEL;
+import static com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture.PASTRY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class BreadServiceTest {
+
+    private BreadRepository breadRepository;
+    private BreadMapper breadMapper;
+    private BreadService breadService;
+
+    @BeforeEach
+    void setUp() {
+        breadRepository = mock(BreadRepository.class);
+        breadMapper = mock(BreadMapper.class);
+        breadService = new BreadService(breadRepository, breadMapper);
+    }
+
+    @Test
+    void searchAutocompleteBreadsUsesStickerCursorForQuerySearch() {
+        Bread firstBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                4,
+                "크루키",
+                PASTRY
+        );
+        Bread secondBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000002"),
+                6,
+                "크루아상",
+                PASTRY
+        );
+
+        when(breadRepository.findAutocompleteByNameContainingAfterStickerNumber(
+                "크루",
+                3,
+                PageRequest.of(0, 2)
+        )).thenReturn(List.of(firstBread, secondBread));
+
+        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("크루", "3", 1);
+
+        assertEquals(List.of(firstBread), actual.getItems());
+        assertEquals("4", actual.getNextCursor());
+        assertTrue(actual.getHasMore());
+    }
+
+    @Test
+    void searchAutocompleteBreadsUsesPopularCursorWhenQueryIsBlank() {
+        Bread firstBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                4,
+                "소금빵",
+                PASTRY
+        );
+        Bread secondBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000002"),
+                8,
+                "베이글",
+                BAGEL
+        );
+
+        when(breadRepository.findPopularAutocompleteAfterCursor(
+                12L,
+                3,
+                PageRequest.of(0, 2)
+        )).thenReturn(List.of(firstBread, secondBread));
+        when(breadRepository.countActiveRecordsByBreadId(firstBread.getId())).thenReturn(11L);
+
+        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("  ", "12_3", 1);
+
+        assertEquals(List.of(firstBread), actual.getItems());
+        assertEquals("11_4", actual.getNextCursor());
+        assertTrue(actual.getHasMore());
+        verify(breadRepository).countActiveRecordsByBreadId(firstBread.getId());
+    }
+
+    @Test
+    void searchAutocompleteBreadsReturnsNoCursorWhenPageEnds() {
+        Bread bread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                4,
+                "소금빵",
+                PASTRY
+        );
+
+        when(breadRepository.findAutocompleteByNameContainingAfterStickerNumber(
+                "소금",
+                null,
+                PageRequest.of(0, 21)
+        )).thenReturn(List.of(bread));
+
+        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("소금", null, null);
+
+        assertEquals(List.of(bread), actual.getItems());
+        assertNull(actual.getNextCursor());
+        assertFalse(actual.getHasMore());
+        verifyNoMoreInteractions(breadMapper);
+    }
+
+    private Bread createBread(UUID id, int stickerNumber, String name, com.bean.breaddiary.domain.breadtype.entity.BreadType breadType) {
+        return Bread.builder()
+                .id(id)
+                .stickerNumber(stickerNumber)
+                .name(name)
+                .breadType(breadType)
+                .imageUrl("https://cdn.bread-diary.app/breads/" + name + ".webp")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #96 

## 🛠️ 작업 내용
- 자동완성 API 에서 무한 스크롤 파라미터를 추가하였습니다.
- 최종 아이템 값을 nextcursor 에 등록하여 다음 스크롤에 해당 값을 페이징 시작값으로 이용할 수 있습니다

## 📢 참고 및 특이사항
- 파일 커밋 이상한거 해버려서 force push 했습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인