### PR TITLE
fix: validate toss webhook with basic auth

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
-    private static final String TOSS_WEBHOOK_SECRET_HEADER = "x-toss-webhook-secret";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     private final AuthService authService;
     private final UserWithdrawalService userWithdrawalService;
@@ -121,7 +121,7 @@ public class AuthController {
 
     @Operation(
             summary = "토스 연결 해제 웹훅",
-            description = "토스 웹훅 secret을 검증하고 eventType에 따라 세션 정리 또는 사용자 완전 삭제를 수행합니다."
+            description = "Authorization Basic 헤더를 검증하고 eventType에 따라 세션 정리 또는 사용자 완전 삭제를 수행합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -135,11 +135,11 @@ public class AuthController {
     })
     @PostMapping("/webhook/toss-unlink")
     public ResponseEntity<ApiResponse<TossWebhookResponse>> handleTossWebhook(
-            @RequestHeader(TOSS_WEBHOOK_SECRET_HEADER) String webhookSecret,
+            @RequestHeader(AUTHORIZATION_HEADER) String authorization,
             @Valid @RequestBody TossWebhookRequest request
     ) {
         return ResponseEntity.ok(
-                ApiResponse.success(userWithdrawalService.handleTossWebhook(webhookSecret, request))
+                ApiResponse.success(userWithdrawalService.handleTossWebhook(authorization, request))
         );
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
@@ -21,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -141,7 +143,7 @@ public class UserWithdrawalService {
 
     private void validateWebhookSecret(String requestWebhookSecret) {
         String configuredSecret = normalizeText(tossWebhookSecret);
-        String incomingSecret = normalizeText(requestWebhookSecret);
+        String incomingSecret = decodeBasicAuthorization(requestWebhookSecret);
 
         if (!StringUtils.hasText(configuredSecret)) {
             throw new ResponseStatusException(
@@ -154,6 +156,37 @@ public class UserWithdrawalService {
             throw new ResponseStatusException(
                     HttpStatus.UNAUTHORIZED,
                     "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+    }
+
+    private String decodeBasicAuthorization(String authorizationHeader) {
+        String normalizedAuthorization = normalizeText(authorizationHeader);
+        if (!StringUtils.hasText(normalizedAuthorization)
+                || !normalizedAuthorization.regionMatches(true, 0, "Basic ", 0, 6)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+
+        String encodedCredentials = normalizedAuthorization.substring(6).trim();
+        if (!StringUtils.hasText(encodedCredentials)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(encodedCredentials);
+            String decodedCredentials = new String(decodedBytes, StandardCharsets.UTF_8);
+            return normalizeText(decodedCredentials);
+        } catch (IllegalArgumentException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다.",
+                    exception
             );
         }
     }


### PR DESCRIPTION
## 🧩 관련 이슈

- #109 

## 🛠️ 작업 내용

- controller에 헤더 검증 로직을 다시 추가 하였습니다.
- key를 추가하였습니다.

## 📢 참고 및 특이사항

```
  [클라이언트]
      |
      | 1. DELETE /users/me
      v
  [우리 서버]
      |
      | 2. 현재 유저 확인
      | 3. 토스 연동 유저면 토스 unlink/탈퇴 관련 처리
      v
  [토스]
      |
      | 4. 상태 변경 후 webhook 전송
      |    POST /auth/webhook/toss-unlink
      v
  [우리 서버]
      |
      | 5. Authorization: Basic ... 검증
      | 6. eventType 확인
      |    - UNLINK -> 세션 정리
      |    - WITHDRAWAL_TOSS -> 하드 삭제
      v
  [삭제 완료]
```

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인