### PR TITLE
fix: restrict user-created breads to their owners

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -32,11 +32,13 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
             from Bread b
             where lower(b.name) like lower(concat('%', :name, '%'))
               and (:cursorStickerNumber is null or b.stickerNumber > :cursorStickerNumber)
+              and (b.createdBy is null or (:userId is not null and b.createdBy = :userId))
             order by b.stickerNumber asc
             """)
     List<Bread> findAutocompleteByNameContainingAfterStickerNumber(
             @Param("name") String name,
             @Param("cursorStickerNumber") Integer cursorStickerNumber,
+            @Param("userId") UUID userId,
             Pageable pageable
     );
 
@@ -57,6 +59,7 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
             left join BreadRecord br
                 on br.bread = b
                 and br.deletedAt is null
+            where (b.createdBy is null or (:userId is not null and b.createdBy = :userId))
             group by b
             having (:recordCountCursor is null
                     or count(br) < :recordCountCursor
@@ -66,6 +69,7 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
     List<Bread> findPopularAutocompleteAfterCursor(
             @Param("recordCountCursor") Long recordCountCursor,
             @Param("stickerNumberCursor") Integer stickerNumberCursor,
+            @Param("userId") UUID userId,
             Pageable pageable
     );
 
@@ -82,10 +86,12 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
             from Bread b
             where (:search is null or lower(b.name) like lower(concat('%', :search, '%')))
               and (:breadType is null or b.breadType = :breadType)
+              and (b.createdBy is null or (:userId is not null and b.createdBy = :userId))
             order by b.stickerNumber asc
             """)
     List<Bread> findCatalogCandidates(
             @Param("search") String search,
-            @Param("breadType") BreadType breadType
+            @Param("breadType") BreadType breadType,
+            @Param("userId") UUID userId
     );
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadComplexService.java
@@ -43,7 +43,7 @@ public class BreadComplexService {
     private final BreadRecordService breadRecordService;
 
     public BreadAutocompleteResponse autocompleteBreads(String query, String cursor, Integer limit, UUID userId) {
-        BreadService.AutocompleteSlice autocompleteSlice = breadService.searchAutocompleteBreads(query, cursor, limit);
+        BreadService.AutocompleteSlice autocompleteSlice = breadService.searchAutocompleteBreads(query, cursor, limit, userId);
         List<Bread> breads = autocompleteSlice.getItems();
 
         Map<UUID, Long> eatCounts = resolveEatCounts(userId, breads);
@@ -65,7 +65,7 @@ public class BreadComplexService {
         int normalizedLimit = normalizeLimit(limit);
         BreadType breadType = resolveBreadType(breadTypeCode);
 
-        List<Bread> candidates = breadService.findCatalogCandidates(search, breadType);
+        List<Bread> candidates = breadService.findCatalogCandidates(search, breadType, userId);
         Map<UUID, BreadRecordCatalogStats> statsMap = resolveCatalogStats(userId, candidates);
 
         List<Bread> filteredBreads = applyFilter(candidates, statsMap, userId, normalizedFilter);
@@ -88,7 +88,7 @@ public class BreadComplexService {
     }
 
     public BreadProfileResponse getBreadProfile(UUID breadId, UUID userId) {
-        Bread bread = breadService.getBreadById(breadId);
+        Bread bread = breadService.getBreadById(breadId, userId);
         List<BreadRecord> records = breadRecordService.findActiveRecordsByUserAndBread(
                 userId,
                 bread

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -39,30 +40,34 @@ public class BreadService {
     private final BreadRepository breadRepository;
     private final BreadMapper breadMapper;
 
-    public Bread getBreadById(UUID breadId) {
-        return breadRepository.findById(breadId)
+    public Bread getBreadById(UUID breadId, UUID userId) {
+        Bread bread = breadRepository.findById(breadId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
                         "해당 빵을 카탈로그에서 찾을 수 없습니다."
                 ));
+
+        validateBreadVisibility(bread, userId);
+        return bread;
     }
 
     public boolean existsByName(String name) {
         return breadRepository.existsByName(name);
     }
 
-    public AutocompleteSlice searchAutocompleteBreads(String query, String cursor, Integer limit) {
+    public AutocompleteSlice searchAutocompleteBreads(String query, String cursor, Integer limit, UUID userId) {
         int normalizedLimit = normalizeAutocompleteLimit(limit);
         Pageable pageable = PageRequest.of(0, normalizedLimit + 1);
 
         if (query == null || query.isBlank()) {
-            return searchPopularAutocompleteBreads(cursor, normalizedLimit, pageable);
+            return searchPopularAutocompleteBreads(cursor, normalizedLimit, pageable, userId);
         }
 
         Integer cursorStickerNumber = parseStickerNumberCursor(cursor);
         List<Bread> breads = breadRepository.findAutocompleteByNameContainingAfterStickerNumber(
                 query.trim(),
                 cursorStickerNumber,
+                userId,
                 pageable
         );
 
@@ -85,10 +90,11 @@ public class BreadService {
         return breadRepository.findAllByCreatedByIsNullOrderByStickerNumberAsc();
     }
 
-    public List<Bread> findCatalogCandidates(String search, BreadType breadType) {
+    public List<Bread> findCatalogCandidates(String search, BreadType breadType, UUID userId) {
         return breadRepository.findCatalogCandidates(
                 normalizeSearch(search),
-                breadType
+                breadType,
+                userId
         );
     }
 
@@ -148,6 +154,15 @@ public class BreadService {
                 .orElse(0) + 1;
     }
 
+    private void validateBreadVisibility(Bread bread, UUID userId) {
+        if (bread.isUserCreated() && !Objects.equals(bread.getCreatedBy(), userId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "해당 빵을 카탈로그에서 찾을 수 없습니다."
+            );
+        }
+    }
+
     private void validateBreadNameNotDuplicated(String name) {
         if (existsByName(name)) {
             throw new ResponseStatusException(
@@ -168,12 +183,14 @@ public class BreadService {
     private AutocompleteSlice searchPopularAutocompleteBreads(
             String cursor,
             int normalizedLimit,
-            Pageable pageable
+            Pageable pageable,
+            UUID userId
     ) {
         PopularAutocompleteCursor popularCursor = parsePopularAutocompleteCursor(cursor);
         List<Bread> breads = breadRepository.findPopularAutocompleteAfterCursor(
                 popularCursor.getRecordCount(),
                 popularCursor.getStickerNumber(),
+                userId,
                 pageable
         );
 

--- a/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexService.java
@@ -32,7 +32,7 @@ public class BreadRecordComplexService {
     public BreadRecordCreateResponse createBreadRecord(UUID userId, CreateBreadRecordRequest request) {
         breadRecordService.validateEatenDate(request.getEatenDate());
 
-        Bread bread = breadService.getBreadById(request.getBreadId());
+        Bread bread = breadService.getBreadById(request.getBreadId(), userId);
         Boolean isFirstRecord = !breadRecordService.existsActiveRecord(userId, bread);
 
         String photoUrl = s3UploadService.uploadBreadPhoto(userId, request.getPhoto());

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadComplexServiceTest.java
@@ -55,7 +55,7 @@ class BreadComplexServiceTest {
         BreadService.AutocompleteSlice autocompleteSlice = new BreadService.AutocompleteSlice(List.of(bread), "6", true);
         BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of(), "6", true);
 
-        when(breadService.searchAutocompleteBreads("크루", "3", 10)).thenReturn(autocompleteSlice);
+        when(breadService.searchAutocompleteBreads("크루", "3", 10, userId)).thenReturn(autocompleteSlice);
         when(breadRecordService.countActiveRecordsByBreadIds(userId, List.of(breadId)))
                 .thenReturn(Map.of(breadId, 5L));
         when(breadService.createAutocompleteResponse(autocompleteSlice, Map.of(breadId, 5L)))
@@ -64,7 +64,7 @@ class BreadComplexServiceTest {
         BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads("크루", "3", 10, userId);
 
         assertSame(expected, actual);
-        verify(breadService).searchAutocompleteBreads("크루", "3", 10);
+        verify(breadService).searchAutocompleteBreads("크루", "3", 10, userId);
         verify(breadRecordService).countActiveRecordsByBreadIds(userId, List.of(breadId));
         verify(breadService).createAutocompleteResponse(autocompleteSlice, Map.of(breadId, 5L));
     }
@@ -74,13 +74,13 @@ class BreadComplexServiceTest {
         BreadService.AutocompleteSlice autocompleteSlice = new BreadService.AutocompleteSlice(List.of(), null, false);
         BreadAutocompleteResponse expected = new BreadAutocompleteResponse(List.of(), null, false);
 
-        when(breadService.searchAutocompleteBreads(null, null, null)).thenReturn(autocompleteSlice);
+        when(breadService.searchAutocompleteBreads(null, null, null, null)).thenReturn(autocompleteSlice);
         when(breadService.createAutocompleteResponse(autocompleteSlice, Map.of())).thenReturn(expected);
 
         BreadAutocompleteResponse actual = breadComplexService.autocompleteBreads(null, null, null, null);
 
         assertSame(expected, actual);
-        verify(breadService).searchAutocompleteBreads(null, null, null);
+        verify(breadService).searchAutocompleteBreads(null, null, null, null);
         verifyNoInteractions(breadRecordService);
         verify(breadService).createAutocompleteResponse(autocompleteSlice, Map.of());
     }
@@ -101,7 +101,7 @@ class BreadComplexServiceTest {
         );
         BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), "1", true, 2L);
 
-        when(breadService.findCatalogCandidates(null, null)).thenReturn(List.of(firstBread, secondBread));
+        when(breadService.findCatalogCandidates(null, null, null)).thenReturn(List.of(firstBread, secondBread));
         when(breadService.createCatalogListResponse(
                 List.of(firstBread),
                 Map.of(),
@@ -121,7 +121,7 @@ class BreadComplexServiceTest {
         );
 
         assertSame(expected, actual);
-        verify(breadService).findCatalogCandidates(null, null);
+        verify(breadService).findCatalogCandidates(null, null, null);
         verifyNoInteractions(breadRecordService);
         verify(breadService).createCatalogListResponse(
                 List.of(firstBread),
@@ -159,7 +159,7 @@ class BreadComplexServiceTest {
         );
         BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), null, false, 2L);
 
-        when(breadService.findCatalogCandidates(null, null)).thenReturn(List.of(uncollectedBread, collectedBread));
+        when(breadService.findCatalogCandidates(null, null, userId)).thenReturn(List.of(uncollectedBread, collectedBread));
         when(breadRecordService.findCatalogStatsByBreadIds(
                 userId,
                 List.of(uncollectedBread.getId(), collectedBread.getId())
@@ -221,7 +221,7 @@ class BreadComplexServiceTest {
         );
         BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), "2_" + firstCollectedBread.getId(), true, 3L);
 
-        when(breadService.findCatalogCandidates(null, null))
+        when(breadService.findCatalogCandidates(null, null, userId))
                 .thenReturn(List.of(uncollectedBread, firstCollectedBread, secondCollectedBread));
         when(breadRecordService.findCatalogStatsByBreadIds(
                 userId,
@@ -281,7 +281,7 @@ class BreadComplexServiceTest {
         BreadCatalogListResponse expected = new BreadCatalogListResponse(List.of(), null, false, 1L);
 
         when(breadTypeService.getBreadTypeByCode("PASTRY")).thenReturn(PASTRY);
-        when(breadService.findCatalogCandidates("크루", PASTRY))
+        when(breadService.findCatalogCandidates("크루", PASTRY, userId))
                 .thenReturn(List.of(collectedBread, uncollectedBread));
         when(breadRecordService.findCatalogStatsByBreadIds(
                 userId,
@@ -307,7 +307,7 @@ class BreadComplexServiceTest {
 
         assertSame(expected, actual);
         verify(breadTypeService).getBreadTypeByCode("PASTRY");
-        verify(breadService).findCatalogCandidates("크루", PASTRY);
+        verify(breadService).findCatalogCandidates("크루", PASTRY, userId);
         verify(breadRecordService).findCatalogStatsByBreadIds(
                 userId,
                 List.of(collectedBread.getId(), uncollectedBread.getId())
@@ -319,6 +319,22 @@ class BreadComplexServiceTest {
                 false,
                 1L
         );
+    }
+
+    @Test
+    void getBreadProfileRejectsAnonymousAccessToUserCreatedBread() {
+        UUID breadId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+
+        when(breadService.getBreadById(breadId, null)).thenThrow(new org.springframework.web.server.ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND));
+
+        org.springframework.web.server.ResponseStatusException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                org.springframework.web.server.ResponseStatusException.class,
+                () -> breadComplexService.getBreadProfile(breadId, null)
+        );
+
+        org.junit.jupiter.api.Assertions.assertEquals(org.springframework.http.HttpStatus.NOT_FOUND, exception.getStatusCode());
+        verify(breadService).getBreadById(breadId, null);
+        verifyNoInteractions(breadRecordService);
     }
 
     @Test
@@ -346,7 +362,7 @@ class BreadComplexServiceTest {
         List<BreadProfileRecordResponse> recordResponses = List.of(new BreadProfileRecordResponse());
         BreadProfileResponse expected = new BreadProfileResponse();
 
-        when(breadService.getBreadById(breadId)).thenReturn(bread);
+        when(breadService.getBreadById(breadId, userId)).thenReturn(bread);
         when(breadRecordService.findActiveRecordsByUserAndBread(userId, bread))
                 .thenReturn(List.of(record));
         when(breadRecordService.createProfileStats(List.of(record))).thenReturn(stats);
@@ -356,7 +372,7 @@ class BreadComplexServiceTest {
         BreadProfileResponse actual = breadComplexService.getBreadProfile(breadId, userId);
 
         assertSame(expected, actual);
-        verify(breadService).getBreadById(breadId);
+        verify(breadService).getBreadById(breadId, userId);
         verify(breadRecordService).findActiveRecordsByUserAndBread(userId, bread);
         verify(breadRecordService).createProfileStats(List.of(record));
         verify(breadRecordService).createProfileRecordResponses(List.of(record));

--- a/src/test/java/com/bean/breaddiary/domain/bread/service/BreadServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/bread/service/BreadServiceTest.java
@@ -7,6 +7,8 @@ import com.bean.breaddiary.domain.bread.repository.BreadRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.UUID;
@@ -16,6 +18,7 @@ import static com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture.PASTRY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -51,13 +54,16 @@ class BreadServiceTest {
                 PASTRY
         );
 
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
         when(breadRepository.findAutocompleteByNameContainingAfterStickerNumber(
                 "크루",
                 3,
+                userId,
                 PageRequest.of(0, 2)
         )).thenReturn(List.of(firstBread, secondBread));
 
-        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("크루", "3", 1);
+        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("크루", "3", 1, userId);
 
         assertEquals(List.of(firstBread), actual.getItems());
         assertEquals("4", actual.getNextCursor());
@@ -79,14 +85,17 @@ class BreadServiceTest {
                 BAGEL
         );
 
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
         when(breadRepository.findPopularAutocompleteAfterCursor(
                 12L,
                 3,
+                userId,
                 PageRequest.of(0, 2)
         )).thenReturn(List.of(firstBread, secondBread));
         when(breadRepository.countActiveRecordsByBreadId(firstBread.getId())).thenReturn(11L);
 
-        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("  ", "12_3", 1);
+        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("  ", "12_3", 1, userId);
 
         assertEquals(List.of(firstBread), actual.getItems());
         assertEquals("11_4", actual.getNextCursor());
@@ -106,15 +115,50 @@ class BreadServiceTest {
         when(breadRepository.findAutocompleteByNameContainingAfterStickerNumber(
                 "소금",
                 null,
+                null,
                 PageRequest.of(0, 21)
         )).thenReturn(List.of(bread));
 
-        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("소금", null, null);
+        BreadService.AutocompleteSlice actual = breadService.searchAutocompleteBreads("소금", null, null, null);
 
         assertEquals(List.of(bread), actual.getItems());
         assertNull(actual.getNextCursor());
         assertFalse(actual.getHasMore());
         verifyNoMoreInteractions(breadMapper);
+    }
+
+    @Test
+    void getBreadByIdAllowsSystemBreadForAnonymousUser() {
+        UUID breadId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+        Bread bread = createBread(breadId, 4, "소금빵", PASTRY);
+
+        when(breadRepository.findById(breadId)).thenReturn(java.util.Optional.of(bread));
+
+        Bread actual = breadService.getBreadById(breadId, null);
+
+        assertEquals(bread, actual);
+    }
+
+    @Test
+    void getBreadByIdRejectsOtherUsersUserCreatedBread() {
+        UUID breadId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+        Bread bread = Bread.builder()
+                .id(breadId)
+                .stickerNumber(4)
+                .name("소금빵")
+                .breadType(PASTRY)
+                .imageUrl("https://cdn.bread-diary.app/breads/salt.webp")
+                .createdBy(UUID.fromString("00000000-0000-0000-0000-000000000009"))
+                .build();
+
+        when(breadRepository.findById(breadId)).thenReturn(java.util.Optional.of(bread));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> breadService.getBreadById(breadId, UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
     }
 
     @Test

--- a/src/test/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/breadrecord/service/BreadRecordComplexServiceTest.java
@@ -4,7 +4,9 @@ import com.bean.breaddiary.domain.bread.entity.Bread;
 import com.bean.breaddiary.domain.breadtype.entity.BreadType;
 import com.bean.breaddiary.domain.bread.service.BreadService;
 import com.bean.breaddiary.domain.breadtype.service.BreadTypeService;
+import com.bean.breaddiary.domain.breadrecord.dto.request.CreateBreadRecordRequest;
 import com.bean.breaddiary.domain.breadrecord.dto.request.UpdateBreadRecordRequest;
+import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordCreateResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDeleteResponse;
 import com.bean.breaddiary.domain.breadrecord.dto.response.BreadRecordDetailResponse;
 import com.bean.breaddiary.domain.breadrecord.entity.BreadRecord;
@@ -47,6 +49,39 @@ class BreadRecordComplexServiceTest {
                 breadRecordService,
                 s3UploadService
         );
+    }
+
+    @Test
+    void createBreadRecordUsesUserScopedBreadLookup() {
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        Bread bread = createBread(null);
+        CreateBreadRecordRequest request = new CreateBreadRecordRequest(
+                breadId,
+                new MockMultipartFile("photo", "photo.webp", "image/webp", "photo".getBytes()),
+                "르뺑블루",
+                LocalDate.of(2026, 3, 14),
+                5,
+                "맛있어요."
+        );
+        BreadRecord savedRecord = createBreadRecord(bread);
+        BreadRecordCreateResponse expected = new BreadRecordCreateResponse();
+
+        when(breadService.getBreadById(breadId, USER_ID)).thenReturn(bread);
+        when(breadRecordService.existsActiveRecord(USER_ID, bread)).thenReturn(false);
+        when(s3UploadService.uploadBreadPhoto(USER_ID, request.getPhoto()))
+                .thenReturn("https://cdn.bread-diary.app/bread-photos/new.webp");
+        when(breadRecordService.createBreadRecord(
+                request,
+                USER_ID,
+                bread,
+                "https://cdn.bread-diary.app/bread-photos/new.webp"
+        )).thenReturn(savedRecord);
+        when(breadRecordService.createResponse(savedRecord, true)).thenReturn(expected);
+
+        BreadRecordCreateResponse actual = breadRecordComplexService.createBreadRecord(USER_ID, request);
+
+        assertSame(expected, actual);
+        verify(breadService).getBreadById(breadId, USER_ID);
     }
 
     @Test


### PR DESCRIPTION
## 🧩 관련 이슈

- #117 

## 🛠️ 작업 내용
- 서비스 로직에서 breads의 userId를 이용해 개인이 올린 빵 도감만 보이도록수정했습니다.

## 📢 참고 및 특이사항
- 아쌉으로 작업해서 빨리 배포 하겠습니다.
- DB는 수작업으로 수정하겠습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인