### PR TITLE
feat: serve onboarding bread images as webp

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapper.java
@@ -17,10 +17,22 @@ public interface OnboardingMapper {
     @Mapping(target = "name", source = "bread.name")
     @Mapping(target = "stickerNumber", source = "bread.stickerNumber")
     @Mapping(target = "breadType", source = "bread.breadType.code")
-    @Mapping(target = "imageUrl", source = "bread.imageUrl")
+    @Mapping(target = "imageUrl", expression = "java(toOnboardingImageUrl(bread.getImageUrl()))")
     OnboardingBreadItemResponse mapToItem(OnboardingBreadCatalog catalog, Bread bread);
 
     default OnboardingBreadListResponse mapToListResponse(List<OnboardingBreadItemResponse> items) {
         return new OnboardingBreadListResponse(items);
+    }
+
+    default String toOnboardingImageUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.endsWith("_placeholder.png")) {
+            return imageUrl;
+        }
+
+        if (imageUrl.endsWith(".png")) {
+            return imageUrl.substring(0, imageUrl.length() - 4) + ".webp";
+        }
+
+        return imageUrl;
     }
 }

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapperTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapperTest.java
@@ -1,0 +1,57 @@
+package com.bean.breaddiary.domain.onboarding.dto.mapper;
+
+import com.bean.breaddiary.domain.bread.entity.Bread;
+import com.bean.breaddiary.domain.breadtype.BreadTypeTestFixture;
+import com.bean.breaddiary.domain.onboarding.dto.response.OnboardingBreadItemResponse;
+import com.bean.breaddiary.domain.onboarding.entity.OnboardingBreadCatalog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OnboardingMapperTest {
+
+    private OnboardingMapper onboardingMapper;
+
+    @BeforeEach
+    void setUp() {
+        onboardingMapper = Mappers.getMapper(OnboardingMapper.class);
+    }
+
+    @Test
+    void mapToItemConvertsCatalogPngToWebpForOnboarding() {
+        Bread bread = bread("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png");
+
+        OnboardingBreadItemResponse response = onboardingMapper.mapToItem(OnboardingBreadCatalog.LOAF_BREAD, bread);
+
+        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.webp", response.getImageUrl());
+    }
+
+    @Test
+    void mapToItemKeepsPlaceholderPngUnchanged() {
+        Bread bread = bread("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5_placeholder.png");
+
+        OnboardingBreadItemResponse response = onboardingMapper.mapToItem(OnboardingBreadCatalog.LOAF_BREAD, bread);
+
+        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5_placeholder.png", response.getImageUrl());
+    }
+
+    @Test
+    void toOnboardingImageUrlReturnsNullWhenImageUrlIsNull() {
+        assertNull(onboardingMapper.toOnboardingImageUrl(null));
+    }
+
+    private Bread bread(String imageUrl) {
+        return Bread.builder()
+                .id(UUID.fromString("b0e1f2a3-c4d5-6789-abcd-ef0123456789"))
+                .stickerNumber(41)
+                .name("생식빵")
+                .breadType(BreadTypeTestFixture.BREAD)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
@@ -50,7 +50,7 @@ class OnboardingComplexServiceTest {
         assertEquals(30, response.getItems().size());
         assertEquals("생식빵", response.getItems().get(0).getName());
         assertEquals("마늘바게트", response.getItems().get(12).getName());
-        assertEquals(true, response.getItems().get(0).getImageUrl().contains("생식빵"));
+        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/001_생식빵.webp", response.getItems().get(0).getImageUrl());
     }
 
     @Test


### PR DESCRIPTION
## 🧩 관련 이슈

- #124 

## 🛠️ 작업 내용
- 온보딩 w전용 이미지 URL 확장자를 .png에서 .webp로 바꾸도록 수정했습니다.

## 📢 참고 및 특이사항
- 없습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인