### PR TITLE
fix: sort collected breads first in all catalog view

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -69,13 +69,13 @@ public class BreadComplexService {
         Map<UUID, BreadRecordCatalogStats> statsMap = resolveCatalogStats(userId, candidates);
 
         List<Bread> filteredBreads = applyFilter(candidates, statsMap, userId, normalizedFilter);
-        List<Bread> sortedBreads = applySort(filteredBreads, statsMap, normalizedSort);
-        List<Bread> cursorAppliedBreads = applyCursor(sortedBreads, statsMap, normalizedSort, cursor);
+        List<Bread> sortedBreads = applySort(filteredBreads, statsMap, normalizedSort, normalizedFilter);
+        List<Bread> cursorAppliedBreads = applyCursor(sortedBreads, statsMap, normalizedSort, normalizedFilter, cursor);
         List<Bread> pageBreads = takePage(cursorAppliedBreads, normalizedLimit);
 
         boolean hasMore = cursorAppliedBreads.size() > normalizedLimit;
         String nextCursor = hasMore && !pageBreads.isEmpty()
-                ? createNextCursor(pageBreads.get(pageBreads.size() - 1), statsMap, normalizedSort)
+                ? createNextCursor(pageBreads.get(pageBreads.size() - 1), statsMap, normalizedSort, normalizedFilter)
                 : null;
 
         return breadService.createCatalogListResponse(
@@ -165,7 +165,8 @@ public class BreadComplexService {
     private List<Bread> applySort(
             List<Bread> breads,
             Map<UUID, BreadRecordCatalogStats> statsMap,
-            String sort
+            String sort,
+            String filter
     ) {
         List<Bread> sortedBreads = new ArrayList<>(breads);
 
@@ -187,6 +188,14 @@ public class BreadComplexService {
                     .toList();
         }
 
+        if (FILTER_ALL.equals(filter)) {
+            sortedBreads.sort(Comparator
+                    .comparing((Bread bread) -> isCollected(bread, statsMap), Comparator.reverseOrder())
+                    .thenComparing(Bread::getStickerNumber)
+                    .thenComparing(bread -> bread.getId().toString()));
+            return sortedBreads;
+        }
+
         sortedBreads.sort(Comparator.comparing(Bread::getStickerNumber));
         return sortedBreads;
     }
@@ -195,13 +204,14 @@ public class BreadComplexService {
             List<Bread> breads,
             Map<UUID, BreadRecordCatalogStats> statsMap,
             String sort,
+            String filter,
             String cursor
     ) {
         if (cursor == null || cursor.isBlank()) {
             return breads;
         }
 
-        if (SORT_STICKER_NUMBER.equals(sort)) {
+        if (SORT_STICKER_NUMBER.equals(sort) && !FILTER_ALL.equals(filter)) {
             return applyStickerNumberCursor(breads, cursor);
         }
 
@@ -245,7 +255,8 @@ public class BreadComplexService {
     private String createNextCursor(
             Bread lastBread,
             Map<UUID, BreadRecordCatalogStats> statsMap,
-            String sort
+            String sort,
+            String filter
     ) {
         BreadRecordCatalogStats stats = statsMap.get(lastBread.getId());
 
@@ -255,6 +266,10 @@ public class BreadComplexService {
 
         if (SORT_RATING.equals(sort) && stats != null && stats.getAvgRating() != null) {
             return roundRating(stats.getAvgRating()) + "_" + lastBread.getId();
+        }
+
+        if (FILTER_ALL.equals(filter)) {
+            return lastBread.getStickerNumber() + "_" + lastBread.getId();
         }
 
         return String.valueOf(lastBread.getStickerNumber());

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
@@ -133,6 +133,129 @@ class BreadComplexServiceTest {
     }
 
     @Test
+    void getBreadCatalogSortsCollectedBreadsFirstForAllFilter() {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Bread uncollectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                1,
+                "소금빵",
+                PASTRY
+        );
+        Bread collectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000002"),
+                2,
+                "크루아상",
+                PASTRY
+        );
+        Map<UUID, BreadRecordCatalogStats> statsMap = Map.of(
+                collectedBread.getId(),
+                new BreadRecordCatalogStats(
+                        collectedBread.getId(),
+                        1L,
+                        4.5,
+                        null,
+                        LocalDate.of(2026, 3, 14)
+                )
+        );
+        BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), null, false, 2L);
+
+        when(breadService.findCatalogCandidates(null, null)).thenReturn(List.of(uncollectedBread, collectedBread));
+        when(breadRecordService.findCatalogStatsByBreadIds(
+                userId,
+                List.of(uncollectedBread.getId(), collectedBread.getId())
+        )).thenReturn(statsMap);
+        when(breadService.createCatalogListResponse(
+                List.of(collectedBread, uncollectedBread),
+                statsMap,
+                null,
+                false,
+                2L
+        )).thenReturn(expected);
+
+        BreadCatalogListResponse actual = breadComplexService.getBreadCatalog(
+                "sticker_number",
+                "all",
+                null,
+                null,
+                null,
+                20,
+                userId
+        );
+
+        assertSame(expected, actual);
+        verify(breadService).createCatalogListResponse(
+                List.of(collectedBread, uncollectedBread),
+                statsMap,
+                null,
+                false,
+                2L
+        );
+    }
+
+    @Test
+    void getBreadCatalogUsesCompositeCursorForAllFilterOrdering() {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Bread firstCollectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000001"),
+                2,
+                "크루아상",
+                PASTRY
+        );
+        Bread secondCollectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000002"),
+                3,
+                "베이글",
+                BAGEL
+        );
+        Bread uncollectedBread = createBread(
+                UUID.fromString("10000000-0000-0000-0000-000000000003"),
+                1,
+                "소금빵",
+                PASTRY
+        );
+        Map<UUID, BreadRecordCatalogStats> statsMap = Map.of(
+                firstCollectedBread.getId(),
+                new BreadRecordCatalogStats(firstCollectedBread.getId(), 1L, 4.0, null, LocalDate.of(2026, 3, 14)),
+                secondCollectedBread.getId(),
+                new BreadRecordCatalogStats(secondCollectedBread.getId(), 1L, 4.5, null, LocalDate.of(2026, 3, 15))
+        );
+        BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), "2_" + firstCollectedBread.getId(), true, 3L);
+
+        when(breadService.findCatalogCandidates(null, null))
+                .thenReturn(List.of(uncollectedBread, firstCollectedBread, secondCollectedBread));
+        when(breadRecordService.findCatalogStatsByBreadIds(
+                userId,
+                List.of(uncollectedBread.getId(), firstCollectedBread.getId(), secondCollectedBread.getId())
+        )).thenReturn(statsMap);
+        when(breadService.createCatalogListResponse(
+                List.of(firstCollectedBread),
+                statsMap,
+                "2_" + firstCollectedBread.getId(),
+                true,
+                3L
+        )).thenReturn(expected);
+
+        BreadCatalogListResponse actual = breadComplexService.getBreadCatalog(
+                "sticker_number",
+                "all",
+                null,
+                null,
+                null,
+                1,
+                userId
+        );
+
+        assertSame(expected, actual);
+        verify(breadService).createCatalogListResponse(
+                List.of(firstCollectedBread),
+                statsMap,
+                "2_" + firstCollectedBread.getId(),
+                true,
+                3L
+        );
+    }
+
+    @Test
     void getBreadCatalogAppliesCollectedFilterWithUserStats() {
         UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         Bread collectedBread = createBread(


### PR DESCRIPTION
## 🧩 관련 이슈

- #99 

## 🛠️ 작업 내용
- 빵 도감 조회시 기록한 방을 우선순위로 정렬 했습니다.


## 📢 참고 및 특이사항
- 없습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인