### PR TITLE
fix: hard-delete matched users on Toss unlink webhook

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserService.java
@@ -35,10 +35,6 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class UserService {
 
-    private static final String WEBHOOK_REFERRER_UNLINK = "UNLINK";
-    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TERMS = "WITHDRAWAL_TERMS";
-    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TOSS = "WITHDRAWAL_TOSS";
-
     private final UserRepository userRepository;
     private final BreadRepository breadRepository;
     private final BreadRecordRepository breadRecordRepository;
@@ -157,21 +153,8 @@ public class UserService {
             }
 
             userId = user.get().getId();
-
-            if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(referrer)) {
-                user.get().clearTossTokens();
-                logWebhookSuccess("tossUnlinkWebhook", userId, referrer, true, startNanos);
-                return new TossWebhookResponse(true, referrer);
-            }
-
-            if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(referrer)
-                    || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(referrer)) {
-                hardDeleteUserData(user.get());
-                logWebhookSuccess("tossWithdrawalWebhook", userId, referrer, true, startNanos);
-                return new TossWebhookResponse(true, referrer);
-            }
-
-            logWebhookSuccess("tossUnknownWebhook", userId, referrer, true, startNanos);
+            hardDeleteUserData(user.get());
+            logWebhookSuccess("tossWebhookHardDelete", userId, referrer, true, startNanos);
             return new TossWebhookResponse(true, referrer);
         } catch (ResponseStatusException exception) {
             logUserFailure(resolveWebhookAction(referrer), userId, referrer, exception, startNanos);
@@ -347,14 +330,7 @@ public class UserService {
     }
 
     private String resolveWebhookAction(String referrer) {
-        if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(normalizeText(referrer))) {
-            return "tossUnlinkWebhook";
-        }
-        if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(normalizeText(referrer))
-                || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(normalizeText(referrer))) {
-            return "tossWithdrawalWebhook";
-        }
-        return "tossWithdrawalWebhook";
+        return "tossWebhookHardDelete";
     }
 
     private String normalizeText(String value) {

--- a/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/bean/breaddiary/domain/user/service/UserWithdrawalService.java
@@ -33,10 +33,6 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class UserWithdrawalService {
 
-    private static final String WEBHOOK_REFERRER_UNLINK = "UNLINK";
-    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TERMS = "WITHDRAWAL_TERMS";
-    private static final String WEBHOOK_REFERRER_WITHDRAWAL_TOSS = "WITHDRAWAL_TOSS";
-
     private final UserService userService;
     private final UserRepository userRepository;
     private final BreadRepository breadRepository;
@@ -100,21 +96,8 @@ public class UserWithdrawalService {
             }
 
             userId = user.get().getId();
-
-            if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(referrer)) {
-                user.get().clearTossTokens();
-                logWebhookSuccess("tossUnlinkWebhook", userId, referrer, true, startNanos);
-                return new TossWebhookResponse(true, referrer);
-            }
-
-            if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(referrer)
-                    || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(referrer)) {
-                hardDeleteUserData(user.get());
-                logWebhookSuccess("tossWithdrawalWebhook", userId, referrer, true, startNanos);
-                return new TossWebhookResponse(true, referrer);
-            }
-
-            logWebhookSuccess("tossUnknownWebhook", userId, referrer, true, startNanos);
+            hardDeleteUserData(user.get());
+            logWebhookSuccess("tossWebhookHardDelete", userId, referrer, true, startNanos);
             return new TossWebhookResponse(true, referrer);
         } catch (ResponseStatusException exception) {
             logUserFailure(resolveWebhookAction(referrer), userId, referrer, exception, startNanos);
@@ -327,14 +310,7 @@ public class UserWithdrawalService {
     }
 
     private String resolveWebhookAction(String referrer) {
-        if (WEBHOOK_REFERRER_UNLINK.equalsIgnoreCase(normalizeText(referrer))) {
-            return "tossUnlinkWebhook";
-        }
-        if (WEBHOOK_REFERRER_WITHDRAWAL_TERMS.equalsIgnoreCase(normalizeText(referrer))
-                || WEBHOOK_REFERRER_WITHDRAWAL_TOSS.equalsIgnoreCase(normalizeText(referrer))) {
-            return "tossWithdrawalWebhook";
-        }
-        return "tossWithdrawalWebhook";
+        return "tossWebhookHardDelete";
     }
 
     private String normalizeText(String value) {

--- a/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/controller/AuthControllerTest.java
@@ -7,9 +7,8 @@ import com.bean.breaddiary.domain.auth.dto.request.TossWebhookRequest;
 import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
 import com.bean.breaddiary.domain.auth.dto.response.LogoutResponse;
 import com.bean.breaddiary.domain.auth.dto.response.TossWebhookResponse;
-import com.bean.breaddiary.domain.auth.entity.TossWebhookEventType;
 import com.bean.breaddiary.domain.auth.service.AuthService;
-import com.bean.breaddiary.domain.user.service.UserService;
+import com.bean.breaddiary.domain.user.service.UserWithdrawalService;
 import com.bean.breaddiary.global.common.GlobalExceptionHandler;
 import com.bean.breaddiary.global.interceptor.AuthRequestAttributes;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,15 +38,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthControllerTest {
 
     private AuthService authService;
-    private UserService userService;
+    private UserWithdrawalService userWithdrawalService;
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
         authService = mock(AuthService.class);
-        userService = mock(UserService.class);
+        userWithdrawalService = mock(UserWithdrawalService.class);
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new AuthController(authService, userService))
+                .standaloneSetup(new AuthController(authService, userWithdrawalService))
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
                 .build();
@@ -238,12 +237,12 @@ class AuthControllerTest {
 
     @Test
     void handleTossWebhookBindsCamelCaseRequestAndSerializesCamelCaseResponse() throws Exception {
-        when(userService.handleTossWebhook(any(String.class), any(TossWebhookRequest.class)))
-                .thenReturn(new TossWebhookResponse(true, TossWebhookEventType.UNLINK));
+        when(userWithdrawalService.handleTossWebhook(any(String.class), any(TossWebhookRequest.class)))
+                .thenReturn(new TossWebhookResponse(true, "UNLINK"));
 
         mockMvc.perform(post("/auth/webhook/toss-unlink")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("x-toss-webhook-secret", "webhook-secret")
+                        .header("Authorization", "Basic d2ViaG9vay1zZWNyZXQ=")
                         .content("""
                                 {
                                   "userKey": "toss-user-key-12345678",
@@ -253,15 +252,15 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.processed").value(true))
-                .andExpect(jsonPath("$.data.eventType").value("UNLINK"))
-                .andExpect(jsonPath("$.data.event_type").doesNotExist());
+                .andExpect(jsonPath("$.data.referrer").value("UNLINK"))
+                .andExpect(jsonPath("$.data.eventType").doesNotExist());
 
         ArgumentCaptor<TossWebhookRequest> requestCaptor = ArgumentCaptor.forClass(TossWebhookRequest.class);
         ArgumentCaptor<String> secretCaptor = ArgumentCaptor.forClass(String.class);
-        verify(userService).handleTossWebhook(secretCaptor.capture(), requestCaptor.capture());
-        assertEquals("webhook-secret", secretCaptor.getValue());
+        verify(userWithdrawalService).handleTossWebhook(secretCaptor.capture(), requestCaptor.capture());
+        assertEquals("Basic d2ViaG9vay1zZWNyZXQ=", secretCaptor.getValue());
         assertEquals("toss-user-key-12345678", requestCaptor.getValue().getUserKey());
-        assertEquals(TossWebhookEventType.UNLINK, requestCaptor.getValue().getEventType());
+        assertEquals("UNLINK", requestCaptor.getValue().getReferrer());
     }
 
     private JsonMapper snakeCaseObjectMapper() {

--- a/src/test/java/com/bean/breaddiary/domain/user/service/UserWithdrawalServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/user/service/UserWithdrawalServiceTest.java
@@ -9,7 +9,6 @@ import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadtype.entity.BreadType;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
 import com.bean.breaddiary.domain.breadrecord.repository.BreadRecordRepository;
-import com.bean.breaddiary.domain.user.dto.mapper.UserMapper;
 import com.bean.breaddiary.domain.user.dto.response.UserWithdrawalResponse;
 import com.bean.breaddiary.domain.user.entity.User;
 import com.bean.breaddiary.domain.user.repository.UserRepository;
@@ -29,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -37,12 +35,12 @@ import static org.mockito.Mockito.when;
 class UserWithdrawalServiceTest {
 
     private UserService userService;
+    private UserWithdrawalService userWithdrawalService;
     private UserRepository userRepository;
     private BreadRepository breadRepository;
     private BreadRecordRepository breadRecordRepository;
     private UserSessionService userSessionService;
     private TossAuthClient tossAuthClient;
-    private UserMapper userMapper;
 
     @BeforeEach
     void setUp() {
@@ -51,16 +49,16 @@ class UserWithdrawalServiceTest {
         breadRecordRepository = mock(BreadRecordRepository.class);
         userSessionService = mock(UserSessionService.class);
         tossAuthClient = mock(TossAuthClient.class);
-        userMapper = mock(UserMapper.class);
-        userService = new UserService(
+        userService = mock(UserService.class);
+        userWithdrawalService = new UserWithdrawalService(
+                userService,
                 userRepository,
                 breadRepository,
                 breadRecordRepository,
                 userSessionService,
-                tossAuthClient,
-                userMapper
+                tossAuthClient
         );
-        ReflectionTestUtils.setField(userService, "tossWebhookSecret", "webhook-secret");
+        ReflectionTestUtils.setField(userWithdrawalService, "tossWebhookSecret", "webhook-secret");
     }
 
     @Test
@@ -70,7 +68,7 @@ class UserWithdrawalServiceTest {
         Bread breadToKeep = bread(userId, 1, "keep-bread");
         Bread breadToDelete = bread(userId, 2, "delete-bread");
 
-        when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+        when(userService.getUserById(userId)).thenReturn(user);
         when(breadRepository.findAllByCreatedBy(userId)).thenReturn(List.of(breadToKeep, breadToDelete));
         when(breadRecordRepository.existsByBread(breadToKeep)).thenReturn(true);
         when(breadRecordRepository.existsByBread(breadToDelete)).thenReturn(false);
@@ -83,7 +81,7 @@ class UserWithdrawalServiceTest {
                         "profile"
                 ));
 
-        UserWithdrawalResponse response = userService.withdrawCurrentUser(userId);
+        UserWithdrawalResponse response = userWithdrawalService.withdrawCurrentUser(userId);
 
         assertTrue(response.isWithdrawn());
         assertNull(breadToKeep.getCreatedBy());
@@ -102,11 +100,11 @@ class UserWithdrawalServiceTest {
         User user = user(userId, "toss-user-key-without-refresh");
         user.updateTossRefreshToken(null);
 
-        when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+        when(userService.getUserById(userId)).thenReturn(user);
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> userService.withdrawCurrentUser(userId)
+                () -> userWithdrawalService.withdrawCurrentUser(userId)
         );
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
@@ -114,22 +112,25 @@ class UserWithdrawalServiceTest {
     }
 
     @Test
-    void handleTossWebhookUnlinkClearsSessionsOnly() {
+    void handleTossWebhookUnlinkHardDeletesUserData() {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440010");
         User user = user(userId, "toss-user-key-unlink");
 
         when(userRepository.findByTossUserKey("toss-user-key-unlink"))
                 .thenReturn(Optional.of(user));
 
-        TossWebhookResponse response = userService.handleTossWebhook(
+        when(breadRepository.findAllByCreatedBy(userId)).thenReturn(List.of());
+
+        TossWebhookResponse response = userWithdrawalService.handleTossWebhook(
                 "webhook-secret",
-                new TossWebhookRequest("toss-user-key-unlink", TossWebhookEventType.UNLINK)
+                new TossWebhookRequest("toss-user-key-unlink", TossWebhookEventType.UNLINK.name())
         );
 
         assertTrue(response.isProcessed());
-        assertEquals(TossWebhookEventType.UNLINK, response.getEventType());
+        assertEquals(TossWebhookEventType.UNLINK.name(), response.getReferrer());
+        verify(breadRecordRepository).hardDeleteAllByUserId(userId);
         verify(userSessionService).deleteAllSessions(userId);
-        verify(userRepository, never()).delete(user);
+        verify(userRepository).delete(user);
         verifyNoInteractions(tossAuthClient);
     }
 
@@ -142,13 +143,13 @@ class UserWithdrawalServiceTest {
                 .thenReturn(Optional.of(user));
         when(breadRepository.findAllByCreatedBy(userId)).thenReturn(List.of());
 
-        TossWebhookResponse response = userService.handleTossWebhook(
+        TossWebhookResponse response = userWithdrawalService.handleTossWebhook(
                 "webhook-secret",
-                new TossWebhookRequest("toss-user-key-withdrawal", TossWebhookEventType.WITHDRAWAL_TOSS)
+                new TossWebhookRequest("toss-user-key-withdrawal", TossWebhookEventType.WITHDRAWAL_TOSS.name())
         );
 
         assertTrue(response.isProcessed());
-        assertEquals(TossWebhookEventType.WITHDRAWAL_TOSS, response.getEventType());
+        assertEquals(TossWebhookEventType.WITHDRAWAL_TOSS.name(), response.getReferrer());
         verify(breadRecordRepository).hardDeleteAllByUserId(userId);
         verify(userSessionService).deleteAllSessions(userId);
         verify(userRepository).delete(user);
@@ -159,9 +160,9 @@ class UserWithdrawalServiceTest {
     void handleTossWebhookRejectsInvalidSecret() {
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> userService.handleTossWebhook(
+                () -> userWithdrawalService.handleTossWebhook(
                         "wrong-secret",
-                        new TossWebhookRequest("toss-user-key", TossWebhookEventType.UNLINK)
+                        new TossWebhookRequest("toss-user-key", TossWebhookEventType.UNLINK.name())
                 )
         );
 


### PR DESCRIPTION
## 🧩 관련 이슈

- #113 

## 🛠️ 작업 내용
- webhook 호출 시 로그아웃, 회원 탈퇴를 분기 처리 했었는데 분기 처리를 없애고 인증 된 요청인 경우 물리 삭제를 진행하도록 수정했습니다.


## 📢 참고 및 특이사항
- 없습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인