### PR TITLE
fix: show placeholder image for unrecorded bread detail

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapper.java
@@ -120,6 +120,14 @@ public interface BreadMapper {
         return toPlaceholderUrl(imageUrl);
     }
 
+    default String resolveProfileImageUrl(String imageUrl, BreadProfileStatsResponse stats) {
+        if (stats != null && stats.getEatCount() != null && stats.getEatCount() > 0) {
+            return imageUrl;
+        }
+
+        return toPlaceholderUrl(imageUrl);
+    }
+
     private String toPlaceholderUrl(String imageUrl) {
         if (imageUrl == null) {
             return null;
@@ -162,7 +170,7 @@ public interface BreadMapper {
     @Mapping(target = "name", source = "bread.name")
     @Mapping(target = "breadType", source = "bread.breadType.code")
     @Mapping(target = "breadTypeLabel", source = "bread.breadType.name")
-    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    @Mapping(target = "imageUrl", expression = "java(resolveProfileImageUrl(bread.getImageUrl(), stats))")
     @Mapping(target = "stats", source = "stats")
     @Mapping(target = "records", source = "records")
     BreadProfileResponse mapToProfileResponse(

--- a/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/controller/BreadControllerProfileTest.java
@@ -95,6 +95,38 @@ class BreadControllerProfileTest {
         verify(breadComplexService).getBreadProfile(breadId, userId);
     }
 
+    @Test
+    void getBreadProfileReturnsPlaceholderImageForUnrecordedBread() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        BreadProfileResponse response = new BreadProfileResponse(
+                breadId,
+                6,
+                "크루아상",
+                "PASTRY",
+                "페이스트리",
+                "https://cdn.bread-diary.app/breads/croissant_placeholder.webp",
+                new BreadProfileStatsResponse(
+                        0L,
+                        null,
+                        null
+                ),
+                List.of()
+        );
+
+        when(breadComplexService.getBreadProfile(breadId, userId)).thenReturn(response);
+
+        mockMvc.perform(get("/breads/catalog/{breadId}", breadId)
+                        .requestAttr(AuthRequestAttributes.USER_ID, userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.image_url").value("https://cdn.bread-diary.app/breads/croissant_placeholder.webp"))
+                .andExpect(jsonPath("$.data.stats.eat_count").value(0))
+                .andExpect(jsonPath("$.data.records").isArray());
+
+        verify(breadComplexService).getBreadProfile(breadId, userId);
+    }
+
     private JsonMapper snakeCaseObjectMapper() {
         return JsonMapper.builder()
                 .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/src/test/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapperTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/dto/mapper/BreadMapperTest.java
@@ -3,6 +3,8 @@ package com.bean.breaddiary.domain.bread.dto.mapper;
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteItemResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadAutocompleteResponse;
 import com.bean.breaddiary.domain.bread.dto.response.BreadCatalogItemResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileResponse;
+import com.bean.breaddiary.domain.bread.dto.response.BreadProfileStatsResponse;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadtype.entity.BreadType;
 import com.bean.breaddiary.domain.breadrecord.dto.projection.BreadRecordCatalogStats;
@@ -11,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -143,5 +147,45 @@ class BreadMapperTest {
         assertEquals(1, response.getItems().size());
         assertEquals("6", response.getNextCursor());
         assertEquals(true, response.getHasMore());
+    }
+
+    @Test
+    void mapToProfileResponseUsesPlaceholderImageForUncollectedBread() {
+        UUID breadId = UUID.fromString("b78af3bc-d52b-4aa9-9996-182003d018ba");
+        Bread bread = Bread.builder()
+                .id(breadId)
+                .stickerNumber(1)
+                .name("크루아상")
+                .breadType(PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/breads/croissant.webp")
+                .build();
+
+        BreadProfileResponse response = breadMapper.mapToProfileResponse(
+                bread,
+                new BreadProfileStatsResponse(0L, null, null),
+                List.of()
+        );
+
+        assertEquals("https://cdn.bread-diary.app/breads/croissant_placeholder.webp", response.getImageUrl());
+    }
+
+    @Test
+    void mapToProfileResponseKeepsOriginalImageForCollectedBread() {
+        UUID breadId = UUID.fromString("b78af3bc-d52b-4aa9-9996-182003d018ba");
+        Bread bread = Bread.builder()
+                .id(breadId)
+                .stickerNumber(1)
+                .name("크루아상")
+                .breadType(PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/breads/croissant.webp")
+                .build();
+
+        BreadProfileResponse response = breadMapper.mapToProfileResponse(
+                bread,
+                new BreadProfileStatsResponse(1L, 4.5, LocalDateTime.of(2026, 4, 1, 9, 0)),
+                List.of()
+        );
+
+        assertEquals("https://cdn.bread-diary.app/breads/croissant.webp", response.getImageUrl());
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #98 

## 🛠️ 작업 내용

- 기록 안 한 빵 상세에서 원본 이미지 대신 placeholder 이미지가 내려가도록 수정
- 기록 있는 빵 상세는 기존대로 원본 이미지 유지

## 📢 참고 및 특이사항
- 확인해주셔서 감사합니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인