### PR TITLE
feat: add onboarding breads API and login selection validation

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/auth/service/AuthComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/auth/service/AuthComplexService.java
@@ -2,19 +2,10 @@ package com.bean.breaddiary.domain.auth.service;
 
 import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
 import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
-import com.bean.breaddiary.domain.bread.entity.Bread;
-import com.bean.breaddiary.domain.bread.service.BreadService;
-import com.bean.breaddiary.domain.onboarding.service.OnboardingService;
+import com.bean.breaddiary.domain.onboarding.service.OnboardingComplexService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -22,41 +13,12 @@ import java.util.UUID;
 public class AuthComplexService {
 
     private final AuthService authService;
-    private final BreadService breadService;
-    private final OnboardingService onboardingService;
+    private final OnboardingComplexService onboardingComplexService;
 
     @Transactional
     public AuthTokenResponse loginWithToss(TossLoginRequest request) {
         AuthTokenResponse response = authService.loginWithToss(request);
-        synchronizeOnboardingSelections(response.getUserId(), request);
+        onboardingComplexService.synchronizeSelectedBreads(response.getUserId(), request == null ? null : request.getSelectedBreadIds());
         return response;
-    }
-
-    private void synchronizeOnboardingSelections(UUID userId, TossLoginRequest request) {
-        if (request == null || request.getSelectedBreadIds() == null) {
-            return;
-        }
-
-        Set<UUID> deduplicatedIds = new LinkedHashSet<>(request.getSelectedBreadIds());
-        if (deduplicatedIds.contains(null)) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "온보딩에서 선택한 빵 정보가 올바르지 않습니다."
-            );
-        }
-        if (deduplicatedIds.isEmpty()) {
-            onboardingService.replaceSelectedBreads(userId, List.of());
-            return;
-        }
-
-        List<Bread> breads = breadService.findAllSystemCatalogBreadsByIds(List.copyOf(deduplicatedIds));
-        if (breads.size() != deduplicatedIds.size()) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "온보딩에서 선택한 빵 정보가 올바르지 않습니다."
-            );
-        }
-
-        onboardingService.replaceSelectedBreads(userId, breads);
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/repository/BreadRepository.java
@@ -32,6 +32,16 @@ public interface BreadRepository extends JpaRepository<Bread, UUID> {
             """)
     List<Bread> findAllSystemCatalogBreadsByIds(@Param("breadIds") List<UUID> breadIds);
 
+
+    @Query("""
+            select b
+            from Bread b
+            where b.createdBy is null
+              and b.name in :names
+            order by b.stickerNumber asc
+            """)
+    List<Bread> findAllSystemCatalogBreadsByNames(@Param("names") List<String> names);
+
     boolean existsByName(String name);
 
     List<Bread> findByNameContainingIgnoreCaseOrderByStickerNumberAsc(String name, Pageable pageable);

--- a/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
+++ b/src/main/java/com/bean/breaddiary/domain/bread/service/BreadService.java
@@ -101,6 +101,14 @@ public class BreadService {
         return breadRepository.findAllSystemCatalogBreadsByIds(breadIds);
     }
 
+    public List<Bread> findAllSystemCatalogBreadsByNames(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return List.of();
+        }
+
+        return breadRepository.findAllSystemCatalogBreadsByNames(names);
+    }
+
     public List<Bread> findCatalogCandidates(String search, BreadType breadType, UUID userId) {
         return breadRepository.findCatalogCandidates(
                 normalizeSearch(search),

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingController.java
@@ -1,0 +1,42 @@
+package com.bean.breaddiary.domain.onboarding.controller;
+
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadListResponse;
+import com.bean.breaddiary.domain.onboarding.service.OnboardingComplexService;
+import com.bean.breaddiary.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "온보딩 API", description = "온보딩에서 선택 가능한 고정 빵 목록을 조회하는 API입니다.")
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/onboarding")
+public class OnboardingController {
+
+    private final OnboardingComplexService onboardingComplexService;
+
+    @Operation(
+            summary = "온보딩 빵 목록 조회",
+            description = "온보딩에서 선택 가능한 고정 30개 빵 목록을 순서대로 조회합니다. 각 항목의 imageUrl은 시스템 카탈로그 원본 이미지를 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "온보딩 빵 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = OnboardingBreadListResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "온보딩 빵 목록 구성 오류")
+    })
+    @GetMapping("/breads")
+    public ResponseEntity<ApiResponse<OnboardingBreadListResponse>> getOnboardingBreads() {
+        return ResponseEntity.ok(ApiResponse.success(onboardingComplexService.getOnboardingBreads()));
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapper.java
@@ -1,0 +1,26 @@
+package com.bean.breaddiary.domain.onboarding.dto.mapper;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.onboarding.entity.OnboardingBreadCatalog;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadItemResponse;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadListResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface OnboardingMapper {
+
+    @Mapping(target = "breadId", source = "bread.id")
+    @Mapping(target = "name", source = "bread.name")
+    @Mapping(target = "stickerNumber", source = "bread.stickerNumber")
+    @Mapping(target = "breadType", source = "bread.breadType.code")
+    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    OnboardingBreadItemResponse mapToItem(OnboardingBreadCatalog catalog, Bread bread);
+
+    default OnboardingBreadListResponse mapToListResponse(List<OnboardingBreadItemResponse> items) {
+        return new OnboardingBreadListResponse(items);
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadItemResponse.java
@@ -1,0 +1,32 @@
+package com.bean.breaddiary.domain.onboarding.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "온보딩 빵 목록 아이템")
+public class OnboardingBreadItemResponse {
+
+    @Schema(description = "카탈로그 빵 ID", example = "b0e1f2a3-c4d5-6789-abcd-ef0123456789")
+    private UUID breadId;
+
+    @Schema(description = "온보딩 표시용 빵 이름", example = "식빵")
+    private String name;
+
+    @Schema(description = "도감 번호", example = "41")
+    private Integer stickerNumber;
+
+    @Schema(description = "빵 종류", example = "BREAD")
+    private String breadType;
+
+    @Schema(description = "원본 카탈로그 이미지 URL", example = "https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png")
+    private String imageUrl;
+}

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadListResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadListResponse.java
@@ -1,0 +1,24 @@
+package com.bean.breaddiary.domain.onboarding.dto.response;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "온보딩 빵 목록 응답")
+public class OnboardingBreadListResponse {
+
+    @ArraySchema(
+            schema = @Schema(implementation = OnboardingBreadItemResponse.class),
+            arraySchema = @Schema(description = "온보딩에서 선택 가능한 고정 30개 빵 목록")
+    )
+    private List<OnboardingBreadItemResponse> items;
+}

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/entity/OnboardingBreadCatalog.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/entity/OnboardingBreadCatalog.java
@@ -1,0 +1,51 @@
+package com.bean.breaddiary.domain.onboarding.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public enum OnboardingBreadCatalog {
+
+    LOAF_BREAD("생식빵"),
+    SALT_BREAD("소금빵"),
+    SOBORO_BREAD("소보로빵"),
+    RED_BEAN_BREAD("단팥빵"),
+    SAUSAGE_BREAD("소시지빵"),
+    ROLL_CAKE("롤 케이크"),
+    CROISSANT("크루아상"),
+    DONUT("도넛"),
+    CASTELLA("카스테라"),
+    BAGEL("베이글"),
+    TWIST_DONUT("꽈배기"),
+    CREAM_PUFF_BREAD("슈크림빵"),
+    GARLIC_BAGUETTE("마늘바게트"),
+    BAGUETTE("바게트"),
+    WAFFLE("와플"),
+    CROQUETTE("고로케"),
+    PANCAKE("팬케이크"),
+    EGG_TART("에그타르트"),
+    MACARON("마카롱"),
+    CHESTNUT_LOAF("밤식빵"),
+    MUFFIN("머핀"),
+    MOCHA_BUN("모카번"),
+    ANBUTTER("앙버터"),
+    SCONE("스콘"),
+    BROWNIE("브라우니"),
+    MAMMOTH_BREAD("맘모스빵"),
+    CIABATTA("치아바타"),
+    CUPCAKE("컵케이크"),
+    HONEY_BREAD("허니브레드"),
+    PRETZEL("프레첼");
+
+    private final String catalogName;
+
+    public static List<String> catalogNames() {
+        return Arrays.stream(values())
+                .map(OnboardingBreadCatalog::getCatalogName)
+                .toList();
+    }
+}

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexService.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexService.java
@@ -1,0 +1,120 @@
+package com.bean.breaddiary.domain.onboarding.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.domain.onboarding.entity.OnboardingBreadCatalog;
+import com.bean.breaddiary.domain.onboarding.dto.mapper.OnboardingMapper;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadItemResponse;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OnboardingComplexService {
+
+    private final OnboardingService onboardingService;
+    private final BreadService breadService;
+    private final OnboardingMapper onboardingMapper;
+
+    public OnboardingBreadListResponse getOnboardingBreads() {
+        Map<String, Bread> breadsByCatalogName = findOnboardingBreadsByCatalogName();
+
+        List<OnboardingBreadItemResponse> items = Arrays.stream(OnboardingBreadCatalog.values())
+                .map(catalog -> onboardingMapper.mapToItem(catalog, requireBread(breadsByCatalogName, catalog)))
+                .toList();
+
+        return onboardingMapper.mapToListResponse(items);
+    }
+
+    @Transactional
+    public void synchronizeSelectedBreads(UUID userId, List<UUID> selectedBreadIds) {
+        if (selectedBreadIds == null) {
+            return;
+        }
+
+        Set<UUID> deduplicatedIds = new LinkedHashSet<>(selectedBreadIds);
+        if (deduplicatedIds.contains(null)) {
+            throw invalidOnboardingSelection();
+        }
+
+        if (deduplicatedIds.isEmpty()) {
+            onboardingService.replaceSelectedBreads(userId, List.of());
+            return;
+        }
+
+        Map<UUID, Bread> allowedBreadsById = findAllowedOnboardingBreadsById();
+        List<Bread> selectedBreads = deduplicatedIds.stream()
+                .map(allowedBreadsById::get)
+                .toList();
+
+        if (selectedBreads.stream().anyMatch(java.util.Objects::isNull)) {
+            throw invalidOnboardingSelection();
+        }
+
+        onboardingService.replaceSelectedBreads(userId, selectedBreads);
+    }
+
+    private Map<UUID, Bread> findAllowedOnboardingBreadsById() {
+        return findOnboardingBreadsByCatalogName().values().stream()
+                .collect(LinkedHashMap::new, (map, bread) -> map.put(bread.getId(), bread), Map::putAll);
+    }
+
+    private Map<String, Bread> findOnboardingBreadsByCatalogName() {
+        List<String> catalogNames = OnboardingBreadCatalog.catalogNames();
+        List<Bread> breads = breadService.findAllSystemCatalogBreadsByNames(catalogNames);
+
+        if (breads.size() != catalogNames.size()) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "온보딩 빵 목록 구성이 올바르지 않습니다."
+            );
+        }
+
+        Map<String, Bread> breadsByCatalogName = new LinkedHashMap<>();
+        for (Bread bread : breads) {
+            breadsByCatalogName.put(bread.getName(), bread);
+        }
+
+        for (OnboardingBreadCatalog catalog : OnboardingBreadCatalog.values()) {
+            if (!breadsByCatalogName.containsKey(catalog.getCatalogName())) {
+                throw new ResponseStatusException(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "온보딩 빵 목록 구성이 올바르지 않습니다."
+                );
+            }
+        }
+
+        return breadsByCatalogName;
+    }
+
+    private Bread requireBread(Map<String, Bread> breadsByCatalogName, OnboardingBreadCatalog catalog) {
+        Bread bread = breadsByCatalogName.get(catalog.getCatalogName());
+        if (bread == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "온보딩 빵 목록 구성이 올바르지 않습니다."
+            );
+        }
+        return bread;
+    }
+
+    private ResponseStatusException invalidOnboardingSelection() {
+        return new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "온보딩에서 선택한 빵 정보가 올바르지 않습니다."
+        );
+    }
+}

--- a/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/bean/breaddiary/global/interceptor/AuthInterceptor.java
@@ -94,7 +94,9 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        if (HTTP_GET.equalsIgnoreCase(method) && "/bread-types".equals(requestUri)) {
+        if (HTTP_GET.equalsIgnoreCase(method)
+                && ("/bread-types".equals(requestUri)
+                || "/onboarding/breads".equals(requestUri))) {
             return true;
         }
 

--- a/src/test/java/com/bean/breaddiary/domain/auth/service/AuthComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/auth/service/AuthComplexServiceTest.java
@@ -2,22 +2,14 @@ package com.bean.breaddiary.domain.auth.service;
 
 import com.bean.breaddiary.domain.auth.dto.request.TossLoginRequest;
 import com.bean.breaddiary.domain.auth.dto.response.AuthTokenResponse;
-import com.bean.breaddiary.domain.bread.entity.Bread;
-import com.bean.breaddiary.domain.bread.service.BreadService;
-import com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture;
-import com.bean.breaddiary.domain.onboarding.service.OnboardingService;
+import com.bean.breaddiary.domain.onboarding.service.OnboardingComplexService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -26,16 +18,14 @@ import static org.mockito.Mockito.when;
 class AuthComplexServiceTest {
 
     private AuthService authService;
-    private BreadService breadService;
-    private OnboardingService onboardingService;
+    private OnboardingComplexService onboardingComplexService;
     private AuthComplexService authComplexService;
 
     @BeforeEach
     void setUp() {
         authService = mock(AuthService.class);
-        breadService = mock(BreadService.class);
-        onboardingService = mock(OnboardingService.class);
-        authComplexService = new AuthComplexService(authService, breadService, onboardingService);
+        onboardingComplexService = mock(OnboardingComplexService.class);
+        authComplexService = new AuthComplexService(authService, onboardingComplexService);
     }
 
     @Test
@@ -57,11 +47,11 @@ class AuthComplexServiceTest {
         authComplexService.loginWithToss(request);
 
         verify(authService).loginWithToss(request);
-        verifyNoOnboardingInteractions();
+        verify(onboardingComplexService).synchronizeSelectedBreads(userId, null);
     }
 
     @Test
-    void loginWithTossReplacesOnboardingSelectionsAfterSuccessfulLogin() {
+    void loginWithTossDelegatesSelectedBreadIdsToOnboardingComplexService() {
         UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
         UUID firstBreadId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
         UUID secondBreadId = UUID.fromString("550e8400-e29b-41d4-a716-446655440002");
@@ -79,82 +69,11 @@ class AuthComplexServiceTest {
                 LocalDateTime.of(2026, 5, 19, 10, 0),
                 true
         );
-        Bread firstBread = Bread.builder().id(firstBreadId).breadType(BreadTypeTestFixture.PASTRY).stickerNumber(1).name("단팥빵").imageUrl("a").build();
-        Bread secondBread = Bread.builder().id(secondBreadId).breadType(BreadTypeTestFixture.PASTRY).stickerNumber(2).name("소금빵").imageUrl("b").build();
 
         when(authService.loginWithToss(request)).thenReturn(response);
-        when(breadService.findAllSystemCatalogBreadsByIds(List.of(firstBreadId, secondBreadId)))
-                .thenReturn(List.of(firstBread, secondBread));
 
         authComplexService.loginWithToss(request);
 
-        verify(onboardingService).replaceSelectedBreads(userId, List.of(firstBread, secondBread));
-    }
-
-
-    @Test
-    void loginWithTossRejectsNullSelectedBreadId() {
-        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-        TossLoginRequest request = new TossLoginRequest(
-                "auth-code",
-                "DEFAULT",
-                java.util.Arrays.asList((UUID) null)
-        );
-        AuthTokenResponse response = new AuthTokenResponse(
-                userId,
-                "access",
-                "refresh",
-                "Bearer",
-                LocalDateTime.of(2026, 4, 20, 10, 0),
-                LocalDateTime.of(2026, 5, 19, 10, 0),
-                true
-        );
-
-        when(authService.loginWithToss(request)).thenReturn(response);
-
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> authComplexService.loginWithToss(request)
-        );
-
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        verify(onboardingService, never()).replaceSelectedBreads(any(), any());
-    }
-
-    @Test
-    void loginWithTossRejectsUnknownOnboardingBreadId() {
-        UUID userId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-        UUID breadId = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
-        TossLoginRequest request = new TossLoginRequest(
-                "auth-code",
-                "DEFAULT",
-                List.of(breadId)
-        );
-        AuthTokenResponse response = new AuthTokenResponse(
-                userId,
-                "access",
-                "refresh",
-                "Bearer",
-                LocalDateTime.of(2026, 4, 20, 10, 0),
-                LocalDateTime.of(2026, 5, 19, 10, 0),
-                true
-        );
-
-        when(authService.loginWithToss(request)).thenReturn(response);
-        when(breadService.findAllSystemCatalogBreadsByIds(List.of(breadId)))
-                .thenReturn(List.of());
-
-        ResponseStatusException exception = assertThrows(
-                ResponseStatusException.class,
-                () -> authComplexService.loginWithToss(request)
-        );
-
-        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-        verify(onboardingService, never()).replaceSelectedBreads(any(), any());
-    }
-
-    private void verifyNoOnboardingInteractions() {
-        verify(breadService, never()).findAllSystemCatalogBreadsByIds(any());
-        verify(onboardingService, never()).replaceSelectedBreads(any(), any());
+        verify(onboardingComplexService).synchronizeSelectedBreads(userId, request.getSelectedBreadIds());
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingControllerTest.java
@@ -1,0 +1,73 @@
+package com.bean.breaddiary.domain.onboarding.controller;
+
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadItemResponse;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadListResponse;
+import com.bean.breaddiary.domain.onboarding.service.OnboardingComplexService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OnboardingControllerTest {
+
+    private OnboardingComplexService onboardingComplexService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        onboardingComplexService = mock(OnboardingComplexService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new OnboardingController(onboardingComplexService))
+                .setMessageConverters(new JacksonJsonHttpMessageConverter(snakeCaseObjectMapper()))
+                .build();
+    }
+
+    @Test
+    void getOnboardingBreadsReturnsSpecResponseWithSnakeCaseFields() throws Exception {
+        UUID breadId = UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789");
+        OnboardingBreadListResponse response = new OnboardingBreadListResponse(
+                List.of(new OnboardingBreadItemResponse(
+                        breadId,
+                        "생식빵",
+                        41,
+                        "BREAD",
+                        "https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png"
+                ))
+        );
+        when(onboardingComplexService.getOnboardingBreads()).thenReturn(response);
+
+        mockMvc.perform(get("/onboarding/breads"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.items[0].bread_id").value(breadId.toString()))
+                .andExpect(jsonPath("$.data.items[0].name").value("생식빵"))
+                .andExpect(jsonPath("$.data.items[0].sticker_number").value(41))
+                .andExpect(jsonPath("$.data.items[0].bread_type").value("BREAD"))
+                .andExpect(jsonPath("$.data.items[0].image_url").value("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png"))
+                .andExpect(jsonPath("$.data.items[0].breadId").doesNotExist())
+                .andExpect(jsonPath("$.data.items[0].imageUrl").doesNotExist());
+
+        verify(onboardingComplexService).getOnboardingBreads();
+    }
+
+    private JsonMapper snakeCaseObjectMapper() {
+        return JsonMapper.builder()
+                .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .build();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
@@ -1,0 +1,136 @@
+package com.bean.breaddiary.domain.onboarding.service;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.bread.service.BreadService;
+import com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture;
+import com.bean.breaddiary.domain.onboarding.entity.OnboardingBreadCatalog;
+import com.bean.breaddiary.domain.onboarding.dto.mapper.OnboardingMapper;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadListResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OnboardingComplexServiceTest {
+
+    private OnboardingService onboardingService;
+    private BreadService breadService;
+    private OnboardingMapper onboardingMapper;
+    private OnboardingComplexService onboardingComplexService;
+
+    @BeforeEach
+    void setUp() {
+        onboardingService = mock(OnboardingService.class);
+        breadService = mock(BreadService.class);
+        onboardingMapper = Mappers.getMapper(OnboardingMapper.class);
+        onboardingComplexService = new OnboardingComplexService(onboardingService, breadService, onboardingMapper);
+    }
+
+    @Test
+    void getOnboardingBreadsReturnsFixedThirtyItemsInCatalogOrder() {
+        when(breadService.findAllSystemCatalogBreadsByNames(OnboardingBreadCatalog.catalogNames()))
+                .thenReturn(createAllOnboardingBreads());
+
+        OnboardingBreadListResponse response = onboardingComplexService.getOnboardingBreads();
+
+        assertEquals(30, response.getItems().size());
+        assertEquals("생식빵", response.getItems().get(0).getName());
+        assertEquals("마늘바게트", response.getItems().get(12).getName());
+        assertEquals(true, response.getItems().get(0).getImageUrl().contains("생식빵"));
+    }
+
+    @Test
+    void synchronizeSelectedBreadsReplacesSavedRowsWhenIdsAreAllowed() {
+        List<Bread> onboardingBreads = createAllOnboardingBreads();
+        Bread firstBread = onboardingBreads.get(0);
+        Bread secondBread = onboardingBreads.get(1);
+        when(breadService.findAllSystemCatalogBreadsByNames(OnboardingBreadCatalog.catalogNames()))
+                .thenReturn(onboardingBreads);
+
+        onboardingComplexService.synchronizeSelectedBreads(
+                UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                List.of(secondBread.getId(), firstBread.getId(), secondBread.getId())
+        );
+
+        verify(onboardingService).replaceSelectedBreads(
+                UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                List.of(secondBread, firstBread)
+        );
+    }
+
+    @Test
+    void synchronizeSelectedBreadsRejectsIdOutsideOnboardingCatalog() {
+        when(breadService.findAllSystemCatalogBreadsByNames(OnboardingBreadCatalog.catalogNames()))
+                .thenReturn(createAllOnboardingBreads());
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> onboardingComplexService.synchronizeSelectedBreads(
+                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                        List.of(UUID.fromString("550e8400-e29b-41d4-a716-446655449999"))
+                )
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(onboardingService, never()).replaceSelectedBreads(any(), any());
+    }
+
+    @Test
+    void synchronizeSelectedBreadsRejectsNullId() {
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> onboardingComplexService.synchronizeSelectedBreads(
+                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                        Arrays.asList((UUID) null)
+                )
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(onboardingService, never()).replaceSelectedBreads(any(), any());
+        verify(breadService, never()).findAllSystemCatalogBreadsByNames(any());
+    }
+
+    @Test
+    void getOnboardingBreadsFailsWhenCatalogBreadIsMissing() {
+        when(breadService.findAllSystemCatalogBreadsByNames(OnboardingBreadCatalog.catalogNames()))
+                .thenReturn(createAllOnboardingBreads().subList(0, 29));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> onboardingComplexService.getOnboardingBreads()
+        );
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
+    }
+
+    private List<Bread> createAllOnboardingBreads() {
+        return Arrays.stream(OnboardingBreadCatalog.values())
+                .map(this::createBread)
+                .collect(Collectors.toList());
+    }
+
+    private Bread createBread(OnboardingBreadCatalog catalog) {
+        int stickerNumber = catalog.ordinal() + 1;
+        return Bread.builder()
+                .id(UUID.nameUUIDFromBytes(catalog.getCatalogName().getBytes(java.nio.charset.StandardCharsets.UTF_8)))
+                .stickerNumber(stickerNumber)
+                .name(catalog.getCatalogName())
+                .breadType(BreadTypeTestFixture.PASTRY)
+                .imageUrl("https://du4zizlgiw14n.cloudfront.net/images/%03d_%s.png".formatted(stickerNumber, catalog.getCatalogName()))
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #121 

## 🛠️ 작업 내용
- 피그마 기준 빵 30개 리스트 해서 온보딩 전용 api를 제작했습니다.
- enum에 빵 리스트 목록을 관리합니다.
- 리스트를 보낼때 `_placeholder`는 제거하고 url 보내게 했습니다.

## 📢 참고 및 특이사항
- postman으로 로컬에서 확인 해본 결과 잘 작동합니다.
<img width="635" height="605" alt="스크린샷 2026-05-10 오후 11 29 48" src="https://github.com/user-attachments/assets/4e02692a-baf4-47b8-b8c0-cd44dc56e8d6" />

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인