### PR TITLE
fix: align onboarding bread image URLs with webp CDN path

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapper.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapper.java
@@ -25,14 +25,23 @@ public interface OnboardingMapper {
     }
 
     default String toOnboardingImageUrl(String imageUrl) {
-        if (imageUrl == null || imageUrl.endsWith("_placeholder.png")) {
+        if (imageUrl == null) {
             return imageUrl;
         }
 
-        if (imageUrl.endsWith(".png")) {
-            return imageUrl.substring(0, imageUrl.length() - 4) + ".webp";
+        if (imageUrl.contains("/images/webp/") && imageUrl.endsWith(".webp")) {
+            return imageUrl;
         }
 
-        return imageUrl;
+        String convertedUrl = imageUrl;
+        if (convertedUrl.contains("/images/") && !convertedUrl.contains("/images/webp/")) {
+            convertedUrl = convertedUrl.replace("/images/", "/images/webp/");
+        }
+
+        if (convertedUrl.endsWith(".png")) {
+            return convertedUrl.substring(0, convertedUrl.length() - 4) + ".webp";
+        }
+
+        return convertedUrl;
     }
 }

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadItemResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadItemResponse.java
@@ -27,6 +27,6 @@ public class OnboardingBreadItemResponse {
     @Schema(description = "빵 종류", example = "BREAD")
     private String breadType;
 
-    @Schema(description = "원본 카탈로그 이미지 URL", example = "https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png")
+    @Schema(description = "온보딩 표시용 카탈로그 이미지 URL", example = "https://du4zizlgiw14n.cloudfront.net/images/webp/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.webp")
     private String imageUrl;
 }

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingControllerTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingControllerTest.java
@@ -45,7 +45,7 @@ class OnboardingControllerTest {
                         "생식빵",
                         41,
                         "BREAD",
-                        "https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png"
+                        "https://du4zizlgiw14n.cloudfront.net/images/webp/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.webp"
                 ))
         );
         when(onboardingComplexService.getOnboardingBreads()).thenReturn(response);
@@ -57,7 +57,7 @@ class OnboardingControllerTest {
                 .andExpect(jsonPath("$.data.items[0].name").value("생식빵"))
                 .andExpect(jsonPath("$.data.items[0].sticker_number").value(41))
                 .andExpect(jsonPath("$.data.items[0].bread_type").value("BREAD"))
-                .andExpect(jsonPath("$.data.items[0].image_url").value("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png"))
+                .andExpect(jsonPath("$.data.items[0].image_url").value("https://du4zizlgiw14n.cloudfront.net/images/webp/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.webp"))
                 .andExpect(jsonPath("$.data.items[0].breadId").doesNotExist())
                 .andExpect(jsonPath("$.data.items[0].imageUrl").doesNotExist());
 

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
@@ -50,7 +50,7 @@ class OnboardingComplexServiceTest {
         assertEquals(30, response.getItems().size());
         assertEquals("생식빵", response.getItems().get(0).getName());
         assertEquals("마늘바게트", response.getItems().get(12).getName());
-        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/001_생식빵.webp", response.getItems().get(0).getImageUrl());
+        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/webp/001_생식빵.webp", response.getItems().get(0).getImageUrl());
     }
 
     @Test


### PR DESCRIPTION
## 🧩 관련 이슈

- #126 

## 🛠️ 작업 내용
- 빵 온보딩 조회 시 cdn url에 디렉토리 구조를 적용하여 반환하도록 수정했습니다.

## 📢 참고 및 특이사항
- PO님이 실수했습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인