### PR TITLE
fix: handle toss withdrawal by webhook referrer

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/controller/AuthController.java
@@ -121,7 +121,7 @@ public class AuthController {
 
     @Operation(
             summary = "토스 연결 해제 웹훅",
-            description = "Authorization Basic 헤더를 검증하고 eventType에 따라 세션 정리 또는 사용자 완전 삭제를 수행합니다."
+            description = "Authorization Basic 헤더를 검증하고 referrer에 따라 토큰 초기화 또는 사용자 완전 삭제를 수행합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossWebhookRequest.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/request/TossWebhookRequest.java
@@ -1,9 +1,7 @@
 package com.bean.breaddiary.domain.auth.dto.request;
 
-import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +15,7 @@ public class TossWebhookRequest {
     @JsonAlias("userKey")
     private String userKey;
 
-    @NotNull(message = "event_type은 필수입니다.")
+    @NotBlank(message = "referrer는 필수입니다.")
     @JsonAlias("eventType")
-    private TossWebhookEventType eventType;
+    private String referrer;
 }

--- a/src/main/java/com/bean/breaddiary/domain/auth/dto/response/TossWebhookResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/dto/response/TossWebhookResponse.java
@@ -1,6 +1,5 @@
 package com.bean.breaddiary.domain.auth.dto.response;
 
-import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +13,6 @@ public class TossWebhookResponse {
     @JsonProperty("processed")
     private boolean processed;
 
-    @JsonProperty("eventType")
-    private TossWebhookEventType eventType;
+    @JsonProperty("referrer")
+    private String referrer;
 }

--- a/src/main/java/com/bean/breaddiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/controller/UserController.java
@@ -1,9 +1,7 @@
 package com.bean.breaddiary.domain.user.controller;
 
 import com.bean.breaddiary.domain.user.dto.response.UserMeResponse;
-import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
 import com.bean.breaddiary.domain.user.service.UserService;
-import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
 import com.bean.breaddiary.global.common.ApiResponse;
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +14,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,7 +28,6 @@ import java.util.UUID;
 public class UserController {
 
     private final UserService userService;
-    private final UserWithdrawalService userWithdrawalService;
 
     @Operation(
             summary = "내 프로필 조회",
@@ -53,30 +49,6 @@ public class UserController {
     ) {
         UUID userId = AuthRequestAttributes.getRequiredUserId(request);
         UserMeResponse response = userService.getCurrentUserProfile(userId);
-
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    @Operation(
-            summary = "회원 탈퇴",
-            description = "토스 연결 끊기를 요청한 뒤 콜백을 기다리지 않고 로컬 사용자 데이터를 즉시 완전 삭제합니다."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "회원 탈퇴 성공",
-                    content = @Content(schema = @Schema(implementation = UserWithdrawalResponse.class))
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
-    })
-    @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<UserWithdrawalResponse>> withdrawCurrentUser(
-            @Parameter(hidden = true) HttpServletRequest request
-    ) {
-        UUID userId = AuthRequestAttributes.getRequiredUserId(request);
-        UserWithdrawalResponse response = userWithdrawalService.withdrawCurrentUser(userId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/bean/breaddiary/domain/user/entity/User.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/entity/User.java
@@ -117,6 +117,12 @@ public class User {
         this.tossAccessTokenExpiresAt = tossAccessTokenExpiresAt;
     }
 
+    public void clearTossTokens() {
+        this.tossAccessToken = null;
+        this.tossRefreshToken = null;
+        this.tossAccessTokenExpiresAt = null;
+    }
+
     public void delete() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
@@ -3,7 +3,6 @@ package com.bean.breaddiary.domain.user.service;
 import com.bean.breaddiary.domain.auth.client.TossAuthClient;
 import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
 import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
-import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.bean.breaddiary.domain.auth.service.UserSessionService;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
@@ -24,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,6 +34,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+
+    private static final String WEBHOOK_REFERRER_UNLINK = "UNLINK";
+    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TERMS = "WITHDRAWAL_TERMS";
+    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TOSS = "WITHDRAWAL_TOSS";
 
     private final UserRepository userRepository;
     private final BreadRepository breadRepository;
@@ -140,33 +145,39 @@ public class UserService {
     ) {
         long startNanos = System.nanoTime();
         UUID userId = null;
-        TossWebhookEventType eventType = request == null ? null : request.getEventType();
+        String referrer = request == null ? null : normalizeText(request.getReferrer());
 
         try {
             validateWebhookSecret(requestWebhookSecret);
 
             Optional<User> user = userRepository.findByTossUserKey(normalizeText(request.getUserKey()));
             if (user.isEmpty()) {
-                logWebhookSuccess(resolveWebhookAction(eventType), null, eventType, false, startNanos);
-                return new TossWebhookResponse(true, request.getEventType());
+                logWebhookSuccess(resolveWebhookAction(referrer), null, referrer, false, startNanos);
+                return new TossWebhookResponse(true, referrer);
             }
 
             userId = user.get().getId();
 
-            if (request.getEventType() == TossWebhookEventType.UNLINK) {
-                clearSessionsOnly(userId);
-                logWebhookSuccess("tossUnlinkWebhook", userId, eventType, true, startNanos);
-                return new TossWebhookResponse(true, request.getEventType());
+            if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(referrer)) {
+                user.get().clearTossTokens();
+                logWebhookSuccess("tossUnlinkWebhook", userId, referrer, true, startNanos);
+                return new TossWebhookResponse(true, referrer);
             }
 
-            hardDeleteUserData(user.get());
-            logWebhookSuccess("tossWithdrawalWebhook", userId, eventType, true, startNanos);
-            return new TossWebhookResponse(true, request.getEventType());
+            if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(referrer)
+                    || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(referrer)) {
+                hardDeleteUserData(user.get());
+                logWebhookSuccess("tossWithdrawalWebhook", userId, referrer, true, startNanos);
+                return new TossWebhookResponse(true, referrer);
+            }
+
+            logWebhookSuccess("tossUnknownWebhook", userId, referrer, true, startNanos);
+            return new TossWebhookResponse(true, referrer);
         } catch (ResponseStatusException exception) {
-            logUserFailure(resolveWebhookAction(eventType), userId, eventType, exception, startNanos);
+            logUserFailure(resolveWebhookAction(referrer), userId, referrer, exception, startNanos);
             throw exception;
         } catch (RuntimeException exception) {
-            logUnexpectedUserFailure(resolveWebhookAction(eventType), userId, eventType, exception, startNanos);
+            logUnexpectedUserFailure(resolveWebhookAction(referrer), userId, referrer, exception, startNanos);
             throw exception;
         }
     }
@@ -198,7 +209,7 @@ public class UserService {
 
     private void validateWebhookSecret(String requestWebhookSecret) {
         String configuredSecret = normalizeText(tossWebhookSecret);
-        String incomingSecret = normalizeText(requestWebhookSecret);
+        String incomingSecret = decodeBasicAuthorization(requestWebhookSecret);
 
         if (!StringUtils.hasText(configuredSecret)) {
             throw new ResponseStatusException(
@@ -211,6 +222,36 @@ public class UserService {
             throw new ResponseStatusException(
                     HttpStatus.UNAUTHORIZED,
                     "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+    }
+
+    private String decodeBasicAuthorization(String authorizationHeader) {
+        String normalizedAuthorization = normalizeText(authorizationHeader);
+        if (!StringUtils.hasText(normalizedAuthorization)
+                || !normalizedAuthorization.regionMatches(true, 0, "Basic ", 0, 6)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+
+        String encodedCredentials = normalizedAuthorization.substring(6).trim();
+        if (!StringUtils.hasText(encodedCredentials)) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다."
+            );
+        }
+
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(encodedCredentials);
+            return normalizeText(new String(decodedBytes, StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "토스 웹훅 인증에 실패했습니다.",
+                    exception
             );
         }
     }
@@ -238,17 +279,17 @@ public class UserService {
     private void logWebhookSuccess(
             String action,
             UUID userId,
-            TossWebhookEventType eventType,
+            String referrer,
             boolean userFound,
             long startNanos
     ) {
         log.info(
-                "USER action={} result=success requestId={} userId={} status={} eventType={} userFound={} durationMs={}",
+                "USER action={} result=success requestId={} userId={} status={} referrer={} userFound={} durationMs={}",
                 action,
                 RequestLogContext.currentRequestIdOrDefault(),
                 valueOrDefault(userId),
                 HttpStatus.OK.value(),
-                valueOrDefault(eventType),
+                valueOrDefault(referrer),
                 userFound,
                 durationMs(startNanos)
         );
@@ -257,18 +298,18 @@ public class UserService {
     private void logUserFailure(
             String action,
             UUID userId,
-            TossWebhookEventType eventType,
+            String referrer,
             ResponseStatusException exception,
             long startNanos
     ) {
         if (exception.getStatusCode().is5xxServerError()) {
             log.error(
-                    "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                    "USER action={} result=fail requestId={} userId={} status={} referrer={} durationMs={}",
                     action,
                     RequestLogContext.currentRequestIdOrDefault(),
                     valueOrDefault(userId),
                     exception.getStatusCode().value(),
-                    valueOrDefault(eventType),
+                    valueOrDefault(referrer),
                     durationMs(startNanos),
                     exception
             );
@@ -276,12 +317,12 @@ public class UserService {
         }
 
         log.warn(
-                "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                "USER action={} result=fail requestId={} userId={} status={} referrer={} durationMs={}",
                 action,
                 RequestLogContext.currentRequestIdOrDefault(),
                 valueOrDefault(userId),
                 exception.getStatusCode().value(),
-                valueOrDefault(eventType),
+                valueOrDefault(referrer),
                 durationMs(startNanos)
         );
     }
@@ -289,27 +330,30 @@ public class UserService {
     private void logUnexpectedUserFailure(
             String action,
             UUID userId,
-            TossWebhookEventType eventType,
+            String referrer,
             RuntimeException exception,
             long startNanos
     ) {
         log.error(
-                "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                "USER action={} result=fail requestId={} userId={} status={} referrer={} durationMs={}",
                 action,
                 RequestLogContext.currentRequestIdOrDefault(),
                 valueOrDefault(userId),
                 "unexpected",
-                valueOrDefault(eventType),
+                valueOrDefault(referrer),
                 durationMs(startNanos),
                 exception
         );
     }
 
-    private String resolveWebhookAction(TossWebhookEventType eventType) {
-        if (eventType == TossWebhookEventType.UNLINK) {
+    private String resolveWebhookAction(String referrer) {
+        if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(normalizeText(referrer))) {
             return "tossUnlinkWebhook";
         }
-
+        if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(normalizeText(referrer))
+                || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(normalizeText(referrer))) {
+            return "tossWithdrawalWebhook";
+        }
         return "tossWithdrawalWebhook";
     }
 

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
@@ -3,7 +3,6 @@ package com.bean.breaddiary.domain.user.service;
 import com.bean.breaddiary.domain.auth.client.TossAuthClient;
 import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
 import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
-import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.bean.breaddiary.domain.auth.service.UserSessionService;
 import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
@@ -33,6 +32,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserWithdrawalService {
+
+    private static final String WEBHOOK_REFERRER_UNLINK = "UNLINK";
+    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TERMS = "WITHDRAWAL_TERMS";
+    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TOSS = "WITHDRAWAL_TOSS";
 
     private final UserService userService;
     private final UserRepository userRepository;
@@ -85,33 +88,39 @@ public class UserWithdrawalService {
     ) {
         long startNanos = System.nanoTime();
         UUID userId = null;
-        TossWebhookEventType eventType = request == null ? null : request.getEventType();
+        String referrer = request == null ? null : normalizeText(request.getReferrer());
 
         try {
             validateWebhookSecret(requestWebhookSecret);
 
             Optional<User> user = userRepository.findByTossUserKey(normalizeText(request.getUserKey()));
             if (user.isEmpty()) {
-                logWebhookSuccess(resolveWebhookAction(eventType), null, eventType, false, startNanos);
-                return new TossWebhookResponse(true, request.getEventType());
+                logWebhookSuccess(resolveWebhookAction(referrer), null, referrer, false, startNanos);
+                return new TossWebhookResponse(true, referrer);
             }
 
             userId = user.get().getId();
 
-            if (request.getEventType() == TossWebhookEventType.UNLINK) {
-                clearSessionsOnly(userId);
-                logWebhookSuccess("tossUnlinkWebhook", userId, eventType, true, startNanos);
-                return new TossWebhookResponse(true, request.getEventType());
+            if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(referrer)) {
+                user.get().clearTossTokens();
+                logWebhookSuccess("tossUnlinkWebhook", userId, referrer, true, startNanos);
+                return new TossWebhookResponse(true, referrer);
             }
 
-            hardDeleteUserData(user.get());
-            logWebhookSuccess("tossWithdrawalWebhook", userId, eventType, true, startNanos);
-            return new TossWebhookResponse(true, request.getEventType());
+            if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(referrer)
+                    || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(referrer)) {
+                hardDeleteUserData(user.get());
+                logWebhookSuccess("tossWithdrawalWebhook", userId, referrer, true, startNanos);
+                return new TossWebhookResponse(true, referrer);
+            }
+
+            logWebhookSuccess("tossUnknownWebhook", userId, referrer, true, startNanos);
+            return new TossWebhookResponse(true, referrer);
         } catch (ResponseStatusException exception) {
-            logUserFailure(resolveWebhookAction(eventType), userId, eventType, exception, startNanos);
+            logUserFailure(resolveWebhookAction(referrer), userId, referrer, exception, startNanos);
             throw exception;
         } catch (RuntimeException exception) {
-            logUnexpectedUserFailure(resolveWebhookAction(eventType), userId, eventType, exception, startNanos);
+            logUnexpectedUserFailure(resolveWebhookAction(referrer), userId, referrer, exception, startNanos);
             throw exception;
         }
     }
@@ -134,11 +143,6 @@ public class UserWithdrawalService {
 
         userSessionService.deleteAllSessions(userId);
         userRepository.delete(user);
-    }
-
-    @Transactional
-    public void clearSessionsOnly(UUID userId) {
-        userSessionService.deleteAllSessions(userId);
     }
 
     private void validateWebhookSecret(String requestWebhookSecret) {
@@ -255,17 +259,17 @@ public class UserWithdrawalService {
     private void logWebhookSuccess(
             String action,
             UUID userId,
-            TossWebhookEventType eventType,
+            String referrer,
             boolean userFound,
             long startNanos
     ) {
         log.info(
-                "USER action={} result=success requestId={} userId={} status={} eventType={} userFound={} durationMs={}",
+                "USER action={} result=success requestId={} userId={} status={} referrer={} userFound={} durationMs={}",
                 action,
                 RequestLogContext.currentRequestIdOrDefault(),
                 valueOrDefault(userId),
                 HttpStatus.OK.value(),
-                valueOrDefault(eventType),
+                valueOrDefault(referrer),
                 userFound,
                 durationMs(startNanos)
         );
@@ -274,18 +278,18 @@ public class UserWithdrawalService {
     private void logUserFailure(
             String action,
             UUID userId,
-            TossWebhookEventType eventType,
+            String referrer,
             ResponseStatusException exception,
             long startNanos
     ) {
         if (exception.getStatusCode().is5xxServerError()) {
             log.error(
-                    "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                    "USER action={} result=fail requestId={} userId={} status={} referrer={} durationMs={}",
                     action,
                     RequestLogContext.currentRequestIdOrDefault(),
                     valueOrDefault(userId),
                     exception.getStatusCode().value(),
-                    valueOrDefault(eventType),
+                    valueOrDefault(referrer),
                     durationMs(startNanos),
                     exception
             );
@@ -293,12 +297,12 @@ public class UserWithdrawalService {
         }
 
         log.warn(
-                "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                "USER action={} result=fail requestId={} userId={} status={} referrer={} durationMs={}",
                 action,
                 RequestLogContext.currentRequestIdOrDefault(),
                 valueOrDefault(userId),
                 exception.getStatusCode().value(),
-                valueOrDefault(eventType),
+                valueOrDefault(referrer),
                 durationMs(startNanos)
         );
     }
@@ -306,25 +310,29 @@ public class UserWithdrawalService {
     private void logUnexpectedUserFailure(
             String action,
             UUID userId,
-            TossWebhookEventType eventType,
+            String referrer,
             RuntimeException exception,
             long startNanos
     ) {
         log.error(
-                "USER action={} result=fail requestId={} userId={} status={} eventType={} durationMs={}",
+                "USER action={} result=fail requestId={} userId={} status={} referrer={} durationMs={}",
                 action,
                 RequestLogContext.currentRequestIdOrDefault(),
                 valueOrDefault(userId),
                 "unexpected",
-                valueOrDefault(eventType),
+                valueOrDefault(referrer),
                 durationMs(startNanos),
                 exception
         );
     }
 
-    private String resolveWebhookAction(TossWebhookEventType eventType) {
-        if (eventType == TossWebhookEventType.UNLINK) {
+    private String resolveWebhookAction(String referrer) {
+        if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(normalizeText(referrer))) {
             return "tossUnlinkWebhook";
+        }
+        if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(normalizeText(referrer))
+                || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(normalizeText(referrer))) {
+            return "tossWithdrawalWebhook";
         }
         return "tossWithdrawalWebhook";
     }


### PR DESCRIPTION
## 🧩 관련 이슈

- #111 

## 🛠️ 작업 내용
- 헤더 값 파싱 해서 key 값을 서버와 비교한 후 referer에 따라 분기 처리 로직하도록 수정했습니다.
- delete user/me 엔드포인트를 제거했습니다.

## 📢 참고 및 특이사항
- 명세서를 봐야 한다는걸 너무 늦게 알아서 해맸습니다. 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인