### PR TITLE
feat: store toss access token for user withdrawal

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
 
             ResolvedTossProfile tossProfile = resolveTossProfile(tossUserInfo);
             UserResolution userResolution = findOrCreateUser(tossProfile);
-            userResolution.user().updateTossRefreshToken(normalizeNullable(tossToken.refreshToken()));
+            updateTossTokens(userResolution.user(), tossToken, issuedAt);
             userId = userResolution.user().getId();
 
             UserSession userSession = createPendingSession(userResolution.user(), issuedAt);
@@ -429,6 +429,20 @@ public class AuthService {
 
     private String normalizeNullable(String value) {
         return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private void updateTossTokens(
+            User user,
+            TossAuthClient.TossGenerateTokenSuccess tossToken,
+            LocalDateTime issuedAt
+    ) {
+        String accessToken = normalizeNullable(tossToken.accessToken());
+        String refreshToken = normalizeNullable(tossToken.refreshToken());
+        LocalDateTime accessTokenExpiresAt = tossToken.expiresIn() == null
+                ? null
+                : issuedAt.plusSeconds(tossToken.expiresIn());
+
+        user.updateTossTokens(accessToken, refreshToken, accessTokenExpiresAt);
     }
 
     private String hashRefreshToken(String refreshToken) {

--- a/src/main/java/com/bean/breaddiary/domain/user/entity/User.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/entity/User.java
@@ -51,8 +51,14 @@ public class User {
     @Column(name = "toss_user_key", length = 100, unique = true)
     private String tossUserKey;
 
+    @Column(name = "toss_access_token", length = 1000)
+    private String tossAccessToken;
+
     @Column(name = "toss_refresh_token", length = 1000)
     private String tossRefreshToken;
+
+    @Column(name = "toss_access_token_expires_at")
+    private LocalDateTime tossAccessTokenExpiresAt;
 
     @Column(name = "email", length = 255, unique = true)
     private String email;
@@ -99,6 +105,16 @@ public class User {
 
     public void updateTossRefreshToken(String tossRefreshToken) {
         this.tossRefreshToken = tossRefreshToken;
+    }
+
+    public void updateTossTokens(
+            String tossAccessToken,
+            String tossRefreshToken,
+            LocalDateTime tossAccessTokenExpiresAt
+    ) {
+        this.tossAccessToken = tossAccessToken;
+        this.tossRefreshToken = tossRefreshToken;
+        this.tossAccessTokenExpiresAt = tossAccessTokenExpiresAt;
     }
 
     public void delete() {

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -50,13 +51,8 @@ public class UserWithdrawalService {
             boolean tossLinked = StringUtils.hasText(user.getTossUserKey());
 
             if (tossLinked) {
-                TossAuthClient.TossGenerateTokenSuccess refreshedToken =
-                        tossAuthClient.refreshAccessToken(requireTossRefreshToken(user));
-                user.updateTossRefreshToken(normalizeText(refreshedToken.refreshToken()));
-                tossAuthClient.unlinkByUserKey(
-                        requireText(refreshedToken.accessToken(), "토스 AccessToken 재발급에 실패했습니다."),
-                        user.getTossUserKey()
-                );
+                String tossAccessToken = resolveTossAccessToken(user);
+                tossAuthClient.unlinkByUserKey(tossAccessToken, user.getTossUserKey());
             }
 
             hardDeleteUserData(user);
@@ -171,6 +167,49 @@ public class UserWithdrawalService {
             );
         }
         return refreshToken;
+    }
+
+    private String resolveTossAccessToken(User user) {
+        if (hasUsableTossAccessToken(user)) {
+            return user.getTossAccessToken().trim();
+        }
+
+        TossAuthClient.TossGenerateTokenSuccess refreshedToken =
+                tossAuthClient.refreshAccessToken(requireTossRefreshToken(user));
+
+        String refreshedAccessToken = requireText(
+                refreshedToken.accessToken(),
+                "토스 AccessToken 재발급에 실패했습니다."
+        );
+        String refreshedRefreshToken = normalizeText(refreshedToken.refreshToken());
+        if (!StringUtils.hasText(refreshedRefreshToken)) {
+            refreshedRefreshToken = user.getTossRefreshToken();
+        }
+
+        LocalDateTime accessTokenExpiresAt = refreshedToken.expiresIn() == null
+                ? null
+                : LocalDateTime.now().plusSeconds(refreshedToken.expiresIn());
+
+        user.updateTossTokens(
+                refreshedAccessToken,
+                refreshedRefreshToken,
+                accessTokenExpiresAt
+        );
+
+        return refreshedAccessToken;
+    }
+
+    private boolean hasUsableTossAccessToken(User user) {
+        if (!StringUtils.hasText(user.getTossAccessToken())) {
+            return false;
+        }
+
+        LocalDateTime expiresAt = user.getTossAccessTokenExpiresAt();
+        if (expiresAt == null) {
+            return true;
+        }
+
+        return expiresAt.isAfter(LocalDateTime.now());
     }
 
     private String requireText(String value, String message) {


### PR DESCRIPTION
## 🧩 관련 이슈

- #104 

## 🛠️ 작업 내용
- User 테이블에 AT와 만료 시간 칼럼을 추가하였습니다.
- 회원 탈퇴 시 AT로 시도 이후 AT 만료 시 RT 재발급 이후 다시 회원 탈퇴를 시도합니다.

## 📢 참고 및 특이사항

- 없습니다,

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인