### PR TITLE
fix: prevent duplicate placeholder suffix on default user bread images

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -34,7 +34,7 @@ public class BreadService {
     private static final int DEFAULT_AUTOCOMPLETE_LIMIT = 20;
     private static final int MAX_AUTOCOMPLETE_LIMIT = 50;
     private static final String DEFAULT_USER_BREAD_IMAGE_URL =
-            "https://du4zizlgiw14n.cloudfront.net/images/014_%EB%85%B9%EC%B0%A8%20%EC%8B%9D%EB%B9%B5_placeholder.png";
+            "https://du4zizlgiw14n.cloudfront.net/images/014_%EB%85%B9%EC%B0%A8%20%EC%8B%9D%EB%B9%B5.png";
 
     private final BreadRepository breadRepository;
     private final BreadMapper breadMapper;

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadServiceTest.java
@@ -2,6 +2,7 @@ package com.bean.breaddiary.domain.bread.service;
 
 import com.bean.breaddiary.domain.bread.dto.mapper.BreadMapper;
 import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateNewBreadRecordRequest;
 import com.bean.breaddiary.domain.bread.repository.BreadRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -113,6 +115,39 @@ class BreadServiceTest {
         assertNull(actual.getNextCursor());
         assertFalse(actual.getHasMore());
         verifyNoMoreInteractions(breadMapper);
+    }
+
+    @Test
+    void createUserBreadUsesOriginalDefaultImageUrl() {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        CreateNewBreadRecordRequest request = new CreateNewBreadRecordRequest();
+        request.setName("말차 크로플");
+
+        Bread savedBread = Bread.builder()
+                .id(UUID.fromString("20000000-0000-0000-0000-000000000001"))
+                .stickerNumber(9)
+                .name("말차 크로플")
+                .breadType(PASTRY)
+                .imageUrl("https://du4zizlgiw14n.cloudfront.net/images/014_%EB%85%B9%EC%B0%A8%20%EC%8B%9D%EB%B9%B5.png")
+                .createdBy(userId)
+                .build();
+
+        when(breadRepository.existsByName("말차 크로플")).thenReturn(false);
+        when(breadRepository.findTopByOrderByStickerNumberDesc()).thenReturn(java.util.Optional.of(
+                Bread.builder().stickerNumber(8).build()
+        ));
+        when(breadMapper.mapToBread(
+                eq(request),
+                eq(PASTRY),
+                eq(9),
+                eq("https://du4zizlgiw14n.cloudfront.net/images/014_%EB%85%B9%EC%B0%A8%20%EC%8B%9D%EB%B9%B5.png"),
+                eq(userId)
+        )).thenReturn(savedBread);
+        when(breadRepository.save(savedBread)).thenReturn(savedBread);
+
+        Bread actual = breadService.createUserBread(request, PASTRY, userId);
+
+        assertEquals(savedBread, actual);
     }
 
     private Bread createBread(UUID id, int stickerNumber, String name, com.bean.breaddiary.domain.breadtype.entity.BreadType breadType) {


### PR DESCRIPTION
## 🧩 관련 이슈

- #115 

## 🛠️ 작업 내용
- breadService에서 기본 이미지 URL 뒤에 _placeholder를 제거했습니다.


## 📢 참고 및 특이사항
- 운영 DB에 저장된 기타 빵에 대한 데이터가 2건 이여서 직접 url 수정해서 클라이언트에게 올바른 이미지 보낼 수 있도록 수정하겠습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인