### PR TITLE
refactor: reduce onboarding bread catalog to nine items

### DIFF
--- a/src/main/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/controller/OnboardingController.java
@@ -25,7 +25,7 @@ public class OnboardingController {
 
     @Operation(
             summary = "온보딩 빵 목록 조회",
-            description = "온보딩에서 선택 가능한 고정 30개 빵 목록을 순서대로 조회합니다. 각 항목의 imageUrl은 시스템 카탈로그 원본 이미지를 반환합니다."
+            description = "온보딩에서 선택 가능한 고정 9개 빵 목록을 순서대로 조회합니다. 각 항목의 imageUrl은 시스템 카탈로그 원본 이미지를 반환합니다."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadListResponse.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/dto/response/OnboardingBreadListResponse.java
@@ -18,7 +18,7 @@ public class OnboardingBreadListResponse {
 
     @ArraySchema(
             schema = @Schema(implementation = OnboardingBreadItemResponse.class),
-            arraySchema = @Schema(description = "온보딩에서 선택 가능한 고정 30개 빵 목록")
+            arraySchema = @Schema(description = "온보딩에서 선택 가능한 고정 9개 빵 목록")
     )
     private List<OnboardingBreadItemResponse> items;
 }

--- a/src/main/java/com/bean/breaddiary/domain/onboarding/entity/OnboardingBreadCatalog.java
+++ b/src/main/java/com/bean/breaddiary/domain/onboarding/entity/OnboardingBreadCatalog.java
@@ -10,36 +10,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public enum OnboardingBreadCatalog {
 
-    LOAF_BREAD("생식빵"),
-    SALT_BREAD("소금빵"),
-    SOBORO_BREAD("소보로빵"),
     RED_BEAN_BREAD("단팥빵"),
-    SAUSAGE_BREAD("소시지빵"),
-    ROLL_CAKE("롤 케이크"),
-    CROISSANT("크루아상"),
-    DONUT("도넛"),
-    CASTELLA("카스테라"),
-    BAGEL("베이글"),
-    TWIST_DONUT("꽈배기"),
-    CREAM_PUFF_BREAD("슈크림빵"),
-    GARLIC_BAGUETTE("마늘바게트"),
-    BAGUETTE("바게트"),
-    WAFFLE("와플"),
-    CROQUETTE("고로케"),
-    PANCAKE("팬케이크"),
-    EGG_TART("에그타르트"),
-    MACARON("마카롱"),
+    SALT_BREAD("소금빵"),
+    DUBAI_CHEWY_COOKIE("두쫀쿠"),
+    SOBORO_BREAD("소보로빵"),
     CHESTNUT_LOAF("밤식빵"),
-    MUFFIN("머핀"),
-    MOCHA_BUN("모카번"),
-    ANBUTTER("앙버터"),
-    SCONE("스콘"),
-    BROWNIE("브라우니"),
-    MAMMOTH_BREAD("맘모스빵"),
-    CIABATTA("치아바타"),
-    CUPCAKE("컵케이크"),
-    HONEY_BREAD("허니브레드"),
-    PRETZEL("프레첼");
+    CREAM_PUFF_BREAD("슈크림빵"),
+    MACARON("마카롱"),
+    DONUT("도넛"),
+    CROISSANT("크루아상");
 
     private final String catalogName;
 

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapperTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/dto/mapper/OnboardingMapperTest.java
@@ -26,7 +26,7 @@ class OnboardingMapperTest {
     void mapToItemConvertsCatalogPngToWebpForOnboarding() {
         Bread bread = bread("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.png");
 
-        OnboardingBreadItemResponse response = onboardingMapper.mapToItem(OnboardingBreadCatalog.LOAF_BREAD, bread);
+        OnboardingBreadItemResponse response = onboardingMapper.mapToItem(OnboardingBreadCatalog.RED_BEAN_BREAD, bread);
 
         assertEquals("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5.webp", response.getImageUrl());
     }
@@ -35,7 +35,7 @@ class OnboardingMapperTest {
     void mapToItemKeepsPlaceholderPngUnchanged() {
         Bread bread = bread("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5_placeholder.png");
 
-        OnboardingBreadItemResponse response = onboardingMapper.mapToItem(OnboardingBreadCatalog.LOAF_BREAD, bread);
+        OnboardingBreadItemResponse response = onboardingMapper.mapToItem(OnboardingBreadCatalog.RED_BEAN_BREAD, bread);
 
         assertEquals("https://du4zizlgiw14n.cloudfront.net/images/041_%EC%83%9D%EC%8B%9D%EB%B9%B5_placeholder.png", response.getImageUrl());
     }

--- a/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
+++ b/src/test/java/com/bean/breaddiary/domain/onboarding/service/OnboardingComplexServiceTest.java
@@ -41,16 +41,17 @@ class OnboardingComplexServiceTest {
     }
 
     @Test
-    void getOnboardingBreadsReturnsFixedThirtyItemsInCatalogOrder() {
+    void getOnboardingBreadsReturnsFixedNineItemsInCatalogOrder() {
         when(breadService.findAllSystemCatalogBreadsByNames(OnboardingBreadCatalog.catalogNames()))
                 .thenReturn(createAllOnboardingBreads());
 
         OnboardingBreadListResponse response = onboardingComplexService.getOnboardingBreads();
 
-        assertEquals(30, response.getItems().size());
-        assertEquals("생식빵", response.getItems().get(0).getName());
-        assertEquals("마늘바게트", response.getItems().get(12).getName());
-        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/webp/001_생식빵.webp", response.getItems().get(0).getImageUrl());
+        assertEquals(9, response.getItems().size());
+        assertEquals("단팥빵", response.getItems().get(0).getName());
+        assertEquals("두쫀쿠", response.getItems().get(2).getName());
+        assertEquals("크루아상", response.getItems().get(8).getName());
+        assertEquals("https://du4zizlgiw14n.cloudfront.net/images/webp/001_단팥빵.webp", response.getItems().get(0).getImageUrl());
     }
 
     @Test
@@ -107,7 +108,7 @@ class OnboardingComplexServiceTest {
     @Test
     void getOnboardingBreadsFailsWhenCatalogBreadIsMissing() {
         when(breadService.findAllSystemCatalogBreadsByNames(OnboardingBreadCatalog.catalogNames()))
-                .thenReturn(createAllOnboardingBreads().subList(0, 29));
+                .thenReturn(createAllOnboardingBreads().subList(0, 8));
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,


### PR DESCRIPTION
## 🧩 관련 이슈

- #128 

## 🛠️ 작업 내용
- 온보딩 빵 리스트를 9개로 축소했습니다.
- 두쫀쿠를 온보딩 빵 리스트에 추가했습니다.
## 📢 참고 및 특이사항
- 그리드 확인 후 수정이 필요하면 12개로 수정해보겠습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: implement login functionality`)
- [x] 관련 이슈 연결 (`#이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인